### PR TITLE
Make ch-builder2tar use ch-image by default

### DIFF
--- a/src/beeflow/common/build/container_drivers.py
+++ b/src/beeflow/common/build/container_drivers.py
@@ -220,7 +220,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
                 pass
 
         # Out of excuses. Pull the image.
-        cmd = (f'ch-image pull {addr} && ch-builder2tar {ch_build_addr} {self.container_archive}'
+        cmd = (f'ch-image pull {addr} && ch-builder2tar -b ch-image {ch_build_addr} {self.container_archive}'
                )
         return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                               check=True, shell=True)
@@ -311,7 +311,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         # Out of excuses. Build the image.
         log.info('Context directory configured. Beginning build.')
         cmd = (f'ch-image build -t {self.container_name} -f {task_dockerfile} {context_dir}\n'
-               f'ch-builder2tar {ch_build_addr} {self.container_archive}'
+               f'ch-builder2tar -b ch-image {ch_build_addr} {self.container_archive}'
                )
         log.info('Executing: {}'.format(cmd))
         return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,


### PR DESCRIPTION
`ch-builder2tar` will use Docker to export containers if it's installed on a given system. We have to explicitly add `-b ch-image` to get it to export the container from Charliecloud. I noticed this when using a workflow with `dockerPull` on my machine.