### PR TITLE
2. Move bee_conf.json file

### DIFF
--- a/bee-launcher/bee_composer.py
+++ b/bee-launcher/bee_composer.py
@@ -12,7 +12,8 @@ class BeeComposer(object):
     def __init__(self):
         self.__pydir = os.path.dirname(os.path.abspath(__file__))
         self.__cwdir = os.getcwd()
-        f = open(self.__pydir + "/bee_conf.json", "r")
+        self.__hdir = os.path.expanduser('~')
+        f = open(self.__hdir + "/.bee/bee_conf.json", "r")
         data = json.load(f)
         port = int(data["pyro4-ns-port"])
         ns = Pyro4.locateNS(port = port, hmac_key = getpass.getuser())

--- a/bee-launcher/bee_launcher.py
+++ b/bee-launcher/bee_launcher.py
@@ -16,7 +16,8 @@ class BeeLauncher(object):
     def __init__(self):
         self.__pydir = os.path.dirname(os.path.abspath(__file__))
         self.__cwdir = os.getcwd()
-        f = open(self.__pydir + "/bee_conf.json", "r")
+        self.__hdir = os.path.expanduser('~')
+        f = open(self.__hdir + "/.bee/bee_conf.json", "r")
         data = json.load(f)
         port = int(data["pyro4-ns-port"])
         ns = Pyro4.locateNS(port = port, hmac_key = getpass.getuser())

--- a/bee-launcher/bee_orc_ctl.py
+++ b/bee-launcher/bee_orc_ctl.py
@@ -40,12 +40,10 @@ class BeeLauncherDaemon(object):
             beetask = BeeOSLauncher(total_tasks + 1, beefile)
             self.__beetasks[beetask_name] = beetask
             return beetask
-        #elif exec_target == 'bee_charliecloud':
-        #    beetask = BeeCharliecloudLauncher(total_tasks + 1, beefile, restore)
-        #    self.__beetasks[beetask_name] = beetask
-        #    return beetask
-
-# Need error checking for none of the above
+        elif exec_target == 'bee_charliecloud':
+            beetask = BeeCharliecloudLauncher(total_tasks + 1, beefile, restore)
+            self.__beetasks[beetask_name] = beetask
+            return beetask
         
     def launch_task(self, beetask):
         beetask.start()
@@ -154,10 +152,10 @@ def main():
     daemon.requestLoop()
     
 def update_system_conf(open_port):
-    pydir = os.path.dirname(os.path.abspath(__file__))
-    f = open(pydir + "/bee_conf.json", "r")
+    hdir = os.path.expanduser('~')
+    f = open(hdir + "/.bee/bee_conf.json", "r")
     data = json.load(f)
-    f = open(pydir + "/bee_conf.json", "w")
+    f = open(hdir + "/.bee/bee_conf.json", "w")
     data["pyro4-ns-port"] = open_port
     json.dump(data, f)
 

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ mkdir ~/.bee/ssh_key
 mkdir ~/.bee/vm_imgs
 mkdir ~/.bee/tmp
 
+
 # Create SSH Key
 ssh-keygen -t rsa -f ~/.bee/ssh_key/id_rsa -q -P ""
 chmod 600 ~/.bee/ssh_key/id_rsa
@@ -32,3 +33,6 @@ echo "Host *" >> ~/.bee/ssh_key/config
 echo "     Port 22" >> ~/.bee/ssh_key/config
 echo "     StrictHostKeyChecking no" >> ~/.bee/ssh_key/config
 echo "     UserKnownHostsFile=/dev/null" >> ~/.bee/ssh_key/config
+
+# Create bee_conf.json
+echo "{\"pyro4-ns-port\": 12345}" >> ~/.bee/bee_conf.json


### PR DESCRIPTION
The bee_conf.json is used to store the current port number that let bee_launcher and bee_orc_ctl talk to each other. The port number can change every time the bee_orc_ctl is launched. Originally this file is placed as same as bee_launcher.py. However, this creates a potential problem when we push code changes to repo. So, we choose to move this file to ~/.bee. The file is created during installation time.