### PR TITLE
Reset Workflow ID

### DIFF
--- a/src/beeflow/common/gdb/gdb_driver.py
+++ b/src/beeflow/common/gdb/gdb_driver.py
@@ -40,11 +40,11 @@ class GraphDatabaseDriver(ABC):
         """
 
     @abstractmethod
-    def reset_workflow(self):
+    def reset_workflow(self, new_id):
         """Reset the execution state of a workflow.
 
         Set all task states to 'WAITING'.
-        Change the workflow ID of the Workflow and Task nodes using uuid4.
+        Change the workflow ID of the Workflow and Task nodes with new_id.
         """
 
     @abstractmethod

--- a/src/beeflow/common/gdb/gdb_driver.py
+++ b/src/beeflow/common/gdb/gdb_driver.py
@@ -41,9 +41,10 @@ class GraphDatabaseDriver(ABC):
 
     @abstractmethod
     def reset_workflow(self):
-        """Reset the execution state of an entire workflow.
+        """Reset the execution state of a workflow.
 
         Set all task states to 'WAITING'.
+        Change the workflow ID of the Workflow and Task nodes using uuid4.
         """
 
     @abstractmethod

--- a/src/beeflow/common/gdb/gdb_driver.py
+++ b/src/beeflow/common/gdb/gdb_driver.py
@@ -45,6 +45,9 @@ class GraphDatabaseDriver(ABC):
 
         Set all task states to 'WAITING'.
         Change the workflow ID of the Workflow and Task nodes with new_id.
+
+        :param new_id: the new workflow ID
+        :type new_id: str
         """
 
     @abstractmethod

--- a/src/beeflow/common/gdb/neo4j_cypher.py
+++ b/src/beeflow/common/gdb/neo4j_cypher.py
@@ -1,5 +1,4 @@
 """Neo4j/Cypher transaction functions used by the Neo4jDriver class."""
-from uuid import uuid4
 
 
 def constrain_workflow_unique(tx):
@@ -341,13 +340,13 @@ def reset_tasks_metadata(tx):
     tx.run(reset_metadata_query)
 
 
-def reset_workflow_id(tx):
+def reset_workflow_id(tx, new_id):
     """Reset the workflow ID of the workflow using uuid4."""
     reset_workflow_id_query = ("MATCH (w:Workflow), (t:Task) "
                                "SET w.workflow_id = $new_id "
                                "SET t.workflow_id = $new_id")
 
-    tx.run(reset_workflow_id_query, new_id=str(uuid4()))
+    tx.run(reset_workflow_id_query, new_id=new_id)
 
 
 def all_tasks_completed(tx):

--- a/src/beeflow/common/gdb/neo4j_cypher.py
+++ b/src/beeflow/common/gdb/neo4j_cypher.py
@@ -341,7 +341,11 @@ def reset_tasks_metadata(tx):
 
 
 def reset_workflow_id(tx, new_id):
-    """Reset the workflow ID of the workflow using uuid4."""
+    """Reset the workflow ID of the workflow using uuid4.
+
+    :param new_id: the new workflow ID
+    :type new_id: str
+    """
     reset_workflow_id_query = ("MATCH (w:Workflow), (t:Task) "
                                "SET w.workflow_id = $new_id "
                                "SET t.workflow_id = $new_id")

--- a/src/beeflow/common/gdb/neo4j_cypher.py
+++ b/src/beeflow/common/gdb/neo4j_cypher.py
@@ -1,4 +1,5 @@
 """Neo4j/Cypher transaction functions used by the Neo4jDriver class."""
+from uuid import uuid4
 
 
 def constrain_workflow_unique(tx):
@@ -338,6 +339,15 @@ def reset_tasks_metadata(tx):
                             "CREATE (:Metadata {state: 'WAITING'})-[:DESCRIBES]->(t)")
 
     tx.run(reset_metadata_query)
+
+
+def reset_workflow_id(tx):
+    """Reset the workflow ID of the workflow using uuid4."""
+    reset_workflow_id_query = ("MATCH (w:Workflow), (t:Task) "
+                               "SET w.workflow_id = $new_id "
+                               "SET t.workflow_id = $new_id")
+
+    tx.run(reset_workflow_id_query, new_id=str(uuid4()))
 
 
 def all_tasks_completed(tx):

--- a/src/beeflow/common/gdb/neo4j_driver.py
+++ b/src/beeflow/common/gdb/neo4j_driver.py
@@ -82,15 +82,15 @@ class Neo4jDriver(GraphDatabaseDriver):
         """
         self._write_transaction(tx.set_paused_tasks_to_running)
 
-    def reset_workflow(self):
+    def reset_workflow(self, new_id):
         """Reset the execution state of an entire workflow.
 
         Sets all task states to 'WAITING'.
-        Changes the workflow ID of the Workflow and Task nodes using uuid4.
+        Changes the workflow ID of the Workflow and Task nodes with new_id.
         """
         with self._driver.session() as session:
             session.write_transaction(tx.reset_tasks_metadata)
-            session.write_transaction(tx.reset_workflow_id)
+            session.write_transaction(tx.reset_workflow_id, new_id=new_id)
 
     def load_task(self, workflow, task):
         """Load a task into a workflow stored in the Neo4j database.

--- a/src/beeflow/common/gdb/neo4j_driver.py
+++ b/src/beeflow/common/gdb/neo4j_driver.py
@@ -87,6 +87,9 @@ class Neo4jDriver(GraphDatabaseDriver):
 
         Sets all task states to 'WAITING'.
         Changes the workflow ID of the Workflow and Task nodes with new_id.
+
+        :param new_id: the new workflow ID
+        :type new_id: str
         """
         with self._driver.session() as session:
             session.write_transaction(tx.reset_tasks_metadata)

