### PR TITLE
Catch unhandled exceptions

### DIFF
--- a/src/beeflow/cli.py
+++ b/src/beeflow/cli.py
@@ -213,6 +213,7 @@ def StartWorkflowManager(bc, args):
         userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
     return subprocess.Popen(["python", get_script_path() + "/wf_manager.py",
                             userconfig_file])
+    #, stdout=PIPE)
 
 def StartTaskManager(bc, args):
     """Start BEETaskManager. Returns a Popen process object."""
@@ -242,8 +243,7 @@ def StartTaskManager(bc, args):
     else:
         userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
     return subprocess.Popen(["python", get_script_path() + "/task_manager.py",
-                            userconfig_file])
-#                            stdout=PIPE, stderr=PIPE)
+                            userconfig_file], stdout=PIPE, stderr=PIPE)
 
 def StartScheduler(bc, args):
     """Start BEEScheduler.

--- a/src/beeflow/cli.py
+++ b/src/beeflow/cli.py
@@ -18,7 +18,7 @@ import sys
 import tempfile
 import time
 import platform
-from subprocess import PIPE
+from subprocess import PIPE, DEVNULL
 from configparser import NoOptionError
 import beeflow.common.log as bee_logging
 from beeflow.common.config_driver import BeeConfig
@@ -212,8 +212,7 @@ def StartWorkflowManager(bc, args):
     else:
         userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
     return subprocess.Popen(["python", get_script_path() + "/wf_manager.py",
-                            userconfig_file])
-    #, stdout=PIPE)
+                            userconfig_file], stdout=DEVNULL, stderr=DEVNULL)
 
 def StartTaskManager(bc, args):
     """Start BEETaskManager. Returns a Popen process object."""
@@ -243,7 +242,8 @@ def StartTaskManager(bc, args):
     else:
         userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
     return subprocess.Popen(["python", get_script_path() + "/task_manager.py",
-                            userconfig_file], stdout=PIPE, stderr=PIPE)
+                            userconfig_file], stdout=DEVNULL, stderr=DEVNULL)
+
 
 def StartScheduler(bc, args):
     """Start BEEScheduler.
@@ -270,7 +270,7 @@ def StartScheduler(bc, args):
     else:
         userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
     return subprocess.Popen(["python", get_script_path() + "/scheduler/scheduler.py",
-                            '--config-file',userconfig_file])
+                            '--config-file',userconfig_file], stdout=DEVNULL, stderr=DEVNULL)
 
 def StartBuild(args):
     """Start builder.

--- a/src/beeflow/cli.py
+++ b/src/beeflow/cli.py
@@ -270,8 +270,7 @@ def StartScheduler(bc, args):
     else:
         userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
     return subprocess.Popen(["python", get_script_path() + "/scheduler/scheduler.py",
-                            '--config-file',userconfig_file],
-                            stdout=PIPE, stderr=PIPE)
+                            '--config-file',userconfig_file])
 
 def StartBuild(args):
     """Start builder.

--- a/src/beeflow/cli.py
+++ b/src/beeflow/cli.py
@@ -27,6 +27,9 @@ log = bee_logging.setup_logging(level='DEBUG')
 restd_log = bee_logging.setup_logging(level='DEBUG') 
 gdb_log = bee_logging.setup_logging(level='DEBUG')
 
+def get_script_path():
+    return os.path.dirname(os.path.realpath(__file__))
+
 def StartGDB(bc, args):
     """Start the graph database. Returns a Popen process object."""
     bee_workdir = bc.userconfig.get('DEFAULT','bee_workdir')
@@ -208,9 +211,8 @@ def StartWorkflowManager(bc, args):
         userconfig_file = args.userconfig_file
     else:
         userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
-    return subprocess.Popen(["python", "-m", "beeflow.wf_manager",
-                            userconfig_file],
-                            stdout=PIPE, stderr=PIPE)
+    return subprocess.Popen(["python", get_script_path() + "/wf_manager.py",
+                            userconfig_file])
 
 def StartTaskManager(bc, args):
     """Start BEETaskManager. Returns a Popen process object."""
@@ -239,9 +241,9 @@ def StartTaskManager(bc, args):
         userconfig_file = args.userconfig_file
     else:
         userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
