### PR TITLE
Crt/issue205: Pylama fixes, SlurmWorker re-factor, improved configuration parameter handling.

### DIFF
--- a/beeflow/common/crt/crt_interface.py
+++ b/beeflow/common/crt/crt_interface.py
@@ -8,6 +8,7 @@ Default: 'CharliecloudDriver' class.
 from beeflow.common.crt.crt_drivers import CharliecloudDriver
 from beeflow.common.crt.crt_drivers import SingularityDriver
 
+
 class ContainerRuntimeInterface:
     """Interface for the container runtime.
 
@@ -15,8 +16,7 @@ class ContainerRuntimeInterface:
     """
 
     def __init__(self, crt_driver=CharliecloudDriver):
-        """Initialize the container runtime interface with a runtime,
-           CharliecloudDriver by default.
+        """Initialize the CRT interface with a runtime, CharliecloudDriver by default.
 
         :param crt_driver: container runtime driver (default: CharliecloudDriver)
         :type crt_driver: subclass of ContainerRuntimeDriver
@@ -24,7 +24,7 @@ class ContainerRuntimeInterface:
         self._crt_driver = crt_driver()
 
     def script_text(self, task):
-        """Build text required to run the task using the container_runtime.
+        """Create text required to run the task using the container_runtime.
 
         :param task: instance of Task
         :rtype string
