### PR TITLE
Fix potential problem on multi-node run

### DIFF
--- a/bee-launcher/bee_aws.py
+++ b/bee-launcher/bee_aws.py
@@ -87,7 +87,6 @@ class BeeAWS(object):
                     "-o StrictHostKeyChecking=no",
                     "-o ConnectTimeout=300",
                     "-o UserKnownHostsFile=/dev/null",
-                    "-q",
                     "-i", "{}".format(self.__aws_key_path),
                     "{}@{}".format(self.__user_name, self.__host),
                     "-x"]

--- a/bee-launcher/bee_aws_launcher.py
+++ b/bee-launcher/bee_aws_launcher.py
@@ -170,6 +170,7 @@ class BeeAWSLauncher(BeeTask):
 
     def general_run(self):
         master = self.__bee_aws_list[0]
+
         for run_conf in self.__task_conf['general_run']:
             host_script_path = run_conf['script']
             vm_script_path = '/home/ubuntu/general_script.sh'
@@ -179,6 +180,11 @@ class BeeAWSLauncher(BeeTask):
                 docker_script_path = '/root/general_script.sh'
             else:
                 docker_script_path = '/home/{}/general_script.sh'.format(self.__docker_conf['docker_username'])
+                for bee_aws in self.__bee_aws_list:
+                    bee_aws.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
+                                            local_pfwd = run_conf['local_port_fwd'],
+                                            remote_pfwd = run_conf['remote_port_fwd'], 
+                                            async = False)
             
             master.copy_file(host_script_path, vm_script_path)
             master.docker_copy_file(vm_script_path, docker_script_path)
@@ -199,10 +205,12 @@ class BeeAWSLauncher(BeeTask):
             else:
                 docker_script_path = '/home/{}/mpi_script.sh'.format(self.__docker_conf['docker_username'])
                 hostfile_path = '/home/{}/hostfile'.format(self.__docker_conf['docker_username'])
-		for bee_aws in self.__bee_aws_list:
-		    bee_aws.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
-					  local_pfwd = run_conf['local_port_fwd'],
-                                          remote_pfwd = run_conf['remote_port_fwd'], async = False)
+                for bee_aws in self.__bee_aws_list:
+                    bee_aws.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
+                                            local_pfwd = run_conf['local_port_fwd'],
+                                            remote_pfwd = run_conf['remote_port_fwd'], 
+                                            async = False)
+		
 
             for bee_aws in self.__bee_aws_list:
                 bee_aws.copy_file(host_script_path, vm_script_path)

--- a/bee-launcher/bee_aws_launcher.py
+++ b/bee-launcher/bee_aws_launcher.py
@@ -199,6 +199,10 @@ class BeeAWSLauncher(BeeTask):
             else:
                 docker_script_path = '/home/{}/mpi_script.sh'.format(self.__docker_conf['docker_username'])
                 hostfile_path = '/home/{}/hostfile'.format(self.__docker_conf['docker_username'])
+		for bee_aws in self.__bee_aws_list:
+		    bee_aws.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
+					  local_pfwd = run_conf['local_port_fwd'],
+                                          remote_pfwd = run_conf['remote_port_fwd'], async = False)
 
             for bee_aws in self.__bee_aws_list:
                 bee_aws.copy_file(host_script_path, vm_script_path)

--- a/bee-launcher/bee_hot
+++ b/bee-launcher/bee_hot
@@ -36,9 +36,9 @@ resources:
         #!/bin/bash
         usermod -aG docker $USER
         yum install -y nfs-utils
-        mkdir -p /exports/host_share
-        chown -R cc:cc /exports
-        echo '/exports/host_share 10.140.80.0/22(rw,async) 10.40.0.0/23(rw,async)' >> /etc/exports
+        #mkdir -p /exports/host_share
+        #chown -R cc:cc /exports
+        #echo '/exports/host_share 10.140.80.0/22(rw,async) 10.40.0.0/23(rw,async)' >> /etc/exports
         systemctl enable rpcbind && systemctl start rpcbind
         systemctl enable nfs-server && systemctl start nfs-server
         systemctl start docker
@@ -63,18 +63,18 @@ resources:
              - network: sharednet1
           security_groups: [{ get_resource: bee_security_group }]
           scheduler_hints: { reservation: { get_param: reservation_id } }
-          user_data:
-            str_replace:
-              template: |
-                #!/bin/bash
-                usermod -aG docker $USER
-                yum install -y nfs-utils
-                mkdir -p /exports/host_share
-                echo "$nfs_server_ip:/exports/host_share    /exports/host_share    nfs" > /etc/fstab
-                mount -a
-                systemctl start docker
-              params:
-                $nfs_server_ip: { get_attr: [bee_master, first_address] }
+          user_data: |
+            #!/bin/bash
+            usermod -aG docker $USER
+            yum install -y nfs-utils
+            systemctl start docker
+            #str_replace:
+            #template: |
+            #mkdir -p /exports/host_share
+            #echo "$nfs_server_ip:/exports/host_share    /exports/host_share    nfs" > /etc/fstab
+            #mount -a
+            #params:
+            #  $nfs_server_ip: { get_attr: [bee_master, first_address] }
 
 # The parameters section gathers configuration from the user.
 parameters:

