### PR TITLE
Fix slurmrestd issue

### DIFF
--- a/beeflow/common/worker/slurm_worker.py
+++ b/beeflow/common/worker/slurm_worker.py
@@ -9,6 +9,7 @@ import subprocess
 import json
 import urllib
 import requests_unixsocket
+import requests
 
 from beeflow.common.worker.worker import Worker
 from beeflow.common.crt.crt_interface import ContainerRuntimeInterface
@@ -86,12 +87,16 @@ class SlurmWorker(Worker):
     @staticmethod
     def query_job(job_id, session, slurm_url):
         """Query slurm for job status."""
-        resp = session.get(f'{slurm_url}/job/{job_id}')
-        if resp.status_code != 200:
-            raise Exception (f'Unable to query job id {job_id}.')
-        else:
-            status = json.loads(resp.text)
-            job_state = status['job_state']
+        try:
+            resp = session.get(f'{slurm_url}/job/{job_id}')
+
+            if resp.status_code != 200:
+                job_state = f"BAD RESPONSE {resp.status_code}"
+            else:
+                status = json.loads(resp.text)
+                job_state = status['job_state']
+        except requests.exceptions.ConnectionError:
+            job_state = "NOT RESPONDING"
         return job_state
 
     def submit_job(self, script, session, slurm_url):

--- a/beeflow/common/worker/slurm_worker.py
+++ b/beeflow/common/worker/slurm_worker.py
@@ -91,12 +91,12 @@ class SlurmWorker(Worker):
             resp = session.get(f'{slurm_url}/job/{job_id}')
 
             if resp.status_code != 200:
-                job_state = f"BAD RESPONSE {resp.status_code}"
+                job_state = f"BAD_RESPONSE_{resp.status_code}"
             else:
                 status = json.loads(resp.text)
                 job_state = status['job_state']
         except requests.exceptions.ConnectionError:
-            job_state = "NOT RESPONDING"
+            job_state = "NOT_RESPONDING"
         return job_state
 
     def submit_job(self, script, session, slurm_url):

--- a/beeflow/task_manager/task_manager.py
+++ b/beeflow/task_manager/task_manager.py
@@ -143,11 +143,8 @@ def update_jobs():
         task_id = list(job)[0]
         current_task = job[task_id]
         job_id = current_task['job_id']
-        try:
-            job_state = worker.query_task(job_id)
-        except Exception as error:
-            print(f'Cannot query state of {job_id}\n {error}')
-            job_state = 'ZOMBIE'
+        job_state = worker.query_task(job_id)
+
         if job_state != current_task['job_state']:
             print(f'{current_task["name"]} {current_task["job_state"]} -> {job_state}')
             current_task['job_state'] = job_state


### PR DESCRIPTION
This PR fixes an issue with slurmrestd not responding to queries. It adds a `NOT RESPONDING` state to alert users when this occurs and continues to retry since it normally works the 2nd or 3rd time. It also temporarily removes the `ZOMBIE` state until we can come up with a better model on how that might occur. 