@@ -38,3 +38,5 @@ class ContainerRuntimeInterface:
         :rtype string
         """
         return self._crt_driver.image_exists(task)
+# Ignore module imported but unused error. No way to know which crt will be needed
+# pylama:ignore=W0611

--- a/beeflow/common/worker/slurm_worker.py
+++ b/beeflow/common/worker/slurm_worker.py
@@ -41,13 +41,15 @@ class SlurmWorker(Worker):
         try:
             self.tm_crt = kwargs['container_runtime']
         except KeyError:
-            print("Container Runtime not supported!")
+            print("No container runtime specified in config, proceeding with caution.")
+            self.tm_crt = None
+            crt_driver = None
         finally:
             if self.tm_crt == 'Charliecloud':
-                CrtDriver = CharliecloudDriver
+                crt_driver = CharliecloudDriver
             elif self.tm_crt == 'Singularity':
-                CrtDriver = SingularityDriver
-            self.crt = ContainerRuntimeInterface(CrtDriver)
+                crt_driver = SingularityDriver
+            self.crt = ContainerRuntimeInterface(crt_driver)
 
         # Get BEE workdir from config file
         self.workdir = kwargs['bee_workdir']
@@ -153,3 +155,6 @@ class SlurmWorker(Worker):
         else:
             job_state = "CANCELLED"
         return cancel_success, job_state
+
+# Ignore module imported but unused error. No way to know which crt will be needed
+# pylama:ignore=W0611

--- a/beeflow/common/worker/slurm_worker.py
+++ b/beeflow/common/worker/slurm_worker.py
@@ -12,96 +12,17 @@ import requests_unixsocket
 
 from beeflow.common.worker.worker import Worker
 from beeflow.common.crt.crt_interface import ContainerRuntimeInterface
-from beeflow.common.config.config_driver import BeeConfig
 
-# Check configuration file for container runtime.
-bc = BeeConfig()
-tm_crt = bc.userconfig['task_manager'].get('container_runtime')
-if tm_crt == 'Charliecloud':
-    from beeflow.common.crt.crt_drivers import CharliecloudDriver as CrtDriver
-elif tm_crt == 'Singularity':
-    from beeflow.common.crt.crt_drivers import SingularityDriver as CrtDriver
-else:
-    print("Container Runtime not supported!")
-
-
-def build_text(task, template_file):
-    """Build text for task script use template if it exists."""
-    job_template = ''
-    try:
-        template_f = open(template_file, 'r')
-        job_template = template_f.read()
-        template_f.close()
-    except OSError:
-        print('\nNo job_template: creating a simple job template!')
-        job_template = '#! /bin/bash\n#SBATCH\n'
-    template = string.Template(job_template)
-    job_text = template.substitute({'name': task.name, 'id': task.id})
-    crt_text = crt.script_text(task)
-    job_text += crt_text
-    return job_text
-
-
-def write_script(task):
-    """Build task script; returns (1, filename) or (-1, error_message)."""
-    success = -1
-    if not crt.image_exists(task):
-        return success, "dockerImageId is not a valid image"
-    # for now using fixed directory for task manager scripts and write them out
-    # we may keep them in memory and only write for a debug or logging option
-    # make directory (now uses date, should be workflow name or id?)
-    workdir = bc.userconfig['DEFAULT'].get('bee_workdir')
-    os.makedirs(f'{workdir}/worker', exist_ok=True)
-    template_file = f'{workdir}/worker/job.template'
-    task_text = build_text(task, template_file)
-    task_script = f'{workdir}/worker/{task.name}.sh'
-    try:
-        script_f = open(task_script, 'w')
-        script_f.write(task_text)
-        script_f.close()
-        success = 1
-    except subprocess.CalledProcessError as error:
-        task_script = error.output.decode('utf-8')
-    return success, task_script
-
-
-def query_job(job_id, session, slurm_url):
-    """Query slurm for job status."""
-    resp = session.get(f'{slurm_url}/job/{job_id}')
-    if resp.status_code != 200:
-        query_success = -1
-        job_state = f'Unable to query job id {job_id}.'
-    else:
-        status = json.loads(resp.text)
-        job_state = status['job_state']
-        query_success = 1
-    return query_success, job_state
-
-
-def cancel_job(job_id, session, slurm_url):
-    """Cancel slurm job and reports status."""
-    cancel_success = 1
-    resp = session.delete(f'{slurm_url}/job/{job_id}')
-    if resp.status_code != 200:
-        cancel_success = -1
-        job_state = f"Unable to cancel job id {job_id}."
-    else:
-        job_state = "CANCELLED"
-    return cancel_success, job_state
-
-
-def submit_job(script, session, slurm_url):
-    """Worker submits job-returns (job_id, job_state), or (-1, error)."""
-    job_id = -1
-    try:
-        job_st = subprocess.check_output(['sbatch', '--parsable', script],
-                                         stderr=subprocess.STDOUT)
-        job_id = int(job_st)
-    except subprocess.CalledProcessError as error:
-        job_status = error.output.decode('utf-8')
-        print(f'job_status is {job_status}')
-    _, job_state = query_job(job_id, session, slurm_url)
-    return job_id, job_state
+# Import all implemented container runtime drivers now
+# No error if they don't exist
+try:
+    from beeflow.common.crt.crt_drivers import CharliecloudDriver
+except ModuleNotFoundError:
+    pass
+try:
+    from beeflow.common.crt.crt_drivers import SingularityDriver
+except ModuleNotFoundError:
+    pass
 
 
 class SlurmWorker(Worker):
@@ -109,18 +30,109 @@ class SlurmWorker(Worker):
 
     def __init__(self, **kwargs):
         """Create a new Slurm Worker object."""
+        # Pull slurm socket configs from kwargs
         self.slurm_socket = kwargs.get('slurm_socket', f'/tmp/slurm_{os.getlogin()}.sock')
         self.session = requests_unixsocket.Session()
         encoded_path = urllib.parse.quote(self.slurm_socket, safe="")
         # Note: Socket path is encoded, http request is not generally.
         self.slurm_url = f"http+unix://{encoded_path}/slurm/v0.0.35"
 
+        # Load appropriate container runtime driver, based on configs in kwargs
+        try:
+            self.tm_crt = kwargs['container_runtime']
+        except KeyError:
+            print("Container Runtime not supported!")
+        finally:
+            if self.tm_crt == 'Charliecloud':
+                CrtDriver = CharliecloudDriver
+            elif self.tm_crt == 'Singularity':
+                CrtDriver = SingularityDriver
+            self.crt = ContainerRuntimeInterface(CrtDriver)
+
+        # Get BEE workdir from config file
+        self.workdir = kwargs['bee_workdir']
+
+    def build_text(self, task, template_file):
+        """Build text for task script use template if it exists."""
+        job_template = ''
+        try:
+            template_f = open(template_file, 'r')
+            job_template = template_f.read()
+            template_f.close()
+        except OSError:
+            print('\nNo job_template: creating a simple job template!')
+            job_template = '#! /bin/bash\n#SBATCH\n'
+        template = string.Template(job_template)
+        job_text = template.substitute({'name': task.name, 'id': task.id})
+        crt_text = self.crt.script_text(task)
+        job_text += crt_text
+        return job_text
+
+    def write_script(self, task):
+        """Build task script; returns (1, filename) or (-1, error_message)."""
+        success = -1
+        if not self.crt.image_exists(task):
+            return success, "dockerImageId is not a valid image"
+        # for now using fixed directory for task manager scripts and write them out
+        # we may keep them in memory and only write for a debug or logging option
+        # make directory (now uses date, should be workflow name or id?)
+        os.makedirs(f'{self.workdir}/worker', exist_ok=True)
+        template_file = f'{self.workdir}/worker/job.template'
+        task_text = self.build_text(task, template_file)
+        task_script = f'{self.workdir}/worker/{task.name}.sh'
+        try:
+            script_f = open(task_script, 'w')
+            script_f.write(task_text)
+            script_f.close()
+            success = 1
+        except subprocess.CalledProcessError as error:
+            task_script = error.output.decode('utf-8')
+        return success, task_script
+
+    @staticmethod
+    def query_job(job_id, session, slurm_url):
+        """Query slurm for job status."""
+        resp = session.get(f'{slurm_url}/job/{job_id}')
+        if resp.status_code != 200:
+            query_success = -1
+            job_state = f'Unable to query job id {job_id}.'
+        else:
+            status = json.loads(resp.text)
+            job_state = status['job_state']
+            query_success = 1
+        return query_success, job_state
+
+    @staticmethod
+    def cancel_job(job_id, session, slurm_url):
+        """Cancel slurm job and reports status."""
+        cancel_success = 1
+        resp = session.delete(f'{slurm_url}/job/{job_id}')
+        if resp.status_code != 200:
+            cancel_success = -1
+            job_state = f"Unable to cancel job id {job_id}."
+        else:
+            job_state = "CANCELLED"
+        return cancel_success, job_state
+
+    def submit_job(self, script, session, slurm_url):
+        """Worker submits job-returns (job_id, job_state), or (-1, error)."""
+        job_id = -1
+        try:
+            job_st = subprocess.check_output(['sbatch', '--parsable', script],
+                                             stderr=subprocess.STDOUT)
+            job_id = int(job_st)
+        except subprocess.CalledProcessError as error:
+            job_status = error.output.decode('utf-8')
+            print(f'job_status is {job_status}')
+        _, job_state = self.query_job(job_id, session, slurm_url)
+        return job_id, job_state
+
     def submit_task(self, task):
         """Worker builds & submits script."""
-        build_success, task_script = write_script(task)
+        build_success, task_script = self.write_script(task)
         if build_success:
-            job_id, job_state = submit_job(task_script,
-                                           self.session, self.slurm_url)
+            job_id, job_state = self.submit_job(task_script,
+                                                self.session, self.slurm_url)
         else:
             job_id = build_success
             job_state = task_script
@@ -128,7 +140,7 @@ class SlurmWorker(Worker):
 
     def query_task(self, job_id):
         """Worker queries job; returns (1, job_state), or (-1, error_msg)."""
-        query_success, job_state = query_job(job_id, self.session, self.slurm_url)
+        query_success, job_state = self.query_job(job_id, self.session, self.slurm_url)
         return query_success, job_state
 
     def cancel_task(self, job_id):
@@ -141,6 +153,3 @@ class SlurmWorker(Worker):
         else:
             job_state = "CANCELLED"
         return cancel_success, job_state
-
-
-crt = ContainerRuntimeInterface(CrtDriver)

--- a/bin/BEEStart
+++ b/bin/BEEStart
@@ -247,6 +247,7 @@ def StartTaskManager(bc, args):
             offset = os.getuid()%100
         tm_dict = {
             'listen_port': 5050 + offset,
+            'container_runtime': 'Charliecloud'
         }
         # Add section (writes to config file)
         bc.modify_section('user','task_manager',tm_dict)


### PR DESCRIPTION
* Addressing various Pylama related errors, and apologies for the seemingly random nature of some of these pylama changes. 
* Made SlurmWorker a class definition that stands alone and does not interfere with global python namespace. I may be totally off here, but a recurrent theme I see in our code is the movement of class methods to global functions. I believe this could be a consequence of the pylama message that says "method could be a function", but a better message would be "method should be static or if not it could be a function". I changed SlurmWorker as an example on how we could do this for other class defs. If I'm not mistaken, task_manager may need similar treatment eventually.
* Harvest SlurmWorker params from kwargs, which are passed down through the task_manager after it reads the BeeConfig file. Removes extraneous config file read in SlurmWorker.