--- a/bee-launcher/bee_os.py
+++ b/bee-launcher/bee_os.py
@@ -191,6 +191,12 @@ class BeeOS(object):
         cmd = ["sudo mount -a"]
         self.run(cmd)
 
+    def set_file_permssion(self, path):
+	cmd = ['sudo chmod',
+               '766',
+	       '{}'.format(path)]
+        self.run(cmd)
+        
 
     def add_docker_container(self, docker):
         self.__docker = docker

--- a/bee-launcher/bee_os.py
+++ b/bee-launcher/bee_os.py
@@ -2,6 +2,7 @@ import subprocess
 from docker import Docker
 import os
 from termcolor import colored, cprint
+import time
 
 class BeeOS(object):
     def __init__(self, task_id, hostname, rank, task_conf, bee_os_conf, key_path, private_ip, master_public_ip, master = ""):
@@ -13,6 +14,7 @@ class BeeOS(object):
         self.__user_name = "cc"
         self.__key_path = key_path
         self.__remote_key_path = '/home/cc/.ssh/id_rsa'
+        self.__instance_share_dir = '/exports/host_share'
 
         # Network
         self.private_ip = private_ip
@@ -29,7 +31,7 @@ class BeeOS(object):
                     "-o StrictHostKeyChecking=no",
                     "-o ConnectTimeout=300",
                     "-o UserKnownHostsFile=/dev/null",
-                    "-q",
+                    #"-q",
                     "-i {}".format(self.__key_path),
                     "{}@{}".format(self.__user_name, self.master_public_ip),
                     "-x"]
@@ -52,7 +54,7 @@ class BeeOS(object):
                     "-o StrictHostKeyChecking=no",
                     "-o ConnectTimeout=300",
                     "-o UserKnownHostsFile=/dev/null",
-                    "-q",
+                    #"-q",
                     "-i {}".format(self.__remote_key_path),
                     "{}@{}".format(self.__user_name, self.private_ip),
                     "-x"]
@@ -107,6 +109,20 @@ class BeeOS(object):
                "{}@{}:{}".format(self.__user_name, worker.private_ip, dest)]
         self.run_on_master(cmd)
 
+    def copy_from_master(self, src, dest):
+        cprint("["+self.hostname+"]: copy file from master: "+src+" --> "+dest+".", self.__output_color)
+        cmd = ["scp",
+               "-i {}".format(self.__key_path),
+               "-o StrictHostKeyChecking=no",
+               "-o ConnectTimeout=300",
+               "-o UserKnownHostsFile=/dev/null",
+               "{}@{}:{}".format(self.__user_name, self.master_public_ip, src),
+               "{}".format(dist)]
+               
+        print(' '.join(cmd))
+        subprocess.call(' '.join(cmd), shell = True)
+
+
 
     def get_ip(self):
         return self.private_ip    
@@ -124,9 +140,58 @@ class BeeOS(object):
         cmd = ["sudo echo",
                "\"{} {}\"".format(private_ip, hostname),
                "|",
-               "sudo tee --append",
-               "/etc/hosts"]
+	       "ssh",
+	       "{}@{}".format(self.__user_name, self.private_ip),
+               "\"sudo tee --append /etc/hosts\""]
         self.run(["'"] + cmd + ["'"])
+
+    def set_nfs_master(self):
+        cprint("["+self.hostname+"]: set NFS on master.", self.__output_color)
+        cmd = ["sudo mkdir",
+               "-p",
+               "{}".format(self.__instance_share_dir)]
+        self.run(cmd)
+
+        cmd = ["sudo chown",
+               "-R",
+               "cc:cc",
+               "{}".format(self.__instance_share_dir)]
+        self.run(cmd)
+
+        cmd = ["sudo echo",
+               "\"{} 10.140.80.0/22(rw,async) 10.40.0.0/23(rw,async)\"".format(self.__instance_share_dir),
+               "|",
+	       "ssh",
+	       "{}@{}".format(self.__user_name, self.private_ip),
+	       "\"sudo tee --append /etc/exports\""]
+        self.run(["'"] + cmd + ["'"])
+
+	cmd = ["sudo exportfs -a"]
+	self.run(cmd)
+
+    def set_nfs_worker(self, master_private_ip):
+        cprint("["+self.hostname+"]: set NFS on worker.", self.__output_color)
+        cmd = ["sudo mkdir",
+               "-p",
+               "{}".format(self.__instance_share_dir)]
+        self.run(cmd)
+
+        cmd = ["sudo chown",
+               "-R",
+               "cc:cc",
+               "{}".format(self.__instance_share_dir)]
+        self.run(cmd)
+
+        cmd = ["sudo echo",
+               "\"{}:{}    {}    nfs\"".format(master_private_ip, self.__instance_share_dir, self.__instance_share_dir),
+               "|",
+               "ssh",
+               "{}@{}".format(self.__user_name, self.private_ip),
+               "\"sudo tee --append /etc/fstab\""]
+        self.run(["'"] + cmd + ["'"])
+
+        cmd = ["sudo mount -a"]
+        self.run(cmd)
 
 
     def add_docker_container(self, docker):
