### PR TITLE
Short Workflow ID Support

### DIFF
--- a/src/beeflow/client/client.py
+++ b/src/beeflow/client/client.py
@@ -56,6 +56,7 @@ def safe_input(type):
             # Cast it to the specified type
             answer = type(answer)
             break
+            # Put logs in main bee_workdir log directory /logs
         except ValueError:
             print(f"Error {answer} is not a valid option")
     return answer
@@ -63,6 +64,7 @@ def safe_input(type):
 # Check short workflow IDs for colliions, increase short ID
 # length if any detected
 def check_short_id_collision():
+    global short_id_len
     resp = requests.get(_url())
     if resp.status_code != requests.codes.okay:
         print(f"Returned {resp.status_code}")
@@ -168,7 +170,7 @@ def submit_workflow(wf_name, workflow_path, main_cwl, yaml=None):
 def start_workflow(wf_id):
     matched_id = match_short_id(wf_id)
     if matched_id:
-        resp = requests.post(_resource(wf_id), json={'wf_id': matched_id})
+        resp = requests.post(_resource(matched_id), json={'wf_id': matched_id})
         if resp.status_code != requests.codes.okay:
             raise ApiError("PUT /jobs{}".format(resp.status_code, matched_id))
         logging.info('Start job: ' + resp.text)
@@ -300,14 +302,14 @@ if __name__ == '__main__':
                     print(f'Exception {e}')
             else:
                 wf_id = submit_workflow(wf_name, workflow_path, main_cwl)
-            print(f"Job submitted! Your workflow id is {wf_id}.")
+            print(f"Job submitted! Your workflow id is {_short_id(wf_id)}.")
         elif int(choice) == 2:
             list_workflows()
-        elif int(choice) < 7:
+        elif int(choice) < 8:
             print("What is the workflow id?")
             wf_id = safe_input(str)
             list(menu_items[int(choice)].values())[0](wf_id)
-        elif int(choice) == 7:
+        elif int(choice) == 8:
             print("What is the workflow id?")
             wf_id = safe_input(str)
             print("Where do you want to save it?")
@@ -315,13 +317,13 @@ if __name__ == '__main__':
             archive_file, archive_filename = copy_workflow(wf_id, archive_path)
             with open(os.path.join(archive_path, archive_filename), 'wb') as a:
                 a.write(archive_file)
-        elif int(choice) == 8:
+        elif int(choice) == 9:
             print("What is the archive path?")
             archive_path = safe_input(Path)
             print("What will be the name of the job?")
             wf_name = safe_input(str)
             wf_id = reexecute_workflow(archive_path, wf_name)
-            print(f"Job submitted! Your workflow id is {wf_id}.")
+            print(f"Job submitted! Your workflow id is {_short_id(wf_id)}.")
 
     except (ValueError, IndexError):
         pass

--- a/src/beeflow/client/client.py
+++ b/src/beeflow/client/client.py
@@ -18,6 +18,12 @@ except IndexError:
 # Set Workflow manager ports, attempt to prevent collisions
 WM_PORT = 5000
 
+# Length of a shortened workflow ID
+short_id_len = 6
+
+# Maximum length of a workflow ID
+MAX_ID_LEN = 32
+
 if platform.system() == 'Windows':
     # Get parent's pid to offset ports. uid method better but not available in Windows
     WM_PORT += os.getppid() % 100
@@ -37,6 +43,9 @@ def _url():
         wfm_listen_port = WM_PORT
     return f'http://127.0.0.1:{wfm_listen_port}/{workflow_manager}/'
 
+def _short_id(wf_id):
+    return wf_id[:short_id_len]
+
 def _resource(tag=""): 
     return _url() + str(tag)
 
@@ -50,6 +59,55 @@ def safe_input(type):
         except ValueError:
             print(f"Error {answer} is not a valid option")
     return answer
