### PR TITLE
Issue446/allow tgz

### DIFF
--- a/src/beeflow/common/build/container_drivers.py
+++ b/src/beeflow/common/build/container_drivers.py
@@ -200,7 +200,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
             log.info('No image specified and no image required, nothing to do.')
             return 0
 
-        # DetermVine name for successful build target
+        # Determine name for successful build target
         ch_build_addr = addr.replace('/', '%')
 
         ch_build_target = '/'.join([self.container_archive, ch_build_addr]) + '.tar.gz'
@@ -449,7 +449,8 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         if self.container_name:
             copy_target = '/'.join([self.container_archive, self.container_name + '.tar.gz'])
         else:
-            copy_target = '/'.join([self.container_archive, os.path.basename(task_container_path)])
+            copy_target = '/'.join([self.container_archive,
+                                    crt_driver.get_ccname(task_container_path) + '.tar.gz'])
         log.info('Build will copy a container to {}'.format(copy_target))
         # Return if image already exist and force==False.
         if os.path.exists(copy_target) and not force:

--- a/src/beeflow/common/build/container_drivers.py
+++ b/src/beeflow/common/build/container_drivers.py
@@ -139,24 +139,22 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         try:
             requirement_DockerRequirements = self.task.requirements['DockerRequirement'].keys()
             dockerRequirements = dockerRequirements.union(requirement_DockerRequirements)
-            log.info('task {} requirement DockerRequirements: {}'.
-                     format(self.task.id, set(requirement_DockerRequirements)))
+            req_string = (f'{set(requirement_DockerRequirements)}')
+            log.info(f'task {self.task.id} requirement DockerRequirements: {req_string}')
         except (TypeError, KeyError):
-            log.info('task {} requirements has no DockerRequirements'.format(self.task.id))
+            log.info(f'task {self.task.name} {self.task.id} no DockerRequirements in requirement')
         try:
             hint_DockerRequirements = self.task.hints['DockerRequirement'].keys()
             dockerRequirements = dockerRequirements.union(hint_DockerRequirements)
-            log.info('task {} hint DockerRequirements: {}'.format(self.task.id,
-                                                                  set(hint_DockerRequirements)))
+            hint_str = (f'{set(hint_DockerRequirements)}')
+            log.info(f'task {self.task.name} {self.task.id} hint DockerRequirements: {hint_str}')
         except (TypeError, KeyError):
-            log.info('task {} hints has no DockerRequirements'.format(self.task.id))
-        log.info('task {} union DockerRequirements consist of: {}'.format(self.task.id,
-                                                                          dockerRequirements))
+            log.info(f'task {self.task.name} {self.task.id} hints has no DockerRequirements')
+        log.info(f'task {self.task.id} union DockerRequirements : {dockerRequirements}')
         exec_superset = self.resolve_priority()
         self.exec_list = [i for i in exec_superset if i[1] in dockerRequirements]
         log_exec_list = [i[1] for i in self.exec_list]
-        log.info('task {} DockerRequirement execution order will be: {}'.format(self.task.id,
-                                                                                log_exec_list))
+        log.info(f'task {self.task.id} DockerRequirement execution order will be: {log_exec_list}')
         log.info('Execution order pre-empts hint/requirement status.')
 
     def dockerPull(self, addr=None, force=False):
@@ -216,13 +214,14 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
             except FileNotFoundError:
                 pass
             try:
-                shutil.rmtree('/var/tmp/'+os.getlogin()+'/ch-image/'+ch_build_addr)
+                shutil.rmtree('/var/tmp/' + os.getlogin() + '/ch-image/' + ch_build_addr)
             except FileNotFoundError:
                 pass
 
         # Out of excuses. Pull the image.
         cmd = (f'ch-image pull {addr}\n'
-               f'ch-convert -i ch-image -o tar {ch_build_addr} {self.container_archive}/{ch_build_addr}.tar.gz'
+               f'ch-convert -i ch-image -o tar {ch_build_addr}'
+               f' {self.container_archive}/{ch_build_addr}.tar.gz'
                )
         return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                               check=True, shell=True)