@@ -145,19 +210,34 @@ class BeeOS(object):
         self.run(['sudo'] + self.__docker.copy_file(src, dest))
         self.run(['sudo'] + self.__docker.update_file_ownership(dest))
 
+    def docker_copy_file_out(self, src, dest):
+        cprint("["+self.hostname+"][Docker]: copy file from docker " + src + " --> " + dest +".", self.__output_color)
+        self.run(['sudo'] + self.__docker.copy_file_out(src, dest))
+
     def docker_seq_run(self, exec_cmd, local_pfwd = [], remote_pfwd = [], async = False):
         cprint("["+self.hostname+"][Docker]: run script:"+exec_cmd+".", self.__output_color)
         self.run(['sudo'] + self.__docker.run([exec_cmd]), local_pfwd = local_pfwd, remote_pfwd = remote_pfwd, async = async)
 
-    def docker_para_run(self, run_conf, exec_cmd, local_pfwd = [], remote_pfwd = [], async = False):
+    def docker_para_run(self, run_conf, exec_cmd, hostfile_path, local_pfwd = [], remote_pfwd = [], async = False):
         cprint("["+self.hostname+"][Docker]: run parallel script:" + exec_cmd + ".", self.__output_color)
         np = int(run_conf['proc_per_node']) * int(run_conf['num_of_nodes'])
         cmd = ["mpirun",
                "--allow-run-as-root",
                "--mca btl_tcp_if_include eno1",
-               "--hostfile /home/{}/hostfile".format(self.__docker.get_docker_username()),
+               "--hostfile {}".format(hostfile_path),
                "-np {}".format(np)]
         cmd = cmd + [exec_cmd]
+        self.run(['sudo'] + self.__docker.run(cmd), local_pfwd = local_pfwd, remote_pfwd = remote_pfwd, async = async)
+
+    def docker_para_run_scalability_test(self, run_conf, exec_cmd, hostfile_path, local_pfwd = [], remote_pfwd = [], async = False):
+        cprint("["+self.hostname+"][Docker]: run parallel script:" + exec_cmd + ".", self.__output_color)
+        np = int(run_conf['proc_per_node']) * int(run_conf['num_of_nodes'])
+        cmd = ["mpirun",
+               "--allow-run-as-root",
+               "--mca btl_tcp_if_include eno1",
+               "--hostfile {}".format(hostfile_path),
+               "-np {}".format(np)]
+        cmd = cmd + [exec_cmd] + [">>", "bee_scalability_test_{}_{}_.output".format(str(run_conf['num_of_nodes']).zfill(3), str(run_conf['proc_per_node']).zfill(3))]
         self.run(['sudo'] + self.__docker.run(cmd), local_pfwd = local_pfwd, remote_pfwd = remote_pfwd, async = async)
 
     def docker_make_hostfile(self, run_conf, nodes, tmp_dir):
@@ -170,9 +250,9 @@ class BeeOS(object):
         cmd = ["touch", hostfile_path]
         subprocess.call(' '.join(cmd), shell = True)
         # Add nodes to hostfile
-        for node in nodes:
+        for i in range(int(run_conf['num_of_nodes'])):
             cmd = ["echo",
-                   "\"{} slots={} \"".format(node.get_hostname(), run_conf['proc_per_node']),
+                   "\"{} slots={} \"".format(nodes[i].get_hostname(), run_conf['proc_per_node']),
                    "|",
                    "tee -a",
                    hostfile_path]

--- a/bee-launcher/bee_os.py
+++ b/bee-launcher/bee_os.py
@@ -31,7 +31,6 @@ class BeeOS(object):
                     "-o StrictHostKeyChecking=no",
                     "-o ConnectTimeout=300",
                     "-o UserKnownHostsFile=/dev/null",
-                    #"-q",
                     "-i {}".format(self.__key_path),
                     "{}@{}".format(self.__user_name, self.master_public_ip),
                     "-x"]
@@ -54,7 +53,6 @@ class BeeOS(object):
                     "-o StrictHostKeyChecking=no",
                     "-o ConnectTimeout=300",
                     "-o UserKnownHostsFile=/dev/null",
-                    #"-q",
                     "-i {}".format(self.__remote_key_path),
                     "{}@{}".format(self.__user_name, self.private_ip),
                     "-x"]