+
+# Check short workflow IDs for colliions, increase short ID
+# length if any detected
+def check_short_id_collision():
+    resp = requests.get(_url())
+    if resp.status_code != requests.codes.okay:
+        print(f"Returned {resp.status_code}")
+        raise ApiError("GET /jobs".format(resp.status_code))
+
+    job_list = jsonpickle.decode(resp.json()['job_list'])
+    if job_list:
+        while short_id_len < MAX_ID_LEN:
+            id_list = [_short_id(job[1]) for job in job_list]
+            id_list_set = set(id_list)
+            # Collision if set shorter than list
+            if len(id_list_set) < len(id_list):
+                short_id_len += 1
+            else:
+                break
+        else:
+            raise RuntimeError("collision detected between two full workflow IDs")
+    else:
+        print("There are currently no jobs.")
+
+# Match user-provided short workflow ID to full workflow IDs
+# If more than one matched, 
+def match_short_id(wf_id):
+    matched_ids = []
+    resp = requests.get(_url())
+    if resp.status_code != requests.codes.okay:
+        print(f"Returned {resp.status_code}")
+        raise ApiError("GET /jobs".format(resp.status_code))
+
+    job_list = jsonpickle.decode(resp.json()['job_list'])
+    if job_list:
+        for job in job_list:
+            if job[1].startswith(wf_id):
+                matched_ids.append(job[1])
+        if len(matched_ids) > 1:
+            logging.info(f"user-provided workflow ID {wf_id} matched multiple stored workflow IDs")
+            print("provided workflow ID ambiguous")
+        elif not matched_ids:
+            logging.info(f"user-provided workflow ID {wf_id} did not match any stored workflow ID")
+            print("provided workflow ID does not match any submitted workflows")
+        else:
+            logging.info(f"user-provided workflow ID {wf_id} matched stored workflow ID {matched_ids[0]}")
+            return matched_ids[0]
+    else:
+        print("There are currently no jobs.")
 
 # Package Workflow
 def package_workflow():
@@ -101,56 +159,70 @@ def submit_workflow(wf_name, workflow_path, main_cwl, yaml=None):
 
     logging.info("Submit job: " + resp.text)
 
+    check_short_id_collision()
+
     wf_id = resp.json()['wf_id']
     logging.info("wf_id is " + str(wf_id))
     return wf_id
 
 # Start workflow on server
 def start_workflow(wf_id):
-    resp = requests.post(_resource(wf_id), json={'wf_id': wf_id})
-    if resp.status_code != requests.codes.okay:
-        raise ApiError("PUT /jobs{}".format(resp.status_code, wf_id))
-    logging.info('Start job: ' + resp.text)
+    matched_id = match_short_id(wf_id)
+    if matched_id:
+        resp = requests.post(_resource(wf_id), json={'wf_id': matched_id})
+        if resp.status_code != requests.codes.okay:
+            raise ApiError("PUT /jobs{}".format(resp.status_code, matched_id))
+        logging.info('Start job: ' + resp.text)
 
 # Query the current status of a job
 def query_workflow(wf_id):
-    resp = requests.get(_resource(wf_id), json={'wf_id': wf_id})
-    if resp.status_code != requests.codes.okay:
-        raise ApiError("GET /jobs {}".format(resp.status_code, wf_id))
-    task_status = resp.json()['msg']
-    logging.info('Query job: ' + resp.text)
+    matched_id = match_short_id(wf_id)
+    if matched_id:
+        resp = requests.get(_resource(matched_id), json={'wf_id': matched_id})
+        if resp.status_code != requests.codes.okay:
+            raise ApiError("GET /jobs {}".format(resp.status_code, matched_id))
+        task_status = resp.json()['msg']
+        logging.info('Query job: ' + resp.text)
 
 # Sends a request to the server to delete the resource 
 def cancel_workflow(wf_id):
-    resp = requests.delete(_resource(wf_id), json={'wf_id': wf_id})
-    # Returns okay if the resource has been deleted
-    # Non-blocking so it returns accepted 
-    if resp.status_code != requests.codes.accepted:
-        raise ApiError("DELETE /jobs{}".format(resp.status_code, wf_id))
-    logging.info('Cancel job: ' + resp.text)
+    matched_id = match_short_id(wf_id)
+    if matched_id:
+        resp = requests.delete(_resource(matched_id), json={'wf_id': matched_id})
+        # Returns okay if the resource has been deleted
+        # Non-blocking so it returns accepted 
+        if resp.status_code != requests.codes.accepted:
+            raise ApiError("DELETE /jobs{}".format(resp.status_code, matched_id))
+        logging.info('Cancel job: ' + resp.text)
 
 # Pause the execution of a job
 def pause_workflow(wf_id):