-    return subprocess.Popen(["python", "-m", "beeflow.task_manager",
-                            userconfig_file],
-                            stdout=PIPE, stderr=PIPE)
+    return subprocess.Popen(["python", get_script_path() + "/task_manager.py",
+                            userconfig_file])
+#                            stdout=PIPE, stderr=PIPE)
 
 def StartScheduler(bc, args):
     """Start BEEScheduler.
@@ -267,7 +269,7 @@ def StartScheduler(bc, args):
         userconfig_file = args.userconfig_file
     else:
         userconfig_file = os.path.expanduser('~/.config/beeflow/bee.conf')
-    return subprocess.Popen(["python", "-m", "beeflow.scheduler.scheduler",
+    return subprocess.Popen(["python", get_script_path() + "/scheduler/scheduler.py",
                             '--config-file',userconfig_file],
                             stdout=PIPE, stderr=PIPE)
 

--- a/src/beeflow/common/log.py
+++ b/src/beeflow/common/log.py
@@ -150,7 +150,6 @@ def save_log(bee_workdir, log, logfile):
     handler = logging.FileHandler(path)
     formatter = LogFormatter(colors=False)
 
-    # Set
     handler.setFormatter(formatter)
     log.addHandler(handler)
     __module_log__ = log
@@ -170,8 +169,10 @@ def catch_exception(type, value, traceback):
         bc = BeeConfig()
         bee_workdir = bc.userconfig.get('DEFAULT', 'bee_workdir')
         # Get the filename sans extension
-        filename = traceback.tb_frame.f_code.co_filename.rsplit('.', 1)[0]
+        path = traceback.tb_frame.f_code.co_filename
+        filename = path.split('/')[-1].rsplit('.', 1)[0]
         save_log(bee_workdir=bee_workdir, log=log, logfile=f'{filename}.log')
         log.critical("Uncaught exception", exc_info=(type, value, traceback))
     else:
+        print(f'__module_log__{__module_log__}')
         __module_log__.critical("Uncaught exception", exc_info=(type, value, traceback))

--- a/src/beeflow/scheduler/scheduler.py
+++ b/src/beeflow/scheduler/scheduler.py
@@ -24,7 +24,6 @@ api = Api(flask_app)
 # List of all available resources
 resources = []
 
-
 class ResourcesHandler(Resource):
     """Resources handler.
 

--- a/src/beeflow/scheduler/scheduler.py
+++ b/src/beeflow/scheduler/scheduler.py
@@ -16,6 +16,8 @@ from beeflow.common.config_driver import BeeConfig
 from beeflow.cli import log
 import beeflow.common.log as bee_logging
 
+sys.excepthook = bee_logging.catch_exception
+
 flask_app = Flask(__name__)
 api = Api(flask_app)
 
@@ -145,7 +147,7 @@ def load_config_values():
         bee_workdir = bc.userconfig['DEFAULT'].get('bee_workdir')
         # Set some defaults
         if not conf['log']:
-            conf['log'] = '/'.join([bee_workdir, 'logs', 'sched.log'])
+            conf['log'] = '/'.join([bee_workdir, 'logs', 'scheduler.log'])
         if not conf['workdir']:
             conf['workdir'] = os.path.join(bee_workdir, 'scheduler')
         if not conf['alloc_logfile']:
@@ -154,7 +156,7 @@ def load_config_values():
     else:
         # Don't read from the config
         if not conf['log']:
-            conf['log'] = 'sched.log'
+            conf['log'] = 'scheduler.log'
         if not conf['workdir']:
             conf['workdir'] = os.getcwd()
         if not conf['alloc_logfile']:
@@ -177,7 +179,7 @@ def load_config_values():
 if __name__ == '__main__':
     CONF, bc = load_config_values()
     bee_workdir = bc.userconfig.get('DEFAULT','bee_workdir')
-    handler = bee_logging.save_log(bee_workdir=bee_workdir, log=log, logfile='sched.log')
+    handler = bee_logging.save_log(bee_workdir=bee_workdir, log=log, logfile='scheduler.log')
     flask_app.sched_conf = CONF
     # Load algorithm data
     algorithms.load(**vars(CONF))

--- a/src/beeflow/scheduler/scheduler.py
+++ b/src/beeflow/scheduler/scheduler.py
@@ -193,7 +193,7 @@ if __name__ == '__main__':
 
     # Flask logging
     flask_app.logger.addHandler(handler) # noqa
-    flask_app.run(debug=True, port=CONF.listen_port)
+    flask_app.run(debug=False, port=CONF.listen_port)
 
 # Ignore todo's or pylama fails
 # pylama:ignore=W0511

--- a/src/beeflow/task_manager.py
+++ b/src/beeflow/task_manager.py
@@ -20,6 +20,8 @@ from beeflow.common.config_driver import BeeConfig
 from beeflow.cli import log
 import beeflow.common.log as bee_logging
 