--- a/bee-launcher/bee_os_launcher.py
+++ b/bee-launcher/bee_os_launcher.py
@@ -319,6 +319,7 @@ class BeeOSLauncher(BeeTask):
                                             async = False)
             
             master.copy_to_master(local_script_path, node_script_path)
+            master.set_file_permssion(node_script_path)
             master.docker_copy_file(node_script_path, docker_script_path)
             master.docker_seq_run(docker_script_path, local_pfwd = run_conf['local_port_fwd'],
                                   remote_pfwd = run_conf['remote_port_fwd'], async = False)
@@ -343,6 +344,7 @@ class BeeOSLauncher(BeeTask):
 			
             
             master.copy_to_master(local_script_path, node_script_path)
+            master.set_file_permssion(node_script_path)
             for bee_os in self.__bee_os_list:
                 bee_os.docker_copy_file(node_script_path, docker_script_path)
 		

--- a/bee-launcher/bee_os_launcher.py
+++ b/bee-launcher/bee_os_launcher.py
@@ -300,6 +300,7 @@ class BeeOSLauncher(BeeTask):
 
     def general_run(self):
         cprint('[' + self.__task_name + '] Execute run scripts.', self.__output_color)
+        
         # General sequential script
         master = self.__bee_os_list[0]
         for run_conf in self.__task_conf['general_run']:
@@ -311,6 +312,11 @@ class BeeOSLauncher(BeeTask):
                 docker_script_path = '/root/general_script.sh'
             else:
                 docker_script_path = '/home/{}/general_script.sh'.format(self.__docker_conf['docker_username'])
+                for bee_os in self.__bee_os_list:
+                    bee_os.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
+                                            local_pfwd = run_conf['local_port_fwd'],
+                                            remote_pfwd = run_conf['remote_port_fwd'], 
+                                            sync = False)
             
             master.copy_to_master(local_script_path, node_script_path)
             master.docker_copy_file(node_script_path, docker_script_path)
@@ -329,10 +335,12 @@ class BeeOSLauncher(BeeTask):
             else:
                 docker_script_path = '/home/{}/mpi_script.sh'.format(self.__docker_conf['docker_username'])
                 hostfile_path = '/home/{}/hostfile'.format(self.__docker_conf['docker_username'])
-		for bee_os in self.__bee_os_list:
-		    bee_os.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
-					  local_pfwd = run_conf['local_port_fwd'],
-                                          remote_pfwd = run_conf['remote_port_fwd'], async = False)	
+                for bee_os in self.__bee_os_list:
+                    bee_os.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
+                                            local_pfwd = run_conf['local_port_fwd'],
+                                            remote_pfwd = run_conf['remote_port_fwd'], 
+                                            async = False)
+			
             
             master.copy_to_master(local_script_path, node_script_path)
             for bee_os in self.__bee_os_list:

--- a/bee-launcher/bee_os_launcher.py
+++ b/bee-launcher/bee_os_launcher.py
@@ -316,7 +316,7 @@ class BeeOSLauncher(BeeTask):
                     bee_os.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
                                             local_pfwd = run_conf['local_port_fwd'],
                                             remote_pfwd = run_conf['remote_port_fwd'], 
-                                            sync = False)
+                                            async = False)
             
             master.copy_to_master(local_script_path, node_script_path)
             master.docker_copy_file(node_script_path, docker_script_path)

--- a/bee-launcher/bee_os_launcher.py
+++ b/bee-launcher/bee_os_launcher.py
@@ -3,6 +3,9 @@ import getpass
 import subprocess
 import time
 from os.path import expanduser
+import getpass
+import sys
+
 
 from docker import Docker
 from termcolor import colored, cprint
@@ -22,7 +25,7 @@ from neutronclient.v2_0.client import Client as neutronClient
 
 class BeeOSLauncher(BeeTask):
 
-    def __init__(self, task_id, beefile):
+    def __init__(self, task_id, beefile = "", scalability_test = False):
 
         BeeTask.__init__(self)
 
@@ -66,6 +69,8 @@ class BeeOSLauncher(BeeTask):
         self.__end_event = Event()
         self.__event_list = []
 
+        self.__scalability_test = scalability_test
+
         self.__current_status = 1 # initialized
 
     def run(self):
@@ -83,14 +88,27 @@ class BeeOSLauncher(BeeTask):
         self.setup_sshconfig()
         self.setup_hostname()
         self.setup_hostfile()
+        self.setup_storage()
         self.add_docker()
+        self.__bee_os_list[0].parallel_run(['hostname'], self.__bee_os_list)
         self.get_docker_img()
         self.start_docker()
         self.__current_status = 2 # waiting
         self.wait_for_others()
         self.__current_status = 4 # Running
-        self.general_run()
+        if (self.__scalability_test):
+            self.scalability_test_run()
+        else:
+            self.general_run()
         self.__current_status = 5 # finished