--- a/src/beeflow/common/gdb/neo4j_driver.py
+++ b/src/beeflow/common/gdb/neo4j_driver.py
@@ -71,23 +71,26 @@ class Neo4jDriver(GraphDatabaseDriver):
     def pause_workflow(self):
         """Pause execution of a running workflow in Neo4j.
 
-        Set tasks with state 'RUNNING' to 'PAUSED'.
+        Sets tasks with state 'RUNNING' to 'PAUSED'.
         """
         self._write_transaction(tx.set_running_tasks_to_paused)
 
     def resume_workflow(self):
         """Resume execution of a paused workflow in Neo4j.
 
-        Set tasks with state 'PAUSED' to 'RUNNING'.
+        Sets tasks with state 'PAUSED' to 'RUNNING'.
         """
         self._write_transaction(tx.set_paused_tasks_to_running)
 
     def reset_workflow(self):
         """Reset the execution state of an entire workflow.
 
-        Set all task states to 'WAITING'.
+        Sets all task states to 'WAITING'.
+        Changes the workflow ID of the Workflow and Task nodes using uuid4.
         """
-        self._write_transaction(tx.reset_tasks_metadata)
+        with self._driver.session() as session:
+            session.write_transaction(tx.reset_tasks_metadata)
+            session.write_transaction(tx.reset_workflow_id)
 
     def load_task(self, workflow, task):
         """Load a task into a workflow stored in the Neo4j database.

--- a/src/beeflow/common/gdb_interface.py
+++ b/src/beeflow/common/gdb_interface.py
@@ -62,7 +62,7 @@ class GraphDatabaseInterface:
         self._connection.resume_workflow()
 
     def reset_workflow(self):
-        """Reset the execution state of an entire workflow."""
+        """Reset the execution state and ID of a workflow."""
         self._connection.reset_workflow()
 
     def load_task(self, workflow, task):

--- a/src/beeflow/common/gdb_interface.py
+++ b/src/beeflow/common/gdb_interface.py
@@ -62,7 +62,11 @@ class GraphDatabaseInterface:
         self._connection.resume_workflow()
 
     def reset_workflow(self, new_id):
-        """Reset the execution state and ID of a workflow."""
+        """Reset the execution state and ID of a workflow.
+
+        :param new_id: the new workflow ID
+        :type new_id: str
+        """
         self._connection.reset_workflow(new_id)
 
     def load_task(self, workflow, task):

--- a/src/beeflow/common/gdb_interface.py
+++ b/src/beeflow/common/gdb_interface.py
@@ -61,9 +61,9 @@ class GraphDatabaseInterface:
         """Resume execution of a running workflow."""
         self._connection.resume_workflow()
 
-    def reset_workflow(self):
+    def reset_workflow(self, new_id):
         """Reset the execution state and ID of a workflow."""
-        self._connection.reset_workflow()
+        self._connection.reset_workflow(new_id)
 
     def load_task(self, workflow, task):
         """Load a task into a workflow in the graph database.

--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -60,7 +60,7 @@ class WorkflowInterface:
         self._gdb_interface.resume_workflow()
 
     def reset_workflow(self):
-        """Reset the execution state of an entire BEE workflow."""
+        """Reset the execution state and ID of a BEE workflow."""
         self._gdb_interface.reset_workflow()
 
     def finalize_workflow(self):

--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -3,6 +3,7 @@
 Delegates its work to a GraphDatabaseInterface instance.
 """
 
+from uuid import uuid4
 from beeflow.common.gdb_interface import GraphDatabaseInterface
 from beeflow.common.wf_data import Workflow, Task, Requirement, Hint
 
@@ -61,7 +62,7 @@ class WorkflowInterface:
 
     def reset_workflow(self):
         """Reset the execution state and ID of a BEE workflow."""
-        self._gdb_interface.reset_workflow()
+        self._gdb_interface.reset_workflow(str(uuid4()))
 
     def finalize_workflow(self):
         """Deconstruct a BEE workflow."""

--- a/src/beeflow/tests/test_wf_interface.py
+++ b/src/beeflow/tests/test_wf_interface.py
@@ -102,6 +102,14 @@ class TestWorkflowInterface(unittest.TestCase):
             self.assertDictEqual(empty_metadata, self.wfi.get_task_metadata(task, metadata.keys()))
             self.assertEqual("WAITING", self.wfi.get_task_state(task))
 
+        # Workflow ID should be reset
+        (gdb_workflow, gdb_tasks) = self.wfi.get_workflow()
+        new_workflow_id = gdb_workflow.id
+
+        self.assertNotEqual(new_workflow_id, workflow.id)
+        for task in gdb_tasks:
+            self.assertEqual(task.workflow_id, new_workflow_id)
+
     def test_finalize_workflow(self):
         """Test workflow deletion from the graph database."""
         self.wfi.initialize_workflow({"input.txt"}, {"output.txt"})


### PR DESCRIPTION
`WorkflowInterface.reset_workflow()` now resets Workflow IDs using `uuid4()`.

New functions in `neo4j_cypher.py`:
- `reset_workflow_id()`

Comments updated in:
- `wf_interface.py`
- `gdb_interface.py`
- `gdb_driver.py`
- `neo4j_driver.py`

Tests updated in `test_wf_interface.py`:
- `test_reset_workflow()`