@@ -289,13 +288,13 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         # Create context directory to use as Dockerfile context, use container name so user
         # can prep the directory with COPY sources as needed.
         context_dir = os.path.expanduser('~')
-        log.info('Context directory will be {}.'.format(context_dir))
+        log.info(f'Context directory will be {context_dir}')
 
         # Determine name for successful build target
         ch_build_addr = self.container_name.replace('/', '%')
 
         ch_build_target = '/'.join([self.container_archive, ch_build_addr]) + '.tar.gz'
-        log.info('Build will create tar ball at {}'.format(ch_build_target))
+        log.info(f'Build will create tar ball at {ch_build_target}')
         # Return if image already exist and force==False.
         if os.path.exists(ch_build_target) and not force:
             return 0
@@ -306,16 +305,17 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
             except FileNotFoundError:
                 pass
             try:
-                shutil.rmtree('/var/tmp/'+os.getlogin()+'/ch-image/'+ch_build_addr)
+                shutil.rmtree('/var/tmp/' + os.getlogin() + '/ch-image/' + ch_build_addr)
             except FileNotFoundError:
                 pass
 
         # Out of excuses. Build the image.
         log.info('Context directory configured. Beginning build.')
         cmd = (f'ch-image build -t {self.container_name} -f {task_dockerfile} {context_dir}\n'
-               f'ch-convert -i ch-image -o tar {ch_build_addr} {self.container_archive}/{ch_build_addr}.tar.gz'
+               f'ch-convert -i ch-image -o tar {ch_build_addr} '
+               f'{self.container_archive}/{ch_build_addr}.tar.gz'
                )
-        log.info('Executing: {}'.format(cmd))
+        log.info(f'Executing: {cmd}')
         return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                               check=True, shell=True)
 
@@ -354,7 +354,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         # Pull the image.
         file_name = crt_driver.get_ccname(import_input_path)
         cmd = (f'ch-convert {import_input_path} {self.deployed_image_root}/{file_name}')
-        log.info(f'Docker import: Assuming container name is {import_input_path}. Is this correct?')
+        log.info(f'Docker import: Assuming container name is {import_input_path}. Correct?')
         return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                               check=True, shell=True)
 
@@ -451,7 +451,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         else:
             copy_target = '/'.join([self.container_archive,
                                     crt_driver.get_ccname(task_container_path) + '.tar.gz'])
-        log.info('Build will copy a container to {}'.format(copy_target))
+        log.info(f'Build will copy a container to {copy_target}')
         # Return if image already exist and force==False.
         if os.path.exists(copy_target) and not force:
             log.info('Container by this name exists in archive. Taking no action.')
@@ -466,7 +466,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         log.info('Copying container.')
         cmd = (f'cp {task_container_path} {copy_target}\n'
                )
-        log.info('Executing: {}'.format(cmd))
+        log.info(f'Executing: {cmd}')
         return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                               check=True, shell=True)
 

--- a/src/beeflow/common/crt_drivers.py
+++ b/src/beeflow/common/crt_drivers.py
@@ -163,6 +163,7 @@ class CharliecloudDriver(ContainerRuntimeDriver):
             except (KeyError, TypeError):
                 # Task Requirements are not mandatory. No dockerPull image specified in task reqs.
                 req_addr = None
+
             # Prefer requirements over hints
             if req_addr:
                 task_addr = req_addr

--- a/src/beeflow/common/crt_drivers.py
+++ b/src/beeflow/common/crt_drivers.py
@@ -113,7 +113,7 @@ class CharliecloudDriver(ContainerRuntimeDriver):
             req_container_name = None
 
         # Prefer requirements over hints
-        if (req_container_name or hint_container_name) and (not hint_container_name):
+        if req_container_name:
             task_container_name = req_container_name
         elif hint_container_name:
             task_container_name = hint_container_name
@@ -139,7 +139,7 @@ class CharliecloudDriver(ContainerRuntimeDriver):
                 req_container_path = None
 
             # Prefer requirements over hints
-            if (req_container_path or hint_container_path) and (not hint_container_path):
+            if req_container_path:
                 task_container_path = req_container_path
             elif hint_container_path:
                 task_container_path = hint_container_path