+
+    def setup_storage(self):
+        # set nfs on master
+        self.__bee_os_list[0].set_nfs_master();
+        master_private_ip = self.__bee_os_list[0].private_ip
+        for i in range(1, len(self.__bee_os_list)):
+            worker = self.__bee_os_list[i]
+            worker.set_nfs_worker(master_private_ip)
 
 
     def wait_for_others(self):
@@ -123,7 +141,7 @@ class BeeOSLauncher(BeeTask):
         cmd = ['openstack stack delete -y {}'.format(self.__stack_name)]
         print(" ".join(cmd))
         subprocess.call(" ".join(cmd), shell=True)
-        time.sleep(45)
+        time.sleep(60)
 
     def create_key(self):
         cprint('[' + self.__task_name + '] Create new ssh key.', self.__output_color)
@@ -147,8 +165,21 @@ class BeeOSLauncher(BeeTask):
         print(" ".join(cmd))
         subprocess.call(cmd, shell=True)
 
+    def launch_stack_storage(self):
+        cprint('[' + self.__task_name + '] Launch stack', self.__output_color)
+        curr_dir = os.path.dirname(os.path.abspath(__file__))
+        hot_template_dir = curr_dir + "/bee_hot_storage"
+        cmd = [ "openstack " +
+                "stack create " + 
+                "-t {} ".format(hot_template_dir) + 
+                "--parameter bee_workers_count={} ".format(int(self.__bee_os_conf['num_of_nodes']) - 1) +
+                "--parameter key_name={} ".format(self.__ssh_key) +
+                "--parameter reservation_id={} ".format(self.__reservation_id) +
+                "--parameter security_group_name={} ".format(self.__bee_os_sgroup) +
+                "{}".format(self.__stack_name)]
+        print(" ".join(cmd))
+        subprocess.call(cmd, shell=True)
         
-
     def get_active_node(self):
         active_nodes = []
         all_active_servers = self.nova.servers.list(search_opts={'status': 'ACTIVE'})
@@ -161,8 +192,15 @@ class BeeOSLauncher(BeeTask):
 
     def wait_for_nodes(self):
         cprint('[' + self.__task_name + '] Waiting for all nodes to become active.', self.__output_color)
+        counter = 0
         while (len(self.get_active_node()) != int(self.__bee_os_conf['num_of_nodes'])):
             time.sleep(5)
+            counter += 1
+            # output something to avoid accident termination by Travis CI
+            if (counter % 30 == 0):
+                sys.stdout.write('.')
+                sys.stdout.flush()
+        print(" ")
         cprint('[' + self.__task_name + '] All nodes are active, wait for networks to become available.', self.__output_color)
         time.sleep(200)
         cprint('[' + self.__task_name + '] Start BEE configuration.', self.__output_color)
@@ -189,6 +227,8 @@ class BeeOSLauncher(BeeTask):
                                        ip_list[1])
                         self.__bee_os_list.insert(0, master)
                         print('find master with ip: ' + ip_list[0] + ", " + ip_list[1])
+    def get_master_ip(self):
+        return self.__bee_os_list[0].master_public_ip
 
     def get_worker_nodes(self):
         cprint('[' + self.__task_name + '] Find the ip for worker nodes.', self.__output_color)
@@ -239,6 +279,8 @@ class BeeOSLauncher(BeeTask):
             for node2 in self.__bee_os_list:
                 node2.add_host_list(node1.get_ip(), node1.get_hostname())
 
+
+
     def add_docker(self):
         cprint('[' + self.__task_name + '] Initialize docker', self.__output_color)
         for bee_os in self.__bee_os_list:
@@ -257,14 +299,19 @@ class BeeOSLauncher(BeeTask):
 
 
     def general_run(self):
-
         cprint('[' + self.__task_name + '] Execute run scripts.', self.__output_color)
         # General sequential script
         master = self.__bee_os_list[0]
         for run_conf in self.__task_conf['general_run']:
             local_script_path = run_conf['script']
             node_script_path = '/exports/host_share/general_script.sh'
