### PR TITLE
Bugfix: BEEStart should not assume bee.conf exists in bee_workdir

### DIFF
--- a/beeflow/common/config/config_driver.py
+++ b/beeflow/common/config/config_driver.py
@@ -160,11 +160,15 @@ class BeeConfig:
         """
         # Discard redundant paths, iff Windows, replace(\,/)
         relative_path = os.path.normpath(relative_path)
-        # Get desired config file name
-        filename = os.path.basename(relative_path)
         # Resolve the true path (expand relative path refs)
         tmp = os.getcwd()
-        os.chdir(os.path.dirname(relative_path))
-        absolute_path = '/'.join([os.getcwd(), filename])
+        if os.path.isdir(relative_path):
+            os.chdir(relative_path)
+            absolute_path = os.getcwd()
+        else:
+            # Get desired config file name
+            filename = os.path.basename(relative_path)
+            os.chdir(os.path.dirname(relative_path))
+            absolute_path = '/'.join([os.getcwd(), filename])
         os.chdir(tmp)
         return absolute_path

--- a/beeflow/common/config/config_driver.py
+++ b/beeflow/common/config/config_driver.py
@@ -71,16 +71,20 @@ class BeeConfig:
             except PermissionError as e:
                 raise PermissionError('Do you have write access to {}?'.\
                                        format(conf_file)) from e
+            # Set default bee_workdir relative to HOME unless otherwise specified.
+            try:
+                self.bee_workdir = kwargs['bee_workdir']
+            except KeyError:
+                self.bee_workdir = os.path.expanduser('~/.beeflow')
+
             # If user specified relative paths, make them absolute
-            self.userconfig_file = self.resolve_path(self.userconfig_file)
-            # Set workdir path as same as bee.conf
-            default_workdir = os.path.dirname(self.userconfig_file)
+            self.bee_workdir = self.resolve_path(self.bee_workdir)
             with open(self.userconfig_file, 'w') as conf_fh:
                 conf_fh.write("# BEE CONFIGURATION FILE #")
                 conf_fh.close()
             self.modify_section('user',
                                 'DEFAULT',
-                                {'bee_workdir': str(default_workdir)})
+                                {'bee_workdir': str(self.bee_workdir)})
 
     def modify_section(self, conf, section, keyvalue, replace=False):
         """Add a new section to the system or user config file.

--- a/bin/BEEStart
+++ b/bin/BEEStart
@@ -205,11 +205,11 @@ def StartWorkflowManager(bc, args):
             offset = os.getppid()%100
         else:
             offset = os.getuid()%100
