### PR TITLE
Simple worker

### DIFF
--- a/src/beeflow/common/worker/__init__.py
+++ b/src/beeflow/common/worker/__init__.py
@@ -1,0 +1,20 @@
+"""Init file for the worker package."""
+import sys
+
+from .slurm_worker import SlurmWorker
+from .lsf_worker import LSFWorker
+from .simple_worker import SimpleWorker
+
+
+supported_workload_schedulers = {
+    'Slurm': SlurmWorker,
+    'LSF': LSFWorker,
+    'Simple': SimpleWorker,
+}
+
+
+def find_worker(name):
+    """Find the worker class or return None."""
+    if name in supported_workload_schedulers:
+        return supported_workload_schedulers[name]
+    return None

--- a/src/beeflow/common/worker/__init__.py
+++ b/src/beeflow/common/worker/__init__.py
@@ -1,9 +1,9 @@
 """Init file for the worker package."""
 import sys
 
-from .slurm_worker import SlurmWorker
-from .lsf_worker import LSFWorker
-from .simple_worker import SimpleWorker
+from beeflow.common.worker.slurm_worker import SlurmWorker
+from beeflow.common.worker.lsf_worker import LSFWorker
+from beeflow.common.worker.simple_worker import SimpleWorker
 
 
 supported_workload_schedulers = {

--- a/src/beeflow/common/worker/simple_worker.py
+++ b/src/beeflow/common/worker/simple_worker.py
@@ -1,0 +1,71 @@
+
+"""Simple Worker class for launching tasks on a system with no workload manager."""
+
+import subprocess
+import beeflow.common.worker.worker as worker
+
+from beeflow.common.crt_interface import ContainerRuntimeInterface
+
+# Import all implemented container runtime drivers now
+# No error if they don't exist
+try:
+    from beeflow.common.crt_drivers import CharliecloudDriver
+except ModuleNotFoundError:
+    pass
+try:
+    from beeflow.common.crt_drivers import SingularityDriver
+except ModuleNotFoundError:
+    pass
+
+
+class SimpleWorker(worker.Worker):
+    """The Worker interface for no workload manager."""
+
+    def __init__(self, **kwargs):
+        """Simple worker class."""
+        self.tasks = {}
+        # Use Charliecloud for now
+        self.crt = ContainerRuntimeInterface(CharliecloudDriver)
+
+    def submit_task(self, task):
+        """Worker submits task; returns job_id, job_state.
+
+        :param task: instance of Task
+        :rtype tuple (int, string)
+        """
+        # TODO: Run the script
+        # TODO: Container runtimes
+        # TODO: MPI jobs
+        # proc = subprocess.Popen(task.command.split())
+        script = self.crt.script_text(task)
+        print(script)
+        # subprocess.Popen(['/bin/sh', task.command])
+        self.tasks[task.id] = subprocess.Popen(['/bin/sh', '-c', script])
+        # self.tasks[task.id] = proc
+        return (task.id, 'PENDING')
+
+    def cancel_task(self, job_id):
+        """Cancel task with job_id; returns job_state.
+
+        :param job_id: to be cancelled
+        :type job_id: integer
+        :rtype string
+        """
+        self.tasks[job_id].kill()
+        return 'CANCELLED'
+
+    def query_task(self, job_id):
+        """Query job state for the task.
+
+        :param job_id: job id to query for status.
+        :type job_id: int
+        :rtype string
+        """
+        rc = self.tasks[job_id].poll()
+        # This assumes a standard returncode
+        if rc is None:
+            return 'RUNNING'
+        elif rc == 0:
+            return 'COMPLETED'
+        else:
+            return 'FAILED'

--- a/src/beeflow/common/worker/simple_worker.py
+++ b/src/beeflow/common/worker/simple_worker.py
@@ -42,7 +42,7 @@ class SimpleWorker(worker.Worker):
         :param task: instance of Task
         :rtype tuple (int, string)
         """
-        script = self.crt.script_text(task)
+        script = self.crt.run_text(task)
         print(script)
         self.tasks[task.id] = subprocess.Popen(['/bin/sh', '-c', script])
         return (task.id, 'PENDING')

--- a/src/beeflow/common/worker/simple_worker.py
+++ b/src/beeflow/common/worker/simple_worker.py
@@ -3,7 +3,7 @@
 
 import subprocess
 
-import beeflow.common.worker.worker as worker
+import beeflow.common.worker.worker import Worker
 from beeflow.common.crt_interface import ContainerRuntimeInterface
 from beeflow.cli import log
 import beeflow.common.log as bee_logging
@@ -20,7 +20,7 @@ except ModuleNotFoundError:
     pass
 
 
-class SimpleWorker(worker.Worker):
+class SimpleWorker(Worker):
     """The Worker interface for no workload manager."""
 
     def __init__(self, container_runtime, **kwargs):

--- a/src/beeflow/common/worker/simple_worker.py
+++ b/src/beeflow/common/worker/simple_worker.py
@@ -3,7 +3,7 @@
 
 import subprocess
 
-import beeflow.common.worker.worker import Worker
+from beeflow.common.worker.worker import Worker
 from beeflow.common.crt_interface import ContainerRuntimeInterface
 from beeflow.cli import log
 import beeflow.common.log as bee_logging

--- a/src/beeflow/common/worker/simple_worker.py
+++ b/src/beeflow/common/worker/simple_worker.py
@@ -2,9 +2,11 @@
 """Simple Worker class for launching tasks on a system with no workload manager."""
 
 import subprocess
-import beeflow.common.worker.worker as worker
 
+import beeflow.common.worker.worker as worker
 from beeflow.common.crt_interface import ContainerRuntimeInterface
+from beeflow.cli import log
+import beeflow.common.log as bee_logging
 
 # Import all implemented container runtime drivers now
 # No error if they don't exist
@@ -21,10 +23,17 @@ except ModuleNotFoundError:
 class SimpleWorker(worker.Worker):
     """The Worker interface for no workload manager."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, container_runtime, **kwargs):
         """Simple worker class."""
         self.tasks = {}
-        # Use Charliecloud for now
+        # TODO: This code should be put into the driver code itself
+        crt_class = None
+        if container_runtime == 'Charliecloud':
+            crt_class = CharliecloudDriver
+        elif container_runtime == 'Singularity':
+            crt_class = SingularityDriver
+        if crt_class is None:
+            log.warning("No container runtime specified in config, proceeding with caution.")
         self.crt = ContainerRuntimeInterface(CharliecloudDriver)
 
     def submit_task(self, task):
@@ -33,15 +42,9 @@ class SimpleWorker(worker.Worker):
         :param task: instance of Task
         :rtype tuple (int, string)
         """
-        # TODO: Run the script
-        # TODO: Container runtimes
-        # TODO: MPI jobs
-        # proc = subprocess.Popen(task.command.split())
         script = self.crt.script_text(task)
         print(script)
-        # subprocess.Popen(['/bin/sh', task.command])
         self.tasks[task.id] = subprocess.Popen(['/bin/sh', '-c', script])
-        # self.tasks[task.id] = proc
         return (task.id, 'PENDING')
 
     def cancel_task(self, job_id):
@@ -62,7 +65,7 @@ class SimpleWorker(worker.Worker):
         :rtype string
         """
         rc = self.tasks[job_id].poll()
-        # This assumes a standard returncode
+        # XXX: This assumes a standard returncode
         if rc is None:
             return 'RUNNING'
         elif rc == 0:

--- a/src/beeflow/task_manager.py
+++ b/src/beeflow/task_manager.py
@@ -253,14 +253,12 @@ class TaskActions(Resource):
 from beeflow.common.worker_interface import WorkerInterface
 import beeflow.common.worker as worker_pkg
 
-supported_workload_schedulers = {'Slurm', 'LSF'}
 try:
     WLS = bc.userconfig.get('DEFAULT', 'workload_scheduler')
 except ValueError as error:
     log.error(f'workload scheduler error {error}')
     WLS = None
 worker_class = worker_pkg.find_worker(WLS)
-# if WLS not in supported_workload_schedulers:
 if worker_class is None:
     sys.exit(f'Workload scheduler {WLS}, not supported.\n' +
              f'Please check {bc.userconfig_file} and restart TaskManager.')

--- a/src/beeflow/task_manager.py
+++ b/src/beeflow/task_manager.py
@@ -252,8 +252,6 @@ class TaskActions(Resource):
 # WorkerInterface needs to be placed here. Don't Move!
 from beeflow.common.worker_interface import WorkerInterface
 import beeflow.common.worker as worker_pkg
-#from beeflow.common.worker.slurm_worker import SlurmWorker
-#from beeflow.common.worker.lsf_worker import LSFWorker
 
 supported_workload_schedulers = {'Slurm', 'LSF'}
 try:


### PR DESCRIPTION
These changes add the SimpleWorker class that should allow for running BEE workflows without a batch scheduler. This is useful for testing and debugging purposes, and is also what I currently use for running workflows in the cloud. I imagine this could also be useful for running a workflow locally before running it on an HPC system.