-            docker_script_path = '/home/{}/general_script.sh'.format(self.__docker_conf['docker_username'])
+            
+            docker_script_path = ''
+            if (self.__docker_conf['docker_username'] == 'root'):
+                docker_script_path = '/root/general_script.sh'
+            else:
+                docker_script_path = '/home/{}/general_script.sh'.format(self.__docker_conf['docker_username'])
+            
             master.copy_to_master(local_script_path, node_script_path)
             master.docker_copy_file(node_script_path, docker_script_path)
             master.docker_seq_run(docker_script_path, local_pfwd = run_conf['local_port_fwd'],
@@ -273,14 +320,65 @@ class BeeOSLauncher(BeeTask):
         for run_conf in self.__task_conf['mpi_run']:
             local_script_path = run_conf['script']
             node_script_path = '/exports/host_share/mpi_script.sh'
-            docker_script_path = '/home/{}/mpi_script.sh'.format(self.__docker_conf['docker_username'])
+            
+            docker_script_path = ''
+            hostfile_path = ''
+            if (self.__docker_conf['docker_username'] == 'root'):
+                docker_script_path = '/root/mpi_script.sh'
+                hostfile_path = '/root/hostfile'
+            else:
+                docker_script_path = '/home/{}/mpi_script.sh'.format(self.__docker_conf['docker_username'])
+                hostfile_path = '/home/{}/hostfile'.format(self.__docker_conf['docker_username'])
+		for bee_os in self.__bee_os_list:
+		    bee_os.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
+					  local_pfwd = run_conf['local_port_fwd'],
+                                          remote_pfwd = run_conf['remote_port_fwd'], async = False)	
+            
             master.copy_to_master(local_script_path, node_script_path)
             for bee_os in self.__bee_os_list:
                 bee_os.docker_copy_file(node_script_path, docker_script_path)
+		
             # Generate hostfile and copy to container
             master.docker_make_hostfile(run_conf, self.__bee_os_list, self.__tmp_dir)
             master.copy_to_master(self.__tmp_dir + '/hostfile', '/home/cc/hostfile')
-            docker_script_path = '/home/{}/mpi_script.sh'.format(self.__docker_conf['docker_username'])
-            master.docker_copy_file('/home/cc/hostfile', '/home/{}/hostfile'.format(self.__docker_conf['docker_username']))
+            master.docker_copy_file('/home/cc/hostfile', hostfile_path)    
             # Run parallel script on all nodes
-            master.docker_para_run(run_conf, docker_script_path, local_pfwd = run_conf['local_port_fwd'],remote_pfwd = run_conf['remote_port_fwd'], async = False)
+            master.docker_para_run(run_conf, 
+                                   docker_script_path, 
+                                   hostfile_path, 
+                                   local_pfwd = run_conf['local_port_fwd'],
+                                   remote_pfwd = run_conf['remote_port_fwd'],
+                                   async = False)
+
+
+    def scalability_test_run(self):
+        cprint('[' + self.__task_name + '] Start scalability test.', self.__output_color)
+        master = self.__bee_os_list[0]
+
+        for run_conf in self.__task_conf['mpi_run']:
+            local_script_path = run_conf['script']
+            node_script_path = '/exports/host_share/mpi_script.sh'
+
+            docker_script_path = ''
+            hostfile_path = ''
+            if (self.__docker_conf['docker_username'] == 'root'):
+                docker_script_path = '/root/mpi_script.sh'
+                hostfile_path = '/root/hostfile'
+            else:
+                docker_script_path = '/home/{}/mpi_script.sh'.format(self.__docker_conf['docker_username'])
+                hostfile_path = '/home/{}/hostfile'.format(self.__docker_conf['docker_username'])
+
+            master.copy_to_master(local_script_path, node_script_path)
+            for bee_os in self.__bee_os_list:
+                bee_os.docker_copy_file(node_script_path, docker_script_path)
+
+            # Generate hostfile and copy to container
+            master.docker_make_hostfile(run_conf, self.__bee_os_list, self.__tmp_dir)
+            master.copy_to_master(self.__tmp_dir + '/hostfile', '/home/cc/hostfile')
+            master.docker_copy_file('/home/cc/hostfile', hostfile_path)
+            master.docker_para_run_scalability_test(run_conf, 
+                                                    docker_script_path, 
+                                                    hostfile_path,
+                                                    local_pfwd = run_conf['local_port_fwd'],
+                                                    remote_pfwd = run_conf['remote_port_fwd'], 
+                                                    async = False)

--- a/bee-launcher/bee_vm.py
+++ b/bee-launcher/bee_vm.py
@@ -68,7 +68,6 @@ class BeeVM(object):
                                 "-o StrictHostKeyChecking=no",
                                 "-o ConnectTimeout=300",
                                 "-o UserKnownHostsFile=/dev/null",
-                                "-q",
                                 "-i {}".format(self.__key_path),
                                 "{}@localhost".format('root'),
                                 "-x"]
@@ -131,7 +130,6 @@ class BeeVM(object):
                     "-o StrictHostKeyChecking=no",
                     "-o ConnectTimeout=300",
                     "-o UserKnownHostsFile=/dev/null",
-                    "-q",
                     "-i {}".format(self.__key_path),
                     "{}@localhost".format(self.__user_name),
                     "-x"]
@@ -153,7 +151,6 @@ class BeeVM(object):
                          "-o StrictHostKeyChecking=no",
                          "-o ConnectTimeout=300",
                          "-o UserKnownHostsFile=/dev/null",
-                         "-q",
                          "-i {}".format(self.__key_path),
                          "{}@localhost".format('root'),
                          "-x"]

