### PR TITLE
Implement WFI reconnect method

### DIFF
--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -25,6 +25,16 @@ class WorkflowInterface:
         self._gdb_interface.connect(**kwargs)
         # Store the Workflow ID in the interface to assign it to new task objects
         self._workflow_id = None
+        # Store the GDB credentials for reconnection if necessary
+        self._kwargs = kwargs
+
+    def reconnect(self):
+        """Reconnect to the graph database using stored credentials."""
+        self._gdb_interface.connect(**self._kwargs)
+        if self.workflow_loaded():
+            self._workflow_id = None
+            # This property automatically sets self._workflow_id when invoked
+            self.workflow_id
 
     def initialize_workflow(self, name, inputs, outputs, requirements=None, hints=None):
         """Begin construction of a BEE workflow.
@@ -39,6 +49,7 @@ class WorkflowInterface:
         :type requirements: list of Requirement
         :param hints: the workflow hints (optional requirements)
         :type hints: list of Hint
+        :rtype: Workflow
         """
         if self.workflow_loaded():
             raise RuntimeError("attempt to re-initialize existing workflow")
@@ -312,7 +323,7 @@ class WorkflowInterface:
         :rtype: str
         """
         if self._workflow_id is None and self.workflow_loaded():
-            workflow = self.get_workflow()
+            workflow = self.get_workflow()[0]
             self._workflow_id = workflow.id
 
         return self._workflow_id

--- a/src/beeflow/tests/test_wf_interface.py
+++ b/src/beeflow/tests/test_wf_interface.py
@@ -24,6 +24,23 @@ class TestWorkflowInterface(unittest.TestCase):
         if self.wfi.workflow_initialized() and self.wfi.workflow_loaded():
             self.wfi.finalize_workflow()
 
+    def test_reconnect(self):
+        """Test workflow reconnection."""
+        workflow = self.wfi.initialize_workflow("test_workflow",
+                                                [InputParameter("test_input", "File", "input.txt")],
+                                                [OutputParameter("test_output", "File",
+                                                                 "output.txt", "viz/output")])
+
+        # Destroy connection object
+        self.wfi._gdb_interface._connection = None
+        # Re-establish connection
+        self.wfi.reconnect()
+
+        self.assertTrue(self.wfi.workflow_loaded())
+        gdb_workflow = self.wfi.get_workflow()[0]
+        self.assertEqual(workflow, gdb_workflow)
+        self.assertEqual(self.wfi._workflow_id, gdb_workflow.id)
+
     def test_initialize_workflow(self):
         """Test workflow initialization.
 


### PR DESCRIPTION
Implements workflow interface `reconnect()` method to re-establish connection to the graph database in the case that connection data is destroyed. Closes #400.

Changes to `WorkflowInterface`:
- Added `reconnect()` method
  - Recreates graph database connection without modifying any existing workflow
  - Restores `WorkflowInterface._workflow_id` from the graph database
- Now storing supplied `kwargs` in the `WorkflowInterface._kwargs` attribute
- Fixed bug retrieving the workflow ID from the database in the `WorkflowInterface.workflod_id` property
- Updated `WorkflowInterface.initialize_workflow()` Sphinx docstring with `rtype`