-    resp = requests.patch(_resource(wf_id), json={'wf_id': wf_id, 'option' : 'pause' })
-    if resp.status_code != requests.codes.okay:
-        raise ApiError("PAUSE /jobs{}".format(resp.status_code, wf_id))
-    logging.info('Pause job: ' + resp.text)
+    matched_id = match_short_id(wf_id)
+    if matched_id:
+        resp = requests.patch(_resource(wf_id), json={'wf_id': matched_id, 'option' : 'pause' })
+        if resp.status_code != requests.codes.okay:
+            raise ApiError("PAUSE /jobs{}".format(resp.status_code, matched_id))
+        logging.info('Pause job: ' + resp.text)
 
 # Resume the execution of a job
 def resume_workflow(wf_id):
-    resp = requests.patch(_resource(wf_id), json={'wf_id': wf_id, 'option' : 'resume' })
-    if resp.status_code != requests.codes.okay:
-        raise ApiError("RESUME /jobs{}".format(resp.status_code, wf_id))
-    logging.info('Resume job: ' + resp.text)
+    matched_id = match_short_id(wf_id)
+    if matched_id:
+        resp = requests.patch(_resource(matched_id), json={'wf_id': matched_id, 'option' : 'resume' })
+        if resp.status_code != requests.codes.okay:
+            raise ApiError("RESUME /jobs{}".format(resp.status_code, matched_id))
+        logging.info('Resume job: ' + resp.text)
 
 
 def copy_workflow(wf_id, archive_path):
