### PR TITLE
Build/issue281: Build logging + Charliecloud syntax updates

### DIFF
--- a/src/beeflow/common/build/README.md
+++ b/src/beeflow/common/build/README.md
@@ -46,7 +46,7 @@ A few examples to use for testing:
 ### dockerPull
 ```
 from beeflow.common.build.container_drivers import CharliecloudBuildDriver
-from beeflow.common.data.wf_data import BuildTask
+from beeflow.common.wf_data import BuildTask
 task = BuildTask(name='hi',command=['hi','hello'],
                  requirements={'DockerRequirement':{'dockerPull':'git.lanl.gov:5050/qwofford/containerhub/lstopo'}},
                  subworkflow=None,
@@ -77,7 +77,7 @@ a.dockerPull('git.lanl.gov:5050/qwofford/containerhub/lstopo',force=True)
 ### dockerFile
 ```
 from beeflow.common.build.container_drivers import CharliecloudBuildDriver
-from beeflow.common.data.wf_data import BuildTask
+from beeflow.common.wf_data import BuildTask
 task = BuildTask(name='hi',command=['hi','hello'],
                  requirements={'DockerRequirement':{'dockerFile':'FROM git.lanl.gov:5050/trandles/baseimages/centos:7\nCMD cat /etc/centos-release',
                                                     'dockerImageId':'my_fun_container:sillytag'}},
@@ -90,7 +90,7 @@ b.dockerFile()
 ### dockerImport
 ```
 from beeflow.common.build.container_drivers import CharliecloudBuildDriver
-from beeflow.common.data.wf_data import BuildTask
+from beeflow.common.wf_data import BuildTask
 task = BuildTask(name='hi',command=['hi','hello'],
                  requirements={},
                  subworkflow=None,
@@ -126,7 +126,7 @@ a.dockerImport()
 ### dockerOutputDirectory
 ```
 from beeflow.common.build.container_drivers import CharliecloudBuildDriver
-from beeflow.common.data.wf_data import BuildTask
+from beeflow.common.wf_data import BuildTask
 task = BuildTask(name='hi',command=['hi','hello'],
                  hints={'DockerRequirement':{'dockerImport':'/usr/projects/beedev/neo4j-3-5-17-ch.tar.gz'}},
                  subworkflow=None,
@@ -147,7 +147,7 @@ a.dockerOutputDirectory()
 ### dockerLoad
 ```
 from beeflow.common.build.container_drivers import CharliecloudBuildDriver
-from beeflow.common.data.wf_data import BuildTask
+from beeflow.common.wf_data import BuildTask
 task = BuildTask(name='hi',command=['hi','hello'],
                  hints={'DockerRequirement':{'dockerLoad':'bogus path'}},
                  subworkflow=None,
@@ -173,7 +173,7 @@ a.dockerLoad()
 ### dockerImageId
 ```
 from beeflow.common.build.container_drivers import CharliecloudBuildDriver
-from beeflow.common.data.wf_data import BuildTask
+from beeflow.common.wf_data import BuildTask
 task = BuildTask(name='hi',command=['hi','hello'],
                  hints={'DockerRequirement':{'dockerImageId':'my_imageid'}},
                  subworkflow=None,

--- a/src/beeflow/common/build/container_drivers.py
+++ b/src/beeflow/common/build/container_drivers.py
@@ -181,6 +181,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
             return 1
         # If no image specified and no image required, nothing to do.
         if not req_addr and not addr:
+            log.info('No image specified and no image required, nothing to do.')
             return 0
 
         # DetermVine name for successful build target

--- a/src/beeflow/common/build/container_drivers.py
+++ b/src/beeflow/common/build/container_drivers.py
@@ -190,6 +190,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         ch_build_target = '/'.join([self.build_dir, ch_build_addr]) + '.tar.gz'
         # Return if image already exist and force==False.
         if os.path.exists(ch_build_target) and not force:
+            log.info('Image already exists. If you want to refresh container, use force option.')
             return 0
         # Force remove any cached images if force==True
         if os.path.exists(ch_build_target) and force:

--- a/src/beeflow/common/build/container_drivers.py
+++ b/src/beeflow/common/build/container_drivers.py
@@ -8,7 +8,7 @@ import os
 import tempfile
 import shutil
 import subprocess
-from beeflow.common.config.config_driver import BeeConfig
+from beeflow.common.config_driver import BeeConfig
 # from beeflow.common.crt.crt_drivers import CharliecloudDriver, SingularityDriver
 from beeflow.cli import log
 import beeflow.common.log as bee_logging
@@ -63,7 +63,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         finally:
             self.build_dir = bc.resolve_path(build_dir)
             os.makedirs(self.build_dir, exist_ok=True)
-            log.info('Build cache directory is:', self.build_dir)
+            log.info(f'Build cache directory is: {self.build_dir}')
         # Deploy build tarballs relative to /var/tmp/username/beeflow by default
         try:
             if bc.userconfig['builder'].get('deployed_image_root'):
@@ -93,7 +93,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         finally:
             self.deployed_image_root = deployed_image_root
             os.makedirs(self.deployed_image_root, exist_ok=True)
-            log.info('Deployed image root directory is:', self.deployed_image_root)
+            log.info(f'Deployed image root directory is: {self.deployed_image_root}')
         # Set container-relative output directory based on BeeConfig, or use '/'
         try:
             container_output_path = bc.userconfig['builder'].get('container_output_path')
@@ -108,7 +108,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
             log.info('Wrote container-relative output path to user BeeConfig file.')
         finally:
             self.container_output_path = container_output_path
-            log.info('Container-relative output path is:', self.container_output_path)
+            log.info(f'Container-relative output path is: {self.container_output_path}')
         self.task = task
         self.docker_image_id = None
 

--- a/src/beeflow/common/build/container_drivers.py
+++ b/src/beeflow/common/build/container_drivers.py
@@ -199,12 +199,12 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
             except FileNotFoundError:
                 pass
             try:
-                shutil.rmtree('/var/tmp/'+os.getlogin()+'/ch-grow/'+ch_build_addr)
+                shutil.rmtree('/var/tmp/'+os.getlogin()+'/ch-image/'+ch_build_addr)
             except FileNotFoundError:
                 pass
 
         # Provably out of excuses. Pull the image.
-        cmd = (f'ch-grow pull {addr}\n'
+        cmd = (f'ch-image pull {addr}\n'
                f'ch-builder2tar {ch_build_addr} {self.build_dir}'
                )
         return subprocess.run(cmd, capture_output=True, check=True, shell=True)
@@ -305,12 +305,12 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
             except FileNotFoundError:
                 pass
             try:
-                shutil.rmtree('/var/tmp/'+os.getlogin()+'/ch-grow/'+ch_build_addr)
+                shutil.rmtree('/var/tmp/'+os.getlogin()+'/ch-image/'+ch_build_addr)
             except FileNotFoundError:
                 pass
 
         # Provably out of excuses. Pull the image.
-        cmd = (f'ch-grow build -t {task_imageid} -f {tmp_dockerfile} {tmp_dir}\n'
+        cmd = (f'ch-image build -t {task_imageid} -f {tmp_dockerfile} {tmp_dir}\n'
                f'ch-builder2tar {ch_build_addr} {self.build_dir}'
                )
         return subprocess.run(cmd, capture_output=True, check=True, shell=True)

--- a/src/beeflow/common/build/container_drivers.py
+++ b/src/beeflow/common/build/container_drivers.py
@@ -191,6 +191,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         # Return if image already exist and force==False.
         if os.path.exists(ch_build_target) and not force:
             log.info('Image already exists. If you want to refresh container, use force option.')
+            log.info(f'Image path: {ch_build_target}')
             return 0
         # Force remove any cached images if force==True
         if os.path.exists(ch_build_target) and force:


### PR DESCRIPTION
Primarily addresses #281, and changes ch-grow to ch-image. Eventually we will need a similar issue when Charliecloud changes `ch-x2y` commands to `ch-convert`, but we can cross that bridge when we get there.

Adds a little more info logging which made troubleshooting container cache a little more straightforward.

Finally, PR #290 is incorporated in these changes as well, so closing that PR unmerged.