--- a/bee-launcher/bee_vm_launcher.py
+++ b/bee-launcher/bee_vm_launcher.py
@@ -216,6 +216,7 @@ class BeeVMLauncher(BeeTask):
     def general_run(self):
         # General sequential script
         master = self.__bee_vm_list[0]
+        
         for run_conf in self.__task_conf['general_run']:
             host_script_path = run_conf['script']
             vm_script_path = '/home/ubuntu/general_script.sh'
@@ -225,6 +226,11 @@ class BeeVMLauncher(BeeTask):
                 docker_script_path = '/root/general_script.sh'
             else:
                 docker_script_path = '/home/{}/general_script.sh'.format(self.__docker_conf['docker_username'])
+                for bee_vm in self.__bee_vm_list:
+                    bee_vm.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
+                                            local_pfwd = run_conf['local_port_fwd'],
+                                            remote_pfwd = run_conf['remote_port_fwd'], 
+                                            async = False)
 
             master.copy_file(host_script_path, vm_script_path)
             master.docker_copy_file(vm_script_path, docker_script_path)
@@ -243,10 +249,12 @@ class BeeVMLauncher(BeeTask):
             else:
                 docker_script_path = '/home/{}/mpi_script.sh'.format(self.__docker_conf['docker_username'])
                 hostfile_path = '/home/{}/hostfile'.format(self.__docker_conf['docker_username'])
-		for bee_vm in self.__bee_vm_list:
-		    bee_vm.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
-					  local_pfwd = run_conf['local_port_fwd'],
-                                          remote_pfwd = run_conf['remote_port_fwd'], async = False)	
+                for bee_vm in self.__bee_vm_list:
+                    bee_vm.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
+                                            local_pfwd = run_conf['local_port_fwd'],
+                                            remote_pfwd = run_conf['remote_port_fwd'], 
+                                            async = False)
+			
 
             for bee_vm in self.__bee_vm_list:
                 bee_vm.copy_file(host_script_path, vm_script_path)

--- a/bee-launcher/bee_vm_launcher.py
+++ b/bee-launcher/bee_vm_launcher.py
@@ -243,6 +243,10 @@ class BeeVMLauncher(BeeTask):
             else:
                 docker_script_path = '/home/{}/mpi_script.sh'.format(self.__docker_conf['docker_username'])
                 hostfile_path = '/home/{}/hostfile'.format(self.__docker_conf['docker_username'])
+		for bee_vm in self.__bee_vm_list:
+		    bee_vm.docker_seq_run('cp -r /home/{}/.ssh /root/'.format(self.__docker_conf['docker_username']),
+					  local_pfwd = run_conf['local_port_fwd'],
+                                          remote_pfwd = run_conf['remote_port_fwd'], async = False)	
 
             for bee_vm in self.__bee_vm_list:
                 bee_vm.copy_file(host_script_path, vm_script_path)

--- a/bee-launcher/docker.py
+++ b/bee-launcher/docker.py
@@ -15,11 +15,11 @@ class Docker(object):
         # Get Dockerfile from git repository.
         cmd = ["git",
                "clone",
-               "{}".format(dockerfile_git_url)]
+               "{}".format(self.__dockerfile_git_url)]
 
         # Resolve repository folder name.
-        self.__dockerfile_path = dockerfile_git_url.split("/")[-1].split(".")[0]
-        self.__docker_img_tag = __dockerfile_path
+        self.__dockerfile_path = self.__dockerfile_git_url.split("/")[-1].split(".")[0]
+        self.__docker_img_tag = self.__dockerfile_path
         return cmd
 
     def get_docker_img(self):        

--- a/examples/bee-launcher-example/lammps2/bee-aws/lammps.beefile
+++ b/examples/bee-launcher-example/lammps2/bee-aws/lammps.beefile
@@ -1,0 +1,29 @@
+{
+	"task_conf": {
+		"task_name": "lammps",
+		"exec_target": "bee_os",
+		"batch_mode": false,
+		"general_run": [],
+		"mpi_run": [{
+			"script": "mpi_lammps.sh",
+			"local_port_fwd": [],
+			"remote_port_fwd": [],
+			"num_of_nodes": "2",
+			"proc_per_node": "1"
+		}],
+		"terminate_after_exec": false
+	},
+	"docker_conf": {
+		"docker_img_tag": "pagrubel/lammps-beeuser",
+		"docker_username": "beeuser",
+		"docker_shared_dir": "/mnt/docker_share"
+	},
+	"exec_env_conf": {
+		"bee_aws": {
+          		"num_of_nodes": "2",
+          		"ami_image": "ami-ad5952d4",
+          		"instance_type": "c3.4xlarge",
+          		"efs_id": "fs-98e73431"
+      }
+	}
+}

