### PR TITLE
4. add the second Flecsale example

### DIFF
--- a/examples/bee-launcher-example/flecsale2/bee-aws/flecsale.beefile
+++ b/examples/bee-launcher-example/flecsale2/bee-aws/flecsale.beefile
@@ -1,0 +1,37 @@
+{
+  "task_conf": {
+      "task_name": "flecsale",
+      "exec_target": "bee_aws",
+      "batch_mode": false,
+      "general_run": [
+	  {
+	      "script": "flecsale_run.sh",
+	      "local_port_fwd": [],
+	      "remote_port_fwd": []
+	  }
+      ],
+     "mpi_run": [
+       {
+          "script": "flecsale_run.sh",
+          "local_port_fwd": [],
+          "remote_port_fwd": [],
+          "num_of_nodes": "1",
+          "proc_per_node": "32"
+       }
+    ],
+    "terminate_after_exec": false
+}, 
+  "docker_conf":{
+       "docker_img_tag": "cjy7117/flecsale2",
+      "docker_username": "flecsi",
+      "docker_shared_dir": "/mnt/docker_share"
+  },
+  "exec_env_conf": {
+     "bee_aws": {
+          "num_of_nodes": "1",
+          "ami_image": "ami-ad5952d4",
+          "instance_type": "c3.4xlarge",
+          "efs_id": "fs-98e73431"
+      }
+  }
+}

--- a/examples/bee-launcher-example/flecsale2/bee-aws/flecsale_run.sh
+++ b/examples/bee-launcher-example/flecsale2/bee-aws/flecsale_run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/home/flecsi/flecsale/build/apps/hydro/2d/hydro_2d -m  /home/flecsi/flecsale/specializations/data/meshes/2d/square/square_32x32.g

--- a/examples/bee-launcher-example/flecsale2/bee-os/flecsale.beefile
+++ b/examples/bee-launcher-example/flecsale2/bee-os/flecsale.beefile
@@ -1,0 +1,35 @@
+{
+  "task_conf": {
+      "task_name": "flecsale",
+      "exec_target": "bee_os",
+      "batch_mode": false,
+      "general_run": [
+	  {
+	      "script": "flecsale_run.sh",
+	      "local_port_fwd": [],
+	      "remote_port_fwd": []
+	  }
+      ],
+     "mpi_run": [
+       {
+          "script": "flecsale_run.sh",
+          "local_port_fwd": [],
+          "remote_port_fwd": [],
+          "num_of_nodes": "1",
+          "proc_per_node": "32"
+       }
+    ],
+    "terminate_after_exec": false
+  }, 
+  "docker_conf":{
+      "docker_img_tag": "cjy7117/flecsale2",
+      "docker_username": "flecsi",
+      "docker_shared_dir": "/mnt/docker_share"
+  },
+  "exec_env_conf": {
+     "bee_os": {
+          "num_of_nodes": "1",
+          "reservation_id": "ddf31d80-a961-4126-8ffe-311c74247721"
+      }
+  }
+}

--- a/examples/bee-launcher-example/flecsale2/bee-os/flecsale_run.sh
+++ b/examples/bee-launcher-example/flecsale2/bee-os/flecsale_run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/home/flecsi/flecsale/build/apps/hydro/2d/hydro_2d -m  /home/flecsi/flecsale/specializations/data/meshes/2d/square/square_32x32.g

--- a/examples/bee-launcher-example/flecsale2/bee-vm/flecsale.beefile
+++ b/examples/bee-launcher-example/flecsale2/bee-vm/flecsale.beefile
@@ -1,0 +1,40 @@
+{
+  "task_conf": {
+      "task_name": "flecsale",
+      "exec_target": "bee_vm",
+      "batch_mode": false,
+      "general_run": [
+	  {
+	      "script": "flecsale_run.sh",
+	      "local_port_fwd": [],
+	      "remote_port_fwd": []
+	  }
+      ],
+     "mpi_run": [
+       {
+          "script": "flecsale_run.sh",
+          "local_port_fwd": [],
+          "remote_port_fwd": [],
+          "num_of_nodes": "1",
+          "proc_per_node": "32"
+       }
+    ],
+    "terminate_after_exec": false
+  }, 
+  "docker_conf":{
+      "docker_img_tag": "cjy7117/flecsale2",
+      "docker_username": "flecsi",
+      "docker_shared_dir": "/mnt/docker_share"
+  },
+  "exec_env_conf": {
+      "bee_vm": {
+	  "node_list": ["cn30"],
+	  "cpu_core_per_socket": "8",
+	  "cpu_thread_per_core": "1",
+	  "cpu_sockets": "2",
+	  "ram_size": "16G",
+	  "kvm_enabled": true,
+	  "host_input_dir": "/home/cc/bee_share"
+      }
+  }
+}

--- a/examples/bee-launcher-example/flecsale2/bee-vm/flecsale_run.sh
+++ b/examples/bee-launcher-example/flecsale2/bee-vm/flecsale_run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/home/flecsi/flecsale/build/apps/hydro/2d/hydro_2d -m  /home/flecsi/flecsale/specializations/data/meshes/2d/square/square_32x32.g


### PR DESCRIPTION
Previous Flecsale can only use one node (process). So, we added a second Flecsale example that can utilize multiple nodes (processes).