### PR TITLE
Build/issue234

### DIFF
--- a/beeflow/common/build/README.md
+++ b/beeflow/common/build/README.md
@@ -41,7 +41,7 @@ Each step in a workflow may include a reference to `DockerRequirement` in the CW
 6. `dockerOutputDirectory:` Set the designated output directory to a specific location inside the Docker container.
 
 
-A few example to use for testing:
+A few examples to use for testing:
 
 ### dockerPull
 ```
@@ -55,8 +55,17 @@ task = BuildTask(name='hi',command=['hi','hello'],
 a = CharliecloudBuildDriver(task)
 a.dockerPull()
 a.dockerPull('git.lanl.gov:5050/trandles/baseimages/centos:7')
+
 task = BuildTask(name='hi',command=['hi','hello'],
                  requirements={},
+                 subworkflow=None,
+                 inputs={},
+                 outputs={})
+a = CharliecloudBuildDriver(task)
+a.dockerPull()
+a.dockerPull('git.lanl.gov:5050/qwofford/containerhub/lstopo')
+
+task = BuildTask(name='hi',command=['hi','hello'],
                  subworkflow=None,
                  inputs={},
                  outputs={})

--- a/beeflow/common/build/README.md
+++ b/beeflow/common/build/README.md
@@ -72,4 +72,5 @@ task = BuildTask(name='hi',command=['hi','hello'],
 a = CharliecloudBuildDriver(task)
 a.dockerPull()
 a.dockerPull('git.lanl.gov:5050/qwofford/containerhub/lstopo')
+a.dockerPull('git.lanl.gov:5050/qwofford/containerhub/lstopo',force=True)
 ```

--- a/beeflow/common/build/container_drivers.py
+++ b/beeflow/common/build/container_drivers.py
@@ -91,24 +91,54 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         """
         print('Charliecloud, validate_build:', self, '.')
 
-    def dockerPull(self, addr=None):
+    def dockerPull(self, addr=None, force=False):
         """CWL compliant dockerPull.
 
         CWL spec 09-23-2020: Specify a Docker image to
         retrieve using docker pull. Can contain the immutable
         digest to ensure an exact container is used.
         """
+        # By default, tasks need not specify hints or reqs
+        task_addr = None
         try:
-            task_addr = self.task.requirements['DockerRequirement']['dockerPull']
-            if addr:
-                print(f"Forcing pull of arg {addr} over Task defined pull {task_addr}")
-            else:
-                addr = task_addr
+            # Try to get Hints
+            hint_addr = self.task.hints['DockerRequirement']['dockerPull']
         except KeyError:
-            if not addr:
-                print("Task and args do not specify image target. Nothing to do.")
-                return 1
+            # Task Hints are not mandatory. No dockerPull image specified in task hints.
+            hint_addr = None
+        try:
+            # Try to get Requirements
+            req_addr = self.task.requirements['DockerRequirement']['dockerPull']
+        except KeyError:
+            # Task Requirements are not mandatory. No dockerPull image specified in task reqs.
+            req_addr = None
+
+        # Prefer requirements over hints
+        if (req_addr or hint_addr) and (not hint_addr):
+            task_addr = req_addr
+        elif hint_addr:
+            task_addr = hint_addr
+
+        # Use task specified image if image parameter empty
+        if not addr:
+            addr = task_addr
+
+        # If we still don't have an addr, exit with success determined by dockerPull entry
+        if req_addr and not addr:
+            print("ERROR: dockerPull set but no image path specified.")
+            return 1
+        elif req_addr not {}:
+            # If no image specified and no image required, nothing to do.
+            return 0
+
+        # Determine name for successful build target
         ch_build_addr = addr.replace('/', '%')
+
+        # Return if image already exist and force==False.
+        if os.path.exists('/'.join([self.build_dir, ch_build_addr])) and not force:
+            return 0
+
+        # Provably out of excuses. Pull the image.
         cmd = (f'ch-grow pull {addr}\n'
                f'ch-builder2tar {ch_build_addr} {self.build_dir}'
                )

--- a/beeflow/common/build/container_drivers.py
+++ b/beeflow/common/build/container_drivers.py
@@ -123,12 +123,12 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         if not addr:
             addr = task_addr
 
-        # If we still don't have an addr, exit with success determined by dockerPull entry
-        if req_addr and not addr:
+        # If Requirement is set but not specified, and param empty, do nothing and error.
+        if req_addr == {} and not addr:
             print("ERROR: dockerPull set but no image path specified.")
             return 1
-        elif req_addr not {}:
-            # If no image specified and no image required, nothing to do.
+        # If no image specified and no image required, nothing to do.
+        if not req_addr and not addr:
             return 0
 
         # Determine name for successful build target


### PR DESCRIPTION
Extending dockerPull to support CWL hint and requirements, plus a force parameter that will over-write everything.

I also added a subtle feature on requirements. If you set a requirement equal to "{}", then dockerPull will fail if an image name is not provided in some other way. Right now, the way to do that is to specify the "addr" parameter.