### PR TITLE
Add workflow profiling code

### DIFF
--- a/src/beeflow/common/wf_profiler.py
+++ b/src/beeflow/common/wf_profiler.py
@@ -1,0 +1,45 @@
+"""Workflow profiling code."""
+import json
+import time
+import os
+
+
+class WorkflowProfiler:
+    """Class for profiling a single workflow's execution."""
+
+    def __init__(self, workflow_name, save_dir):
+        """WorkflowProfiler constructor."""
+        self._workflow_name = workflow_name
+        # TODO: Put this is in the config file
+        profile_fname = '%s-profile-%.20i.json' % (workflow_name, int(time.time()))
+        self._profile_fname = os.path.join(save_dir, profile_fname)
+        self._state_changes = []
+        self._scheduling_results = []
+
+    def add_state_change(self, task, next_state):
+        """Save a change of state for a task (at each task state change)."""
+        self._state_changes.append({
+            'task_id': task.id,
+            'task_name': task.name,
+            # State is not stored in the task object
+            # 'previous_state': task.state,
+            'next_state': next_state,
+            'timestamp': int(time.time()),
+        })
+
+    def add_scheduling_results(self, tasks, resources, allocations):
+        """Add scheduling results (given the set of available resources)."""
+        self._scheduling_results.append({
+            'tasks': tasks,
+            'resources': resources,
+            'allocations': dict(allocations),
+            'timestamp': int(time.time()),
+        })
+
+    def save(self):
+        """Save the workflow results (run on workflow completion)."""
+        with open(self._profile_fname, 'w') as fp:
+            json.dump({
+                'state_changes': self._state_changes,
+                'scheduling_results': self._scheduling_results,
+            }, fp=fp, indent=4)


### PR DESCRIPTION
This is another smaller PR which adds a workflow profiling script. I'm going to mark this as WIP for right now, until I can add this code to the workflow manager and add some configuration options to the `bee.conf`. Basically this is useful for running experiments with BEE workflows and then capturing task runtimes, output results from the scheduler, etc. I've used this for experiments in a couple of our paper submissions and I could see this being useful for others who want to measure workflow performance. Once this PR goes through I plan to open another with the cloud launching code.