### PR TITLE
Fix paths in cli.py and make Tensorflow optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,13 @@ pylint = { version = ">=2.3.1" }
 APScheduler = "^3.6.3"
 jsonpickle = "^1.3"
 requests-unixsocket = "^0.2.0"
-tensorflow = "^2.3.0"
-matplotlib = "^3.3.1"
+
+# Scheduler optional dependencies
+tensorflow = { version = "^2.3.0", optional = true }
+matplotlib = { version = "^3.3.1", optional = true }
+
+[tool.poetry.extras]
+scheduler_extras = ["tensorflow", "matplotlib"]
 
 [tool.poetry.dev-dependencies]
 # Developer dependencies

--- a/src/beeflow/cli.py
+++ b/src/beeflow/cli.py
@@ -206,7 +206,7 @@ def StartWorkflowManager(bc, args):
         userconfig_file = args.userconfig_file
     else:
         userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
-    return subprocess.Popen(["python", 'beeflow/wf_manager.py',
+    return subprocess.Popen(["python", "-m", "beeflow.wf_manager",
                             userconfig_file],
                             stdout=PIPE, stderr=PIPE)
 
@@ -237,7 +237,7 @@ def StartTaskManager(bc, args):
         userconfig_file = args.userconfig_file
     else:
         userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
-    return subprocess.Popen(["python", 'beeflow/task_manager.py',
+    return subprocess.Popen(["python", "-m", "beeflow.task_manager",
                             userconfig_file],
                             stdout=PIPE, stderr=PIPE)
 
@@ -265,7 +265,7 @@ def StartScheduler(bc, args):
         userconfig_file = args.userconfig_file
     else:
         userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
-    return subprocess.Popen(['python', 'beeflow/scheduler/scheduler.py',
+    return subprocess.Popen(["python", "-m", "beeflow.scheduler.scheduler",
                             '--config-file',userconfig_file],
                             stdout=PIPE, stderr=PIPE)
 

--- a/src/beeflow/tests/test_scheduler_rest.py
+++ b/src/beeflow/tests/test_scheduler_rest.py
@@ -20,7 +20,7 @@ def scheduler():
     """
     # Setup
     proc = subprocess.Popen([
-        'python', 'beeflow/scheduler/scheduler.py',
+        'python', '-m', 'beeflow.scheduler.scheduler',
         '-p', SCHEDULER_TEST_PORT,
         '--no-config',
         '--log', '/tmp/sched.log',

--- a/src/beeflow/tests/test_wf_manager.py
+++ b/src/beeflow/tests/test_wf_manager.py
@@ -36,7 +36,7 @@ def test_submit_workflow(flask_client, mocker): # noqa
 
     wf_id = 42
 
-    files = {'workflow': open('beeflow/data/cwl/cf.cwl', 'rb')}
+    files = {'workflow': open('src/beeflow/data/cwl/cf.cwl', 'rb')}
     response = flask_client.put('/bee_wfm/v1/jobs/submit/' + str(wf_id),
                                 data=files)
 


### PR DESCRIPTION
I've modified the cli.py script to launch the Task Manager, Workflow Manager and Scheduler using the module option. This addresses [Issue #275](https://github.com/lanl/BEE_Private/issues/275) and should allow us to launch BEE from any location.

Also, I went ahead and made Tensorflow and matplotlib optional. You should be able to install them by running `poetry install -E scheduler_extras`