--- a/examples/bee-launcher-example/lammps2/bee-aws/lammps.beefile
+++ b/examples/bee-launcher-example/lammps2/bee-aws/lammps.beefile
@@ -1,7 +1,7 @@
 {
 	"task_conf": {
 		"task_name": "lammps",
-		"exec_target": "bee_os",
+		"exec_target": "bee_aws”,
 		"batch_mode": false,
 		"general_run": [],
 		"mpi_run": [{

--- a/examples/bee-launcher-example/lammps2/bee-aws/mpi_lammps.sh
+++ b/examples/bee-launcher-example/lammps2/bee-aws/mpi_lammps.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/home/beeuser/lammps/src/lmp_mpi -in /home/beeuser/lammps/examples/melt/in.melt

--- a/examples/bee-launcher-example/lammps2/bee-os/lammps.beefile
+++ b/examples/bee-launcher-example/lammps2/bee-os/lammps.beefile
@@ -1,0 +1,27 @@
+{
+	"task_conf": {
+		"task_name": "lammps",
+		"exec_target": "bee_os",
+		"batch_mode": false,
+		"general_run": [],
+		"mpi_run": [{
+			"script": "mpi_lammps.sh",
+			"local_port_fwd": [],
+			"remote_port_fwd": [],
+			"num_of_nodes": "2",
+			"proc_per_node": "1"
+		}],
+		"terminate_after_exec": false
+	},
+	"docker_conf": {
+		"docker_img_tag": "pagrubel/lammps-beeuser",
+		"docker_username": "beeuser",
+		"docker_shared_dir": "/mnt/docker_share"
+	},
+	"exec_env_conf": {
+		"bee_os": {
+			"num_of_nodes": "2",
+			"reservation_id": "26aa8a6d-a72d-4bf8-a1e8-5cc2ef526e01"
+		}
+	}
+}

--- a/examples/bee-launcher-example/lammps2/bee-os/mpi_lammps.sh
+++ b/examples/bee-launcher-example/lammps2/bee-os/mpi_lammps.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/home/beeuser/lammps/src/lmp_mpi -in /home/beeuser/lammps/examples/melt/in.melt

--- a/examples/bee-launcher-example/lammps2/bee-vm/lammps.beefile
+++ b/examples/bee-launcher-example/lammps2/bee-vm/lammps.beefile
@@ -1,0 +1,32 @@
+{
+	"task_conf": {
+		"task_name": "lammps",
+		"exec_target": "bee_os",
+		"batch_mode": false,
+		"general_run": [],
+		"mpi_run": [{
+			"script": "mpi_lammps.sh",
+			"local_port_fwd": [],
+			"remote_port_fwd": [],
+			"num_of_nodes": "2",
+			"proc_per_node": "1"
+		}],
+		"terminate_after_exec": false
+	},
+	"docker_conf": {
+		"docker_img_tag": "pagrubel/lammps-beeuser",
+		"docker_username": "beeuser",
+		"docker_shared_dir": "/mnt/docker_share"
+	},
+	"exec_env_conf": {
+		"bee_vm": {
+	  		"node_list": ["cn30", "cn31"],
+	  		"cpu_core_per_socket": "8",
+	  		"cpu_thread_per_core": "1",
+	  		"cpu_sockets": "2",
+	  		"ram_size": "16G",
+	  		"kvm_enabled": true,
+	 	 	"host_input_dir": "/home/cc/bee_share"
+      		}
+	}
+}

--- a/examples/bee-launcher-example/lammps2/bee-vm/lammps.beefile
+++ b/examples/bee-launcher-example/lammps2/bee-vm/lammps.beefile
@@ -1,7 +1,7 @@
 {
 	"task_conf": {
 		"task_name": "lammps",
-		"exec_target": "bee_os",
+		"exec_target": "bee_vm”,
 		"batch_mode": false,
 		"general_run": [],
 		"mpi_run": [{

--- a/examples/bee-launcher-example/lammps2/bee-vm/lammps.beefile
+++ b/examples/bee-launcher-example/lammps2/bee-vm/lammps.beefile
@@ -1,7 +1,7 @@
 {
 	"task_conf": {
 		"task_name": "lammps",
-		"exec_target": "bee_vm”,
+        "exec_target": "bee_vm",
 		"batch_mode": false,
 		"general_run": [],
 		"mpi_run": [{

--- a/examples/bee-launcher-example/lammps2/bee-vm/mpi_lammps.sh
+++ b/examples/bee-launcher-example/lammps2/bee-vm/mpi_lammps.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/home/beeuser/lammps/src/lmp_mpi -in /home/beeuser/lammps/examples/melt/in.melt


### PR DESCRIPTION
(1) This PR contains a bug fix that may prevent MPI run correctly on a multi-process/node environment. This bug may affect BEE-VM/AWS/OpenStack launcher. Since we run everything as root inside the container, the ssh keys need to be copied from the default user in the container (e.g. beeuser), otherwise, we may encounter an MPI error.
(2) I also add a performance optimization for BEE-OpenStack Launcher that speeds up its launching speed by 30% - 50%. It optimization basically allows worker instances to launch at the same time as the master instance.