+sys.excepthook = bee_logging.catch_exception
+
 if len(sys.argv) > 2:
     bc = BeeConfig(userconfig=sys.argv[1])
 else:

--- a/src/beeflow/wf_manager.py
+++ b/src/beeflow/wf_manager.py
@@ -418,6 +418,6 @@ if __name__ == '__main__':
     # Flask logging
     # Putting this off for another issue so noqa to appease the lama
     flask_app.logger.addHandler(handler) #noqa
-    flask_app.run(debug=False, port=str(wfm_listen_port))
+    flask_app.run(debug=True, port=str(wfm_listen_port))
 
 # pylama:ignore=W0511

--- a/src/beeflow/wf_manager.py
+++ b/src/beeflow/wf_manager.py
@@ -19,10 +19,13 @@ from beeflow.common.config_driver import BeeConfig
 from beeflow.cli import log
 import beeflow.common.log as bee_logging
 
+sys.excepthook = bee_logging.catch_exception
+
 if len(sys.argv) > 2:
     bc = BeeConfig(userconfig=sys.argv[1])
 else:
     bc = BeeConfig()
+
 
 if bc.userconfig.has_section('workflow_manager'):
     # Try getting listen port from config if exists, use WM_PORT if it doesnt exist
@@ -399,9 +402,10 @@ api.add_resource(JobsList, '/bee_wfm/v1/jobs/')
 api.add_resource(JobSubmit, '/bee_wfm/v1/jobs/submit/<string:wf_id>')
 api.add_resource(JobActions, '/bee_wfm/v1/jobs/<string:wf_id>')
 api.add_resource(JobUpdate, '/bee_wfm/v1/jobs/update/')
-
+checkthis
 
 if __name__ == '__main__':
+    print("HUH")
     # Setup the Scheduler
     setup_scheduler()
 
@@ -418,6 +422,6 @@ if __name__ == '__main__':
     # Flask logging
     # Putting this off for another issue so noqa to appease the lama
     flask_app.logger.addHandler(handler) #noqa
-    flask_app.run(debug=True, port=str(wfm_listen_port))
+    flask_app.run(debug=False, port=str(wfm_listen_port))
 
 # pylama:ignore=W0511

--- a/src/beeflow/wf_manager.py
+++ b/src/beeflow/wf_manager.py
@@ -402,10 +402,8 @@ api.add_resource(JobsList, '/bee_wfm/v1/jobs/')
 api.add_resource(JobSubmit, '/bee_wfm/v1/jobs/submit/<string:wf_id>')
 api.add_resource(JobActions, '/bee_wfm/v1/jobs/<string:wf_id>')
 api.add_resource(JobUpdate, '/bee_wfm/v1/jobs/update/')
-checkthis
 
 if __name__ == '__main__':
-    print("HUH")
     # Setup the Scheduler
     setup_scheduler()
 
@@ -422,6 +420,6 @@ if __name__ == '__main__':
     # Flask logging
     # Putting this off for another issue so noqa to appease the lama
     flask_app.logger.addHandler(handler) #noqa
-    flask_app.run(debug=False, port=str(wfm_listen_port))
+    flask_app.run(debug=True, port=str(wfm_listen_port))
 
 # pylama:ignore=W0511

--- a/src/beeflow/wf_manager.py
+++ b/src/beeflow/wf_manager.py
@@ -406,9 +406,7 @@ api.add_resource(JobUpdate, '/bee_wfm/v1/jobs/update/')
 if __name__ == '__main__':
     # Setup the Scheduler
     setup_scheduler()
-
     log.info(f'wfm_listen_port:{wfm_listen_port}')
-
     bee_workdir = bc.userconfig.get('DEFAULT','bee_workdir')
     handler = bee_logging.save_log(bee_workdir=bee_workdir, log=log, logfile='wf_manager.log')
 
@@ -420,6 +418,6 @@ if __name__ == '__main__':
     # Flask logging
     # Putting this off for another issue so noqa to appease the lama
     flask_app.logger.addHandler(handler) #noqa
-    flask_app.run(debug=True, port=str(wfm_listen_port))
+    flask_app.run(debug=False, port=str(wfm_listen_port))
 
 # pylama:ignore=W0511


### PR DESCRIPTION
This PR resolves #330. It adds code to log all unhandled exceptions using [sys.excepthook](https://docs.python.org/3/library/sys.html#sys.excepthook). One weird issue that made this more complicated is that we have to do some introspection on the traceback to figure out which log the error belongs to if the error occurs before our log setup code. This adds an additional requirement that each log file match the name of the script it is logging. So, I changed `sched.log` to `scheduler.log`. 