### PR TITLE
Set Input Type After Evaluating Expression

### DIFF
--- a/src/beeflow/common/crt_drivers.py
+++ b/src/beeflow/common/crt_drivers.py
@@ -206,7 +206,7 @@ class CharliecloudDriver(ContainerRuntimeDriver):
                 log.info('Moving with the expectation that {} is the runtime container target'.
                          format(task_container_name))
 
-        command = ''.join(task.command) + '\n'
+        command = ' '.join(task.command) + '\n'
         if baremetal:
             return command
 
@@ -223,7 +223,6 @@ class CharliecloudDriver(ContainerRuntimeDriver):
                 f'rm -rf {deployed_image_root}/{task_container_name}\n'
                 )
         log.info('run text:\n{}'.format(text))
->>>>>>> develop
         return text
 
     def build_text(self, userconfig, task):

--- a/src/beeflow/common/gdb/gdb_driver.py
+++ b/src/beeflow/common/gdb/gdb_driver.py
@@ -214,10 +214,22 @@ class GraphDatabaseDriver(ABC):
         """
 
     @abstractmethod
+    def set_task_input_type(self, task, input_id, type_):
+        """Set the type of a task input.
+
+        :param task: the task whose input type to set
+        :type task: Task
+        :param input_id: the ID of the input
+        :type input_id: str
+        :param type_: the input type to set
+        :param type_: str
+        """
+
+    @abstractmethod
     def set_task_output_glob(self, task, output_id, glob):
         """Set the glob of a task output.
 
-        :param task: the task whose output to set
+        :param task: the task whose output glob to set
         :type task: Task
         :param output_id: the ID of the output
         :type output_id: str

--- a/src/beeflow/common/gdb/neo4j_cypher.py
+++ b/src/beeflow/common/gdb/neo4j_cypher.py
@@ -472,6 +472,22 @@ def set_task_output(tx, task, output_id, value):
     tx.run(output_query, task_id=task.id, output_id=output_id, value=value)
 
 
+def set_task_input_type(tx, task, input_id, type_):
+    """Set the type of a task input.
+
+    :param task: the task whose input type to set
+    :type task: Task
+    :param input_id: the ID of the input
+    :type input_id: str
+    :param type_: the input type to set
+    :param type_: str
+    """
+    type_query = ("MATCH (:Task {id: $task_id})<-[:INPUT_OF]-(i:Input {id: $input_id}) "
+                  "SET i.type = $type_")
+
+    tx.run(type_query, task_id=task.id, input_id=input_id, type_=type_)
+
+
 def set_task_output_glob(tx, task, output_id, glob):
     """Set a task's output value.
 
@@ -482,10 +498,10 @@ def set_task_output_glob(tx, task, output_id, glob):
     :param glob: the glob of the output
     :type glob: str
     """
-    output_query = ("MATCH (:Task {id: $task_id})<-[:OUTPUT_OF]-(o:Output {id: $output_id}) "
-                    "SET o.glob = $glob")
+    glob_query = ("MATCH (:Task {id: $task_id})<-[:OUTPUT_OF]-(o:Output {id: $output_id}) "
+                  "SET o.glob = $glob")
 
-    tx.run(output_query, task_id=task.id, output_id=output_id, glob=glob)
+    tx.run(glob_query, task_id=task.id, output_id=output_id, glob=glob)
 
 
 def set_init_tasks_to_ready(tx):

--- a/src/beeflow/common/gdb/neo4j_driver.py
+++ b/src/beeflow/common/gdb/neo4j_driver.py
@@ -301,6 +301,18 @@ class Neo4jDriver(GraphDatabaseDriver):
         """
         self._write_transaction(tx.set_task_output, task=task, output_id=output_id, value=value)
 
+    def set_task_input_type(self, task, input_id, type_):
+        """Set the type of a task input.
+
+        :param task: the task whose input type to set
+        :type task: Task
+        :param input_id: the ID of the input
+        :type input_id: str
+        :param type_: the input type to set
+        :param type_: str
+        """
+        self._write_transaction(tx.set_task_input_type, task=task, input_id=input_id, type_=type_)
+
     def set_task_output_glob(self, task, output_id, glob):
         """Set the glob of a task output.
 

--- a/src/beeflow/common/gdb_interface.py
+++ b/src/beeflow/common/gdb_interface.py
@@ -280,6 +280,7 @@ class GraphDatabaseInterface:
                     else:
                         # Pattern "foo" (strip quotes)
                         values.append(m[1:-1])
+                self._connection.set_task_input_type(task, id, "string")
                 self._connection.set_task_input(task, id, values[0] + values[1])
             else:
                 raise ValueError(f"unable to evaluate expression {step_input.value_from}")

--- a/src/beeflow/tests/test_wf_interface.py
+++ b/src/beeflow/tests/test_wf_interface.py
@@ -434,8 +434,8 @@ class TestWorkflowInterface(unittest.TestCase):
                        '$("test_" + inputs.test_input)')],
             [StepOutput("test_task/output", "File", None, "$(inputs.test_input).bak")])
 
-        test_input = StepInput("test_input", "File", "test_input.txt", "default.txt", "test_input",
-                               None, None, '$("test_" + inputs.test_input)')
+        test_input = StepInput("test_input", "string", "test_input.txt", "default.txt",
+                               "test_input", None, None, '$("test_" + inputs.test_input)')
         self.wfi.evaluate_expression(task, "test_input")
         self.assertEqual(test_input, self.wfi.get_task_input(task, "test_input"))
 


### PR DESCRIPTION
Patch adds code to change input type in the graph database:
- Added `set_task_input_type()` method to `GraphDatabaseInterface`, `GraphDatabaseDriver`, and `Neo4jDriver`
  - Called by `WorkflowInterface.evaluate_expression()` before setting input value when called with `output=False`
- Added `set_task_input_type()` function to `neo4j_cypher.py`