### PR TITLE
Workflow ID Patch

### DIFF
--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -48,8 +48,11 @@ class WorkflowInterface:
         self._gdb_interface.connect(**self._gdb_details)
 
         workflow = Workflow(name, hints, requirements, inputs, outputs)
+        self._workflow_id = workflow.id
+
         # Load the new workflow into the graph database
         self._gdb_interface.initialize_workflow(workflow)
+
         return workflow
 
     def execute_workflow(self):

--- a/src/beeflow/tests/test_wf_interface.py
+++ b/src/beeflow/tests/test_wf_interface.py
@@ -38,6 +38,7 @@ class TestWorkflowInterface(unittest.TestCase):
 
         self.assertEqual(gdb_workflow, workflow)
         self.assertEqual(gdb_workflow.id, workflow.id)
+        self.assertIsNotNone(self.wfi._workflow_id)
 
     def test_execute_workflow(self):
         """Test workflow execution initialization (set initial tasks' states to 'READY')."""
@@ -149,6 +150,7 @@ class TestWorkflowInterface(unittest.TestCase):
         self.assertEqual(subworkflow, task.subworkflow)
         self.assertSetEqual(inputs, task.inputs)
         self.assertSetEqual(outputs, task.outputs)
+        self.assertEqual(task.workflow_id, self.wfi._workflow_id)
         self.assertIsInstance(task.id, str)
 
         # Graph database assertions


### PR DESCRIPTION
Simple patch fixing failure to propagate workflow ID to tasks
- `wf_interface.initialize_workflow()` now stores workflow ID in private attribute
- `test_wf_interface` now tests for propagation of workflow ID to tasks