@@ -165,7 +165,7 @@ class CharliecloudDriver(ContainerRuntimeDriver):
                 req_addr = None
 
             # Prefer requirements over hints
-            if (req_addr or hint_addr) and (not hint_addr):
+            if req_addr or hint_addr:
                 task_addr = req_addr
             elif hint_addr:
                 task_addr = hint_addr

--- a/src/beeflow/common/crt_drivers.py
+++ b/src/beeflow/common/crt_drivers.py
@@ -175,7 +175,7 @@ class CharliecloudDriver(ContainerRuntimeDriver):
                 log.info('Found dockerPull address, assuming this contains the container name.')
                 if len(runtime_target_list) > 1:
                     raise RuntimeError(
-                        'Too many container runtimes specified! Pick a maximum of one per workflow step.'
+                        'Too many container runtimes specified! Pick one per workflow step.'
                     )
             if len(runtime_target_list) == 0:
                 log.warning('No containerName specified.')
@@ -184,14 +184,13 @@ class CharliecloudDriver(ContainerRuntimeDriver):
             else:
                 # Build container name from container path.
                 task_container_name = runtime_target_list[0]
-                log.info('Moving with the expectation that {} is the runtime container target'.
-                         format(task_container_name))
+                log.info(f'Moving with expectation: {task_container_name} is the container target')
 
         if baremetal:
             return [], [str(arg) for arg in task.command], []
 
         container_path = '/'.join([container_archive, task_container_name]) + '.tar.gz'
-        log.info('Expecting container at {}. Ready to deploy and run.'.format(container_path))
+        log.info(f'Expecting container at {container_path}. Ready to deploy and run.')
 
         chrun_opts, cc_setup = self.get_cc_options()
         deployed_image_root = bc.userconfig.get('builder', 'deployed_image_root')
@@ -199,13 +198,14 @@ class CharliecloudDriver(ContainerRuntimeDriver):
         command = ' '.join(task.command)
         cc_setup = cc_setup.split()
         pre_commands = [cc_setup] if cc_setup else []
+        deployed_path = deployed_image_root + '/' + task_container_name
         pre_commands.extend([
             f'mkdir -p {deployed_image_root}\n'.split(),
-            f'ch-convert -i tar -o dir {container_path} {deployed_image_root}/{task_container_name}\n'.split()
+            f'ch-convert -i tar -o dir {container_path} {deployed_path}\n'.split()
         ])
-        main_command = f'ch-run --join {deployed_image_root}/{task_container_name} {chrun_opts} -- {command}\n'.split()
+        main_command = f'ch-run --join {deployed_path} {chrun_opts} -- {command}\n'.split()
         post_commands = [
-            f'rm -rf {deployed_image_root}/{task_container_name}\n'.split(),
+            f'rm -rf {deployed_path}\n'.split(),
         ]
         return pre_commands, main_command, post_commands
 

--- a/src/beeflow/common/crt_drivers.py
+++ b/src/beeflow/common/crt_drivers.py
@@ -163,9 +163,8 @@ class CharliecloudDriver(ContainerRuntimeDriver):
             except (KeyError, TypeError):
                 # Task Requirements are not mandatory. No dockerPull image specified in task reqs.
                 req_addr = None
-
             # Prefer requirements over hints
-            if req_addr or hint_addr:
+            if req_addr:
                 task_addr = req_addr
             elif hint_addr:
                 task_addr = hint_addr

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf/clamr.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf/clamr.cwl
@@ -3,7 +3,7 @@
 class: CommandLineTool
 cwlVersion: v1.0
 
-baseCommand: /CLAMR/clamr_cpuonly
+baseCommand: /clamr/CLAMR-master/clamr_cpuonly
 # This is the stdout field which makes all stdout be captured in this file
 # stderr is not currently implemented but it is also a thing
 stdout: clamr_stdout.txt


### PR DESCRIPTION
This PR fixes the problem with using copyContainer for an image tar with extension .tgz

After preprocessing DockerRequirements, the builder places an image in the container_archive and that is always a tar.gz file. So the run scripts will use that copy.