-        wfm_dict = {
+        server_dict = {
             'listen_port': 5000 + offset,
         }
         # Add section (writes to config file)
-        bc.modify_section('user','workflow_manager',wfm_dict)
+        bc.modify_section('user','workflow_manager',server_dict)
     if args.config_only:
         return None
     # Either use the userconfig file argument specified to BEEStart,
@@ -283,25 +283,29 @@ def parse_args(args=sys.argv[1:]):
 
     parser.add_argument("-d", "--debug", action="store_true",
                         help="enable debugging output\nIf debug is specified all output will go to the console.\nOnly one BEE service may be launched by BEEStart if debug is requested.")
-    parser.add_argument("--wfm", action="store_true", help="start the BEEWorkflowManager (implies --gdb)")
+    parser.add_argument("--server", action="store_true", help="start the BEEWorkflowManager (implies --gdb)")
     parser.add_argument("--gdb", action="store_true", help="start the configured graph database")
     parser.add_argument("--tm", action="store_true", help="start the BEETaskManager")
     parser.add_argument("--restd", action="store_true", help="start the Slurm REST daemon")
     parser.add_argument("--userconfig-file", help="specify the path to a user configuration file")
+    parser.add_argument("--bee-workdir", help="specify the path for BEE to store temporary files and artifacts")
     parser.add_argument("--config-only", action="store_true", help="create a valid configuration file, but don't launch bee services.")
     return parser.parse_args(args)
 
 def main():
     args = parse_args()
-    start_all = not any([args.wfm, args.tm, args.gdb, args.restd]) or all([args.wfm, args.tm, args.gdb, args.restd])
-    if args.debug and not (sum([args.wfm,args.tm,args.gdb, args.restd]) == 1):
+    start_all = not any([args.server, args.tm, args.gdb, args.restd]) or all([args.server, args.tm, args.gdb, args.restd])
+    if args.debug and not (sum([args.server,args.tm,args.gdb, args.restd]) == 1):
         print("DEBUG requested, exactly one service must be specified",
               file=sys.stderr)
         return 1
+    # Pass configuration file params to config_driver.py
+    config_params = {}
     if args.userconfig_file:
-        bc = BeeConfig(userconfig=args.userconfig_file)
-    else:
-        bc = BeeConfig()
+        config_params['userconfig'] = args.userconfig_file
+    if args.bee_workdir:
+        config_params['bee_workdir'] = args.bee_workdir
+    bc = BeeConfig(**config_params)
 
     # Setup logging based on args.debug
     log = setup_logging(bc, args.debug)
@@ -329,14 +333,14 @@ def main():
                 return 1
             # Don't append the graph database to list of processes to wait for
             log.info('Loading Graph Database')
-    if args.wfm or start_all:
+    if args.server or start_all:
         proc = StartWorkflowManager(bc, args)
         if not args.config_only:
             if proc is None:
                 log.error('Workflow Manager failed to start. Exiting.')
                 print('Workflow Manager failed to start. Exiting.', file=sys.stderr)
                 return 1
-            create_pid_file(proc, 'wfm.pid', bc)
+            create_pid_file(proc, 'server.pid', bc)
             wait_list.append(('Workflow Manager', proc))
             log.info('Loading Workflow Manager')
     if args.tm or start_all:

--- a/bin/BEEStart
+++ b/bin/BEEStart
@@ -212,8 +212,14 @@ def StartWorkflowManager(bc, args):
         bc.modify_section('user','workflow_manager',wfm_dict)
     if args.config_only:
         return None
+    # Either use the userconfig file argument specified to BEEStart,
+    # or assume the default path to ~/.config/beeflow/bee.conf.
+    if args.userconfig_file:
+        userconfig_file = args.userconfig_file
+    else:
+        userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
     return subprocess.Popen(["python", 'beeflow/server/server.py',
-                            '/'.join([bc.userconfig.get('DEFAULT','bee_workdir'),'bee.conf'])],
+                            userconfig_file],
                             stdout=PIPE, stderr=PIPE)
 
 def StartTaskManager(bc, args):
@@ -234,8 +240,14 @@ def StartTaskManager(bc, args):
         bc.modify_section('user','task_manager',tm_dict)
     if args.config_only:
         return None
-    return subprocess.Popen(["python", "beeflow/task_manager/task_manager.py",
-                            '/'.join([bc.userconfig.get('DEFAULT','bee_workdir'),'bee.conf'])],
+    # Either use the userconfig file argument specified to BEEStart,
+    # or assume the default path to ~/.config/beeflow/bee.conf.
+    if args.userconfig_file:
+        userconfig_file = args.userconfig_file
+    else:
+        userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
+    return subprocess.Popen(["python", 'beeflow/task_manager/task_manager.py',
+                            userconfig_file],
                             stdout=PIPE, stderr=PIPE)
 
 def create_pid_file(proc, pid_file, bc):

--- a/bin/BEEStart
+++ b/bin/BEEStart
@@ -306,6 +306,9 @@ def main():
     if args.bee_workdir:
         config_params['bee_workdir'] = args.bee_workdir
     bc = BeeConfig(**config_params)
+    # If workdir argument exists, over-write
+    if args.bee_workdir:
+        bc.modify_section('user', 'DEFAULT', {'bee_workdir':bc.resolve_path(args.bee_workdir)} )
 
     # Setup logging based on args.debug
     log = setup_logging(bc, args.debug)


### PR DESCRIPTION
Added a check in BEEStart to always pass an argument to server.py and task_manager.py. If the user specifies a userconfig file to BEEStart at the cmd line, that will be used. Otherwise, ~/.config/beeflow/bee.conf. will be used.

This is a bug fix. Long term fix is to implement a class for all BEE components. Something like ConfigInit.