### PR TITLE
Bee startup

### DIFF
--- a/beeflow/common/config/config_driver.py
+++ b/beeflow/common/config/config_driver.py
@@ -32,21 +32,38 @@ class BeeConfig:
         self.userconfig = ConfigParser()
         system = platform.system()
         if system == "Linux":
-            sysconfig_file = '/etc/beeflow/bee.conf'
-            userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
+            self.sysconfig_file = '/etc/beeflow/bee.conf'
+            self.userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
         elif system == "Darwin":
-            sysconfig_file = '/Library/Application Support/beeflow/bee.conf'
-            userconfig_file = os.path.expanduser('~/Library/Application Support/beeflow/bee.conf')
+            self.sysconfig_file = '/Library/Application Support/beeflow/bee.conf'
+            self.userconfig_file = os.path.expanduser('~/Library/Application Support/beeflow/bee.conf')
         elif system == "Windows":
-            sysconfig_file = ''
-            userconfig_file = os.path.expandvars(r'%APPDATA%\beeflow\bee.conf')
+            self.sysconfig_file = ''
+            self.userconfig_file = os.path.expandvars(r'%APPDATA%\beeflow\bee.conf')
 
         try:
-            self.sysconfig.read_file(open(sysconfig_file))
+            self.sysconfig.read_file(open(self.sysconfig_file))
         except FileNotFoundError:
-            print("System configuration " + sysconfig_file + " not found")
+            print("System configuration " + self.sysconfig_file + " not found")
 
         try:
-            self.userconfig.read_file(open(userconfig_file))
+            self.userconfig.read_file(open(self.userconfig_file))
         except FileNotFoundError:
-            print("User configuration " + userconfig_file + " not found")
+            print("User configuration " + self.userconfig_file + " not found")
+
+    def add_section(self, conf, secdict):
+        """Add a new section to the system or user config file.
+
+        :param conf: which config file to edit
+        :type conf: string, 'user', 'system', or 'both'
+        :param secdict: key-value pairs of configuration variable
+        :type secdict: dictionary, first entry MUST BE 'name': <value> of the new section
+        """
+        section_name = secdict.pop('name')
+        newconfig = ConfigParser()
+        newconfig[str(section_name)] = secdict
+        if conf == 'user':
+            with open(self.userconfig_file, 'a')as configfile:
+                configfile.write('\n')
+                newconfig.write(configfile)
+                configfile.close()

--- a/beeflow/common/config/config_driver.py
+++ b/beeflow/common/config/config_driver.py
@@ -44,12 +44,12 @@ class BeeConfig:
         try:
             self.sysconfig.read_file(open(self.sysconfig_file))
         except FileNotFoundError:
-            print("System configuration " + self.sysconfig_file + " not found")
+            pass
 
         try:
             self.userconfig.read_file(open(self.userconfig_file))
         except FileNotFoundError:
-            print("User configuration " + self.userconfig_file + " not found")
+            pass
 
     def add_section(self, conf, secdict):
         """Add a new section to the system or user config file.

--- a/beeflow/common/gdb/neo4j_driver.py
+++ b/beeflow/common/gdb/neo4j_driver.py
@@ -12,6 +12,8 @@ from beeflow.common.gdb.gdb_driver import GraphDatabaseDriver
 from beeflow.common.gdb import neo4j_cypher as tx
 from beeflow.common.data.wf_data import Task, Requirement
 
+from beeflow.common.config.config_driver import BeeConfig
+
 # Default Neo4j authentication
 # We may want to instead get these from a config at some point
 DEFAULT_URI = "bolt://localhost:7687"
@@ -36,6 +38,13 @@ class Neo4jDriver(GraphDatabaseDriver):
         :param password: the password for the database user account
         :type password: string
         """
+        bc = BeeConfig()
+        if bc.userconfig.has_section('graphdb'):
+            graphsec = bc.userconfig['graphdb']
+            bolt_port = graphsec.get('bolt_port')
+            db_hostname = graphsec.get('hostname')
+            uri="bolt://" + str(db_hostname) + ":" + str(bolt_port)
+            password=str(graphsec.get('dbpass'))
         try:
             # Connect to the Neo4j database using the Neo4j proprietary driver
             self._driver = Neo4jDatabase.driver(uri, auth=(user, password))

--- a/beeflow/server/startup.py
+++ b/beeflow/server/startup.py
@@ -1,0 +1,7 @@
+from beeflow.common.config.config_driver import BeeConfig
+
+bc = BeeConfig()
+
+bolt_port = bc.userconfig['graphdb'].get('bolt_port','7687')
+http_port = bc.userconfig['graphdb'].get('http_port','7474')
+https_port = bc.userconfig['graphdb'].get('https_port','7473')

--- a/beeflow/server/startup.py
+++ b/beeflow/server/startup.py
@@ -2,6 +2,26 @@ from beeflow.common.config.config_driver import BeeConfig
 
 bc = BeeConfig()
 
-bolt_port = bc.userconfig['graphdb'].get('bolt_port','7687')
-http_port = bc.userconfig['graphdb'].get('http_port','7474')
-https_port = bc.userconfig['graphdb'].get('https_port','7473')
+if bc.userconfig.has_section('graphdb'):
+    graphsec = bc.userconfig['graphdb']
+    bolt_port = graphsec.get('bolt_port','7687')
+    http_port = graphsec.get('http_port','7474')
+    https_port = graphsec.get('https_port','7473')
+    gdb_img = graphsec.get('gdb_image','')
+    gdb_img_mntdir = graphsec.get('gdb_img_mntdir','/tmp')
+else:
+    print("[graphdb] section not found in user bee.conf.")
+    print("Default values will be added to user bee.conf.")
+    print("Please edit your bee.conf and rerun startup.")
+
+    graphdb_dict = {
+        'name': 'graphdb',
+        'bolt_port': 7687,
+        'http_port': 7474,
+        'https_port': 7473,
+        'gdb_img':
+        'neo4j-ch.tar',
+        'gdb_img_mntdir': '/tmp',
+        }
+
+    bc.add_section('user', graphdb_dict)