-    resp = requests.patch(_url(), files={'wf_id': wf_id.encode()})
-    if resp.status_code != requests.codes.okay:
-        raise ApiError("COPY /jobs{}".format(resp.status_code, wf_id))
-    archive_file = jsonpickle.decode(resp.json()['archive_file'])
-    archive_filename = resp.json()['archive_filename']
-    return archive_file, archive_filename
+    matched_id = match_short_id(wf_id)
+    if matched_id:
+        resp = requests.patch(_url(), files={'wf_id': matched_id.encode()})
+        if resp.status_code != requests.codes.okay:
+            raise ApiError("COPY /jobs{}".format(resp.status_code, matched_id))
+        archive_file = jsonpickle.decode(resp.json()['archive_file'])
+        archive_filename = resp.json()['archive_filename']
+        return archive_file, archive_filename
 
 def reexecute_workflow(archive_path, wf_name):
     files = {
@@ -163,6 +235,8 @@ def reexecute_workflow(archive_path, wf_name):
         raise ApiError("REEXECUTE /jobs{}".format(resp.status_code))
 
     logging.info("ReExecute Workflow: " + resp.text)
+
+    check_short_id_collision()
 
     wf_id = resp.json()['wf_id']
     return wf_id
@@ -177,8 +251,8 @@ def list_workflows():
     job_list = jsonpickle.decode(resp.json()['job_list'])
     if job_list:
         print(f"Name\tID\t\t\t\t\tStatus")
-        for i in job_list:
-            print(f"{i[0]}\t{i[1]}\t{i[2]}")
+        for name, wf_id, status in job_list:
+            print(f"{name}\t{_short_id(wf_id)}\t{status}")
     else:
         print("There are currently no jobs.")
 
@@ -227,7 +301,7 @@ if __name__ == '__main__':
                     print(f'Exception {e}')
             else:
                 wf_id = submit_workflow(wf_name, workflow_path, main_cwl)
-            print(f"Job submitted! Your workflow id is {wf_id}.")
+            print(f"Job submitted! Your workflow id is {_short_id(wf_id)}.")
         elif int(choice) == 2:
             list_workflows()
         elif int(choice) < 7:
@@ -248,7 +322,7 @@ if __name__ == '__main__':
             print("What will be the name of the job?")
             wf_name = safe_input(str)
             wf_id = reexecute_workflow(archive_path, wf_name)
-            print(f"Job submitted! Your workflow id is {wf_id}.")
+            print(f"Job submitted! Your workflow id is {_short_id(wf_id)}.")
 
     except (ValueError, IndexError):
         pass

--- a/src/beeflow/client/client.py
+++ b/src/beeflow/client/client.py
@@ -84,7 +84,6 @@ def check_short_id_collision():
         print("There are currently no jobs.")
 
 # Match user-provided short workflow ID to full workflow IDs
-# If more than one matched, 
 def match_short_id(wf_id):
     matched_ids = []
     resp = requests.get(_url())
@@ -301,7 +300,7 @@ if __name__ == '__main__':
                     print(f'Exception {e}')
             else:
                 wf_id = submit_workflow(wf_name, workflow_path, main_cwl)
-            print(f"Job submitted! Your workflow id is {_short_id(wf_id)}.")
+            print(f"Job submitted! Your workflow id is {wf_id}.")
         elif int(choice) == 2:
             list_workflows()
         elif int(choice) < 7:
@@ -322,7 +321,7 @@ if __name__ == '__main__':
             print("What will be the name of the job?")
             wf_name = safe_input(str)
             wf_id = reexecute_workflow(archive_path, wf_name)
-            print(f"Job submitted! Your workflow id is {_short_id(wf_id)}.")
+            print(f"Job submitted! Your workflow id is {wf_id}.")
 
     except (ValueError, IndexError):
         pass

--- a/src/beeflow/common/wf_data.py
+++ b/src/beeflow/common/wf_data.py
@@ -54,7 +54,7 @@ class Workflow:
         
         :rtype: str
         """
-        return f"{self.name}-{uuid4().hex}"
+        return uuid4().hex
 
     def __eq__(self, other):
         """Test the equality of two workflows.

--- a/src/beeflow/common/wf_data.py
+++ b/src/beeflow/common/wf_data.py
@@ -43,11 +43,18 @@ class Workflow:
         self.inputs = inputs
         self.outputs = outputs
 
-        # Workflow ID as UUID if not given
+        # Init Workflow ID as name-UUID if not given
         if workflow_id:
             self.id = workflow_id
         else:
-            self.id = str(uuid4())
+            self.id = self.generate_workflow_id()
+    
+    def generate_workflow_id(self):
+        """Generate a unique workflow ID.
+        
+        :rtype: str
+        """
+        return f"{self.name}-{uuid4().hex}"
 
     def __eq__(self, other):
         """Test the equality of two workflows.

--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -3,7 +3,6 @@
 Delegates its work to a GraphDatabaseInterface instance.
 """
 
-from uuid import uuid4
 from beeflow.common.gdb_interface import GraphDatabaseInterface
 from beeflow.common.wf_data import Workflow, Task
 
@@ -78,7 +77,8 @@ class WorkflowInterface:
 
     def reset_workflow(self):
         """Reset the execution state and ID of a BEE workflow."""
-        self._workflow_id = str(uuid4())
+        workflow, _ = self.get_workflow()
+        self._workflow_id = workflow.generate_workflow_id()
         self._gdb_interface.reset_workflow(self._workflow_id)
 
     def finalize_workflow(self):
@@ -323,7 +323,7 @@ class WorkflowInterface:
         :rtype: str
         """
         if self._workflow_id is None and self.workflow_loaded():
-            workflow = self.get_workflow()[0]
+            workflow, _ = self.get_workflow()
             self._workflow_id = workflow.id
 
         return self._workflow_id

--- a/src/beeflow/wf_manager.py
+++ b/src/beeflow/wf_manager.py
@@ -16,7 +16,7 @@ import getpass
 import subprocess
 import cwl_utils.parser.cwl_v1_0 as cwl
 # Server and REST handlin
-from flask import Flask, jsonify, make_response, send_file
+from flask import Flask, jsonify, make_response
 from flask_restful import Resource, Api, reqparse
 # Interacting with the rm, tm, and scheduler
 from werkzeug.datastructures import FileStorage
@@ -132,6 +132,19 @@ class ResourceMonitor():
 
 rm = ResourceMonitor()
 
+
+def validate_wf_id(func):
+    """Validate tempoary hard coded workflow id."""
+    def wrapper(*args, **kwargs):
+        wf_id = kwargs['wf_id']
+        current_wf_id = wfi.workflow_id
+        if wf_id != current_wf_id:
+            log.info(f'Wrong workflow id. Set to {wf_id}, but should be {current_wf_id}')
+            resp = make_response(jsonify(status='wf_id not found'), 404)
+            return resp
+        return func(*args, **kwargs)
+    return wrapper
+
 def process_running(pid):
     """Check if the process with pid is running"""
     try:
@@ -177,23 +190,20 @@ class JobsList(Resource):
     def __init__(self):
         """Initialize job list class."""
         self.reqparse = reqparse.RequestParser()
-        self.reqparse.add_argument('name', type=str, location='form')
-        self.reqparse.add_argument('yaml', type=str, location='form')
-        self.reqparse.add_argument('main_cwl', type=str, location='form')
-        self.reqparse.add_argument('tarball', type=FileStorage, required=False,
+        self.reqparse.add_argument('wf_name', type=FileStorage, required=False,
                                    location='files')
-        #self.reqparse.add_argument('wf_filename', type=FileStorage, required=False,
-        #                           location='files')
-        #self.reqparse.add_argument('workflow', type=FileStorage, required=False,
-        #                           location='files')
-        #self.reqparse.add_argument('yaml', type=FileStorage, required=False,
-        #                           location='files')
-        #self.reqparse.add_argument('main_cwl', type=FileStorage, required=False,
-        #                           location='files')
+        self.reqparse.add_argument('wf_filename', type=FileStorage, required=False,
+                                   location='files')
+        self.reqparse.add_argument('workflow', type=FileStorage, required=False,
+                                   location='files')
+        self.reqparse.add_argument('yaml', type=FileStorage, required=False,
+                                   location='files')
+        self.reqparse.add_argument('main_cwl', type=FileStorage, required=False,
+                                   location='files')
         self.reqparse.add_argument('workflow_archive', type=FileStorage, required=False,
                                    location='files')
-        self.reqparse.add_argument('wf_id', type=str, required=False,
-                                   location='json')
+        self.reqparse.add_argument('wf_id', type=FileStorage, required=False,
+                                   location='files')
         super(JobsList, self).__init__()
 
     def get(self):
@@ -201,129 +211,116 @@ class JobsList(Resource):
         # For each dir in bee_workdir look at its state at .bee_state
         workflows_dir = os.path.join(bee_workdir, 'workflows')
         job_list = []
-        job_dict = {}
         if os.path.isdir(workflows_dir):
             workflows = next(os.walk(workflows_dir))[1]
-
             for wf_id in workflows:
                 wf_path = os.path.join(workflows_dir, wf_id) 
                 status_path = os.path.join(wf_path, 'bee_wf_status')
-
                 name_path = os.path.join(wf_path, 'bee_wf_name')
                 status = pathlib.Path(status_path).read_text()
                 name = pathlib.Path(name_path).read_text()
                 job_list.append([name, wf_id, status])
-                job_dict[wf_id] = {'name': name, 'status': status}
 
-        #resp = make_response(jsonify(job_list=jsonpickle.encode(job_list)), 200)
-        import json
-        resp = make_response(jsonify(job_list=json.dumps(job_dict)), 200)
+        resp = make_response(jsonify(job_list=jsonpickle.encode(job_list)), 200)
         return resp
 
     def post(self):
         global wfi
         """Get a workflow or give file not found error."""
         data = self.reqparse.parse_args()
-        print(data)
-        # Temporary
 
-        # if data['workflow'] == "":
-        #     resp = make_response(jsonify(msg='No file found', status='error'), 400)
-        #     return resp
+        if data['workflow'] == "":
+            resp = make_response(jsonify(msg='No file found', status='error'), 400)
+            return resp
         # Workflow file
-        tarball = data['tarball']
-        #wf_filename = data['wf_filename'].read().decode()
-        main_cwl = data['main_cwl']#.read().decode()
-        name = data['name']
+        wf_tarball = data['workflow']
+        wf_filename = data['wf_filename'].read().decode()
+        main_cwl = data['main_cwl'].read().decode()
+        job_name = data['wf_name'].read().decode()
         # None if not sent
         yaml_file = data['yaml']
-        print(f'{tarball} {main_cwl} {name} {yaml_file}')
-        resp = make_response(jsonify(msg='Workflow uploaded', status='ok', wf_id=42), 201)
 
-        #if tarball:
-        # We have to bind mount a new GDB with charliecloud.
-        kill_gdb()
-        # Remove the old gdb
-        remove_gdb()
-        # Start a new GDB 
-        gdb_workdir = os.path.join(bee_workdir, 'current_gdb')
-        # Get the path of this scrip so we can access the start_gdb scrip relateive to this one
-        script_path = get_script_path()
-        subprocess.run([f'{script_path}/start_gdb.py', '--gdb_workdir', gdb_workdir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        # Need to wait a moment for the GDB
-        time.sleep(10)
+        if wf_tarball:
+            # We have to bind mount a new GDB with charliecloud.
+            kill_gdb()
+            # Remove the old gdb
+            remove_gdb()
+            # Start a new GDB 
+            gdb_workdir = os.path.join(bee_workdir, 'current_gdb')
+            script_path = get_script_path()
+            subprocess.run([f'{script_path}/start_gdb.py', '--gdb_workdir', gdb_workdir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            # Need to wait a moment for the GDB
+            time.sleep(10)
 
-        if wfi:
-            if wfi.workflow_initialized() and wfi.workflow_loaded():
-                # Clear the workflow if we've already run one
-                wfi.finalize_workflow()
+            if wfi:
+                if wfi.workflow_initialized() and wfi.workflow_loaded():
+                    # Clear the workflow if we've already run one
+                    wfi.finalize_workflow()
 
-        # Save the workflow temporarily to this folder for the parser
-        #
-        temp_dir = tempfile.mkdtemp()
-        temp_tarball_path = os.path.join(temp_dir, tarball.filename)
-        tarball.save(temp_tarball_path)
-        # Archive tarballs must be tgz 
-        extension = '.tgz'
-        subprocess.run(['tar', 'xf', f'{tarball.filename}', '--strip-components', '1'], cwd=temp_dir)
+            # Save the workflow temporarily to this folder for the parser
+            #
+            temp_dir = tempfile.mkdtemp()
+            temp_tarball_path = os.path.join(temp_dir, wf_filename)
+            wf_tarball.save(temp_tarball_path)
+            # Archive tarballs must be tgz 
+            extension = '.tgz'
+            wf_dirname = wf_filename[:len(extension)]
+            subprocess.run(['tar', 'xf', f'{wf_filename}', '--strip-components', '1'], cwd=temp_dir)
 
-        parser = CwlParser()
-        temp_cwl_path = os.path.join(temp_dir, main_cwl)
-        if yaml_file != None:
-            temp_yaml_path = os.path.join(temp_dir, yaml_file)
-            wfi = parser.parse_workflow(temp_cwl_path, temp_yaml_path)
+            parser = CwlParser()
+            temp_cwl_path = os.path.join(temp_dir, main_cwl)
+            if yaml_file != None:
+                yaml_file = yaml_file.read().decode()
+                temp_yaml_path = os.path.join(temp_dir, yaml_file)
+                wfi = parser.parse_workflow(temp_cwl_path, temp_yaml_path)
+            else:
+                wfi = parser.parse_workflow(temp_cwl_path)
+
+            # Save the workflow to the workflow_id dir
+            wf_id = wfi.workflow_id
+            workflow_dir = os.path.join(bee_workdir, 'workflows', wf_id)
+            os.makedirs(workflow_dir)
+            #workflow_path = os.path.join(workflow_dir, wf_filename)
+            #wf_tarball.save(workflow_path)
+
+            # Copy workflow files to archive
+            for f in os.listdir(temp_dir):
+                f_path = os.path.join(temp_dir, f)
+                if os.path.isfile(f_path):
+                    shutil.copy(f_path, workflow_dir)
+
+            # Create status file
+            status_path = os.path.join(workflow_dir, 'bee_wf_status')
+            with open(status_path, 'w') as status:
+                status.write('Pending')
+
+            # Create wf name file 
+            name_path = os.path.join(workflow_dir, 'bee_wf_name')
+            with open(name_path, 'w') as name:
+                name.write(job_name)
+            resp = make_response(jsonify(msg='Workflow uploaded', status='ok', wf_id=wf_id), 201)
+            return resp
         else:
-            wfi = parser.parse_workflow(temp_cwl_path)
-
-        # Save the workflow to the workflow_id dir
-        wf_id = wfi.workflow_id
-        workflow_dir = os.path.join(bee_workdir, 'workflows', wf_id)
-        os.makedirs(workflow_dir)
-        #workflow_path = os.path.join(workflow_dir, wf_filename)
-        #tarball.save(workflow_path)
-
-        # Copy workflow files to archive
-        for f in os.listdir(temp_dir):
-            f_path = os.path.join(temp_dir, f)
-            if os.path.isfile(f_path):
-                shutil.copy(f_path, workflow_dir)
-
-        # Create status file
-        status_path = os.path.join(workflow_dir, 'bee_wf_status')
-        with open(status_path, 'w') as status:
-            status.write('Pending')
-
-        # Create wf name file 
-        name_path = os.path.join(workflow_dir, 'bee_wf_name')
-        with open(name_path, 'w') as wf_name:
-            wf_name.write(name)
-        (_, tasks) = wfi.get_workflow()
-        tasks_info =  {}
-        for t in tasks:
-            print(f'{t.id} {t.name} {t.base_command}')
-            # Return  name, base_comand, and status
-            tasks_info[t.id] = {'name': t.name, 'command':t.base_command, 'status':'WAITING'}
-        resp = make_response(jsonify(msg='Workflow uploaded', status='ok', wf_id=wf_id, tasks=tasks_info), 201)
-        return resp
+            resp = make_response(jsonify(msg='File corrupted', status='error'), 400)
+            return resp
 
 
     def put(self):
-        global wfi
         """ReExecute a workflow"""
         global reeexecute
         data = self.reqparse.parse_args()
-        print(data)
         if data['workflow_archive'] == "":
             resp = make_response(jsonify(msg='No file found', status='error'), 400)
             return resp
 
         workflow_archive = data['workflow_archive']
-        job_name = data['name']
+        filename = data['wf_filename'].read().decode()
+        job_name = data['wf_name'].read().decode()
 
         if workflow_archive:
             # Make a temp directory to store the archive
             tmp_path = tempfile.mkdtemp()
-            archive_path = os.path.join(tmp_path, workflow_archive.filename)
+            archive_path = os.path.join(tmp_path, filename)
             workflow_archive.save(archive_path)
             # Extract to tmp directory
             subprocess.run(['tar', '-xf', archive_path, '-C', tmp_path])
@@ -333,7 +330,7 @@ class JobsList(Resource):
             remove_gdb()
 
             # Copy GDB to gdb_workdir
-            archive_dir = workflow_archive.filename.split('.')[0]
+            archive_dir = filename.split('.')[0]
             gdb_path = os.path.join(tmp_path, archive_dir, 'gdb')
             gdb_workdir = os.path.join(bee_workdir, 'current_gdb')
 
@@ -343,11 +340,9 @@ class JobsList(Resource):
             script_path = get_script_path()
             subprocess.run([f'{script_path}/start_gdb.py', '--gdb_workdir', gdb_workdir, '--reexecute'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             time.sleep(10)
+
             # Initialize the database connection object
-            wfi = WorkflowInterface(user='neo4j', bolt_port=bc.userconfig.get('graphdb', 'bolt_port'),
-                    db_hostname=bc.userconfig.get('graphdb', 'hostname'),
-                                password=bc.userconfig.get('graphdb', 'dbpass'))
-            #wfi.initialize_workflow(name=name, inputs=None, outputs=None)
+            wfi.initialize_workflow(inputs=None, outputs=None, existing=True)
             # Reset the workflow state and generate a new workflow ID
             wfi.reset_workflow()
             wf_id = wfi.workflow_id
@@ -375,17 +370,14 @@ class JobsList(Resource):
     def patch(self):
         """Copy workflow archive"""
         data = self.reqparse.parse_args()
-        wf_id = data['wf_id']
+        wf_id = data['wf_id'].read().decode()
         archive_path = os.path.join(bee_workdir, 'archives', wf_id + '.tgz')
-        #with open(archive_path, 'rb') as a:
-        #   archive_file = a.read()
-        #archive_filename = os.path.basename(archive_path)
-        #resp = make_response(jsonify(archive_file=archive_file, 
-        #    archive_filename=archive_filename), 200)
-        #return resp
-        #print(archive_filename)
-        #print(archive_path)
-        return send_file(archive_path, as_attachment=True, attachment_filename=f'{wf_id}.tgz')
+        with open(archive_path, 'rb') as a:
+           archive_file = jsonpickle.encode(a.read())
+        archive_filename = os.path.basename(archive_path)
+        resp = make_response(jsonify(archive_file=archive_file, 
+            archive_filename=archive_filename), 200)
+        return resp
 
 
 # Submit tasks to the TM
@@ -408,8 +400,7 @@ def submit_tasks_scheduler(sched_tasks):
     # The workflow name will eventually be added to the wfi workflow object
     resp = requests.put(_resource('sched', "workflows/workflow/jobs"), json=sched_tasks)
     if resp.status_code != 200:
-        #log.info(f"Something bad happened {resp.status_code}")
-        pass
+        log.info(f"Something bad happened {resp.status_code}")
     return resp.json()
 
 
@@ -481,6 +472,7 @@ class JobActions(Resource):
         self.reqparse.add_argument('option', type=str, location='json')
 
     @staticmethod
+    @validate_wf_id
     def post(wf_id):
         """Start job. Send tasks to the task manager."""
         # Get dependent tasks that branch off of bee_init and send to the scheduler
@@ -501,35 +493,27 @@ class JobActions(Resource):
         return "Started Workflow"
 
     @staticmethod
+    @validate_wf_id
     def get(wf_id):
         """Check the database for the current status of all the tasks."""
-        wf_id = wfi.workflow_id
-        workflow_dir = os.path.join(bee_workdir, 'workflows', wf_id)
-        status_path = os.path.join(workflow_dir, 'bee_wf_status')
-        with open(status_path, 'r') as status:
-            wf_status = status.read().split()
-
-        tasks_info =  {}
-        if wfi != None:
-            (_, tasks) = wfi.get_workflow()
-            for task in tasks:
-                # Return  name, base_comand, and status
-                tasks_info[task.id] = {'status':wfi.get_task_state(task), 'name':task.name}
-        else:
-            if wf_status == 'Cancelled':
-                pass
-        resp = make_response(jsonify(status='ok', tasks=tasks_info, wf=wf_status), 200)
+        (_, tasks) = wfi.get_workflow()
+        task_status = ""
+        for task in tasks:
+            if task.name != "bee_init" and task.name != "bee_exit":
+                task_status += f"{task.name}--{wfi.get_task_state(task)}\n"
+        log.info("Returned query")
+        resp = make_response(jsonify(msg=task_status, status='ok'), 200)
         return resp
 
     @staticmethod
+    @validate_wf_id
     def delete(wf_id):
         """Send a request to the task manager to cancel any ongoing tasks."""
-        # TODO needs to be updated to only cancel tasks realated to this workflow
         resp = requests.delete(_resource('tm'))
         if resp.status_code != 200:
             log.info(f"Delete from task manager returned bad status: {resp.status_code}")
         wf_id = wfi.workflow_id
-        workflow_dir = os.path.join(bee_workdir, 'workflows', wf_id)
+        workflows_dir = os.path.join(bee_workdir, 'workflows')
         status_path = os.path.join(workflow_dir, 'bee_wf_status')
         with open(status_path, 'w') as status:
             status.write('Cancelled')
@@ -541,12 +525,12 @@ class JobActions(Resource):
         resp = make_response(jsonify(status='cancelled'), 202)
         return resp
 
+    @validate_wf_id
     def patch(self, wf_id):
         """Pause or resume workflow."""
         global WORKFLOW_PAUSED
         # Stop sending jobs to the task manager
         data = self.reqparse.parse_args()
-        print(data)
         option = data['option']
         if option == 'pause':
             WORKFLOW_PAUSED = True
@@ -589,11 +573,9 @@ class JobUpdate(Resource):
         task_id = data['task_id']
         job_state = data['job_state']
 
-        if wfi:
-            task = wfi.get_task_by_id(task_id)
-            wfi.set_task_state(task, job_state)
-        else:
-            return
+
+        task = wfi.get_task_by_id(task_id)
+        wfi.set_task_state(task, job_state)
 
         if 'metadata' in data:
             if data['metadata'] != None:
@@ -668,3 +650,4 @@ if __name__ == '__main__':
     # Putting this off for another issue so noqa to appease the lama
     flask_app.logger.addHandler(handler) #noqa
     flask_app.run(debug=True, port=str(wfm_listen_port))
+

--- a/src/beeflow/wf_manager.py
+++ b/src/beeflow/wf_manager.py
@@ -513,7 +513,7 @@ class JobActions(Resource):
         if resp.status_code != 200:
             log.info(f"Delete from task manager returned bad status: {resp.status_code}")
         wf_id = wfi.workflow_id
-        workflows_dir = os.path.join(bee_workdir, 'workflows')
+        workflow_dir = os.path.join(bee_workdir, 'workflows')
         status_path = os.path.join(workflow_dir, 'bee_wf_status')
         with open(status_path, 'w') as status:
             status.write('Cancelled')


### PR DESCRIPTION
Workflow IDs are generated using UUID, which in their hex representation are 32 characters long, making them inconvenient and unwieldy for users. This PR adds support for shortened workflow IDs and resolves #422.

Changes:
* Workflow ID generation refactored to `Workflow.generate_workflow_id()` method
* Workflow name removed from ID, leaving only UUID
* Client supports user-side shortened workflow IDs
  * Full-length IDs still stored in database
  * Shortened 6-character IDs presented to user by default
  * Checks for short ID collisions when workflows are added/re-executed, increments short ID length if any detected
  * All client functions that accept workflow IDs as user input can now take partial workflow IDs, matching them against full IDs from job list
    * `start_workflow()`
    * `query_workflow()`
    * `cancel_workflow()`
    * `pause_workflow()`
    * `resume_workflow()`
    * `copy_workflow()`
  * Client `list_workflows()` function now displays shortened workflow IDs