### PR TITLE
Fix path for scripts and outputs for task/job.

### DIFF
--- a/src/beeflow/common/worker/lsf_worker.py
+++ b/src/beeflow/common/worker/lsf_worker.py
@@ -82,7 +82,7 @@ class LSFWorker(Worker):
 
     def build_text(self, task):
         """Build text for task script; use template if it exists."""
-        workflow_path = f'{self.workdir}/{task.workflow_id}/{task.name}-{task.id}'
+        workflow_path = f'{self.workdir}/workflows/{task.workflow_id}/{task.name}-{task.id}'
         template_text = '#! /bin/bash\n'
         template_text += f'#BSUB -J {task.name}-{task.id}\n'
         template_text += f'#BSUB -o {workflow_path}/{task.name}-{task.id}.out\n'
@@ -99,7 +99,7 @@ class LSFWorker(Worker):
 
     def write_script(self, task):
         """Build task script; returns filename of script."""
-        script_dir = f'{self.workdir}/{task.workflow_id}/{task.name}-{task.id}'
+        script_dir = f'{self.workdir}/workflows/{task.workflow_id}/{task.name}-{task.id}'
         if not self.crt.image_exists(task):
             raise Exception(f'dockerImageId not accessible for task {task.name}.')
         os.makedirs(script_dir, exist_ok=True)


### PR DESCRIPTION
Simple fix for LSF so that the step job scripts and outputs will be in the proper path and archived.