--- a/beeflow/server/startup.py
+++ b/beeflow/server/startup.py
@@ -1,3 +1,7 @@
+import getpass
+import os
+import shutil
+import subprocess
 import sys
 import tempfile
 from beeflow.common.config.config_driver import BeeConfig
@@ -11,9 +15,9 @@ if bc.userconfig.has_section('graphdb'):
     http_port = graphsec.get('http_port','7474')
     https_port = graphsec.get('https_port','7473')
     gdb_img = graphsec.get('gdb_image','')
-    gdb_img_mntdir = graphsec.get('gdb_img_mntdir','/tmp')
+    gdb_img_mntdir = graphsec.get('gdb_image_mntdir','/tmp')
 else:
-    print("[graphdb] section not found in configuration file, default values will be added.")
+    print("[graphdb] section not found in configuration file, default values will be added")
 
     graphdb_dict = {
         'name': 'graphdb',
@@ -21,12 +25,35 @@ else:
         'bolt_port': 7687,
         'http_port': 7474,
         'https_port': 7473,
-        'gdb_img':
-        'neo4j-ch.tar',
-        'gdb_img_mntdir': '/tmp',
+        'gdb_image': 'neo4j-ch.tar',
+        'gdb_image_mntdir': '/tmp',
         }
 
     bc.add_section('user', graphdb_dict)
 
-    sys.exit("Please check " + str(bc.userconfig_file) + " and rerun startup.")
+    sys.exit("Please check " + str(bc.userconfig_file) + " and rerun startup")
 
+user_confdir = os.path.expanduser('~/.config/beeflow')
+container_dir = tempfile.mkdtemp(suffix="_" + getpass.getuser(), prefix="gdb_", dir=str(gdb_img_mntdir))
+print("GraphDB container mount directory " + container_dir + " created")
+newdir = os.path.split(container_dir)[1]
+
+subprocess.run(["ch-tar2dir",str(gdb_img),str(container_dir)])
+
+container_path = container_dir + "/" + os.listdir(str(container_dir))[0]
+container_config_path = os.path.join(user_confdir, newdir)
+os.mkdir(container_config_path)
+gdb_configfile = shutil.copyfile(container_path + "/var/lib/neo4j/conf/neo4j.conf", container_config_path + "/neo4j.conf")
+print(gdb_configfile)
+
+cfile = open(gdb_configfile, "rt")
+data = cfile.read()
+cfile.close()
+data = data.replace("#dbms.connector.bolt.listen_address=:7687", "dbms.connector.bolt.listen_address=:" + str(bolt_port))
+data = data.replace("#dbms.connector.http.listen_address=:7474", "dbms.connector.http.listen_address=:" + str(http_port))
+data = data.replace("#dbms.connector.https.listen_address=:7473", "dbms.connector.https.listen_address=:" + str(https_port))
+cfile = open(gdb_configfile, "wt")
+cfile.write(data)
+cfile.close()
+
+subprocess.run(["ch-run","-w","--set-env=" + container_path + "/environment","-b",container_config_path + ":/var/lib/neo4j/conf",container_path,"--","neo4j","console"])

--- a/beeflow/server/startup.py
+++ b/beeflow/server/startup.py
@@ -1,21 +1,23 @@
+import sys
+import tempfile
 from beeflow.common.config.config_driver import BeeConfig
 
 bc = BeeConfig()
 
 if bc.userconfig.has_section('graphdb'):
     graphsec = bc.userconfig['graphdb']
+    db_hostname = graphsec.get('hostname','localhost')
     bolt_port = graphsec.get('bolt_port','7687')
     http_port = graphsec.get('http_port','7474')
     https_port = graphsec.get('https_port','7473')
     gdb_img = graphsec.get('gdb_image','')
     gdb_img_mntdir = graphsec.get('gdb_img_mntdir','/tmp')
 else:
-    print("[graphdb] section not found in user bee.conf.")
-    print("Default values will be added to user bee.conf.")
-    print("Please edit your bee.conf and rerun startup.")
+    print("[graphdb] section not found in configuration file, default values will be added.")
 
     graphdb_dict = {
         'name': 'graphdb',
+        'hostname': 'localhost',
         'bolt_port': 7687,
         'http_port': 7474,
         'https_port': 7473,
@@ -25,3 +27,6 @@ else:
         }
 
     bc.add_section('user', graphdb_dict)
+
+    sys.exit("Please check " + str(bc.userconfig_file) + " and rerun startup.")
+


### PR DESCRIPTION
Merge bee_startup branch. Major details:

- beeflow/server/startup.py script
  - will create user config dir if missing
  - will create user bee.conf file if missing and populate it with initial values for graphdb configuration
  - prepares neo4j container for running using config values in user bee.conf
  - runs the database using charliecloud

- beeflow/common/config/config_driver.py
  - new "add_section" method to BeeConfig class to add a new configuration [section] and default values
  - removed annoying messages about missing system or user configuration files

- beeflow/common/gdb/neo4j_driver.py
  - now uses BeeConfig class to get values for neo4j hostname, password, bolt port from user bee.conf

Closes issue #125 