### PR TITLE
Wfi/restart task

### DIFF
--- a/src/beeflow/common/gdb/gdb_driver.py
+++ b/src/beeflow/common/gdb/gdb_driver.py
@@ -71,6 +71,27 @@ class GraphDatabaseDriver(ABC):
 
         Runnable tasks are tasks with all input dependencies fulfilled.
         """
+    
+    @abstractmethod
+    def restart_task(self, old_task, new_task):
+        """Restart a failed task.
+        
+        Create a Task node for new_task with state 'RESTARTED' and an edge
+        to indicate that it is the child of the Task node of old_task.
+
+        :param old_task: the failed task
+        :type old_task: Task
+        :param new_task: the new (restarted) task
+        :type new_task: Task
+        """
+
+    @abstractmethod
+    def finalize_task(self, task):
+        """Set task state to 'COMPLETED' and set inputs from source.
+        
+        :param task: the task to finalize
+        :type task: Task
+        """
 
     @abstractmethod
     def get_task_by_id(self, task_id):
@@ -148,13 +169,11 @@ class GraphDatabaseDriver(ABC):
         """
 
     @abstractmethod
-    def get_task_metadata(self, task, keys):
+    def get_task_metadata(self, task):
         """Return the metadata of a task in the graph database.
 
         :param task: the task whose metadata to retrieve
         :type task: Task
-        :param keys: the metadata keys whose values to retrieve
-        :type keys: iterable of str
         :rtype: dict
         """
 

--- a/src/beeflow/common/gdb/neo4j_cypher.py
+++ b/src/beeflow/common/gdb/neo4j_cypher.py
@@ -424,9 +424,9 @@ def set_task_metadata(tx, task, metadata):
     for k, v in metadata.items():
         # Manual sanitization needed for keys as the official Neo4j driver does not
         # currently support parameter substitution for property keys
-        if fullmatch(r"[A-Za-z_][0-9A-Za-z_]*", k) is None:
+        if fullmatch(r"[A-Za-z][0-9A-Za-z_]*", k) is None:
             raise ValueError(f"invalid metadata key: {k}")
-        metadata_query = f"MATCH (m:Metadata)-[:DESCRIBES]->(:Task {id: $task_id}) SET m.{k} = $value"
+        metadata_query = f"MATCH (m:Metadata)-[:DESCRIBES]->(:Task {{id: $task_id}}) SET m.{k} = $value"
 
         tx.run(metadata_query, task_id=task.id, value=v)
 

--- a/src/beeflow/common/gdb/neo4j_cypher.py
+++ b/src/beeflow/common/gdb/neo4j_cypher.py
@@ -3,14 +3,6 @@
 from re import fullmatch
 
 
-def constrain_tasks_unique(tx):
-    """Constrain tasks to have unique names."""
-    unique_task_query = ("CREATE CONSTRAINT ON (t:Task) "
-                         "ASSERT t.id IS UNIQUE")
-
-    tx.run(unique_task_query)
-
-
 def create_workflow_node(tx, workflow):
     """Create a Workflow node in the Neo4j database.
 

--- a/src/beeflow/common/gdb/neo4j_cypher.py
+++ b/src/beeflow/common/gdb/neo4j_cypher.py
@@ -422,6 +422,8 @@ def set_task_metadata(tx, task, metadata):
     :type metadata: dict
     """
     for k, v in metadata.items():
+        # Manual sanitization needed for keys as the official Neo4j driver does not
+        # currently support parameter substitution for property keys
         if fullmatch(r"[A-Za-z_][0-9A-Za-z_]*", k) is None:
             raise ValueError(f"invalid metadata key: {k}")
         metadata_query = f"MATCH (m:Metadata)-[:DESCRIBES]->(:Task {id: $task_id}) SET m.{k} = $value"

--- a/src/beeflow/common/gdb/neo4j_driver.py
+++ b/src/beeflow/common/gdb/neo4j_driver.py
@@ -144,7 +144,8 @@ class Neo4jDriver(GraphDatabaseDriver):
             session.write_transaction(tx.create_task_input_nodes, task=new_task)
             session.write_transaction(tx.create_task_output_nodes, task=new_task)
             session.write_transaction(tx.create_task_metadata_node, task=new_task)
-            session.write_transaction(tx.add_dependencies, task=new_task, restarted_task=True)
+            session.write_transaction(tx.add_dependencies, task=new_task, old_task=old_task,
+                                      restarted_task=True)
 
     def finalize_task(self, task):
         """Set task state to 'COMPLETED' and set inputs from source.

--- a/src/beeflow/common/gdb/neo4j_driver.py
+++ b/src/beeflow/common/gdb/neo4j_driver.py
@@ -559,4 +559,4 @@ def _reconstruct_metadata(metadata_record):
     :rtype: dict
     """
     rec = metadata_record["m"]
-    return {key: val for key, val in rec.items()}
+    return {key: val for key, val in rec.items() if key != "state"}

--- a/src/beeflow/common/gdb/neo4j_driver.py
+++ b/src/beeflow/common/gdb/neo4j_driver.py
@@ -549,7 +549,7 @@ def _reconstruct_task(task_record, hints, requirements, inputs, outputs):
                 workflow_id=rec["workflow_id"], task_id=rec["id"])
 
 
-def _reconstruct_metadata(metadata_record, keys):
+def _reconstruct_metadata(metadata_record):
     """Reconstruct a dict containing the job description metadata retrieved from Neo4j.
 
     :param metadata_record: the database record of the metadata

--- a/src/beeflow/common/gdb/neo4j_driver.py
+++ b/src/beeflow/common/gdb/neo4j_driver.py
@@ -46,8 +46,6 @@ class Neo4jDriver(GraphDatabaseDriver):
         try:
             # Connect to the Neo4j database using the Neo4j proprietary driver
             self._driver = Neo4jDatabase.driver(uri, auth=(user, password))
-            # Require tasks to have unique names
-            self._require_tasks_unique()
         except ServiceUnavailable:
             print("Neo4j database unavailable. Is it running?")
 
@@ -391,10 +389,6 @@ class Neo4jDriver(GraphDatabaseDriver):
         outputs = [_reconstruct_task_outputs(output_record) for output_record in output_records]
 
         return list(zip(trecords, hints, reqs, inputs, outputs))
-
-    def _require_tasks_unique(self):
-        """Require tasks to have unique names."""
-        self._write_transaction(tx.constrain_tasks_unique)
 
     def _read_transaction(self, tx_fun, **kwargs):
         """Run a Neo4j read transaction.

--- a/src/beeflow/common/gdb_interface.py
+++ b/src/beeflow/common/gdb_interface.py
@@ -82,6 +82,16 @@ class GraphDatabaseInterface:
     def initialize_ready_tasks(self):
         """Set runnable tasks in a workflow to ready."""
         self._connection.initialize_ready_tasks()
+    
+    def restart_task(self, old_task, new_task):
+        """Create a new task from a failed task checkpoint restart enabled.
+        
+        :param old_task: the failed task
+        :type old_task: Task
+        :param new_task: the new (restarted) task
+        :type new_task: Task
+        """
+        self._connection.restart_task(old_task, new_task)
 
     def finalize_task(self, task):
         """Set a task's state to completed.
@@ -158,16 +168,14 @@ class GraphDatabaseInterface:
         """
         return self._connection.set_task_state(task, state)
 
-    def get_task_metadata(self, task, keys):
+    def get_task_metadata(self, task):
         """Return the job description metadata of a task.
 
         :param task: the task whose metadata to retrieve
         :type task: Task
-        :param keys: the metadata keys whose values to retrieve
-        :type keys: iterable of str
         :rtype: dict
         """
-        return self._connection.get_task_metadata(task, keys)
+        return self._connection.get_task_metadata(task)
 
     def set_task_metadata(self, task, metadata):
         """Set the job description metadata of a task.

--- a/src/beeflow/common/wf_data.py
+++ b/src/beeflow/common/wf_data.py
@@ -63,8 +63,10 @@ class Workflow:
         Currently, the code is boilerplate. We do not support multiple workflows.
 
         :param other: the workflow with which to test equality
-        :type other: instance of Workflow
+        :type other: Workflow
         """
+        if type(other) is not Workflow:
+            return False
         id_sort = lambda i: i.id
         return bool(self.name == other.name and
                     sorted(self.hints) == sorted(other.hints) and
@@ -76,7 +78,7 @@ class Workflow:
         """Test the inequality of two workflows.
 
         :param other: the workflow with which to test inequality
-        :type other: instance of Workflow
+        :type other: Workflow
         """
         return bool(not self.__eq__(other))
 
@@ -161,9 +163,11 @@ class Task:
 
         Task ID and dependencies do not factor into equality testing.
         :param other: the task with which to test equality
-        :type other: instance of Task
+        :type other: Task
         :rtype: bool
         """
+        if type(other) is not Task:
+            return False
         id_sort = lambda i: i.id
         return bool(self.name == other.name and
                     self.base_command == other.base_command and
@@ -177,7 +181,7 @@ class Task:
         """Test the inequality of two tasks.
 
         :param other: the task with which to test inequality
-        :type other: instance of Task
+        :type other: Task
         :rtype: bool
         """
         return bool(not self.__eq__(other))

--- a/src/beeflow/common/wf_data.py
+++ b/src/beeflow/common/wf_data.py
@@ -128,15 +128,33 @@ class Task:
         if task_id:
             self.id = task_id
         else:
-            self.id = str(uuid4())
+            self.id = self.generate_workflow_id()
 
-    def copy(self):
-        """Make a copy of this task."""
-        return Task(name=self.name, base_command=self.base_command,
-                    hints=self.hints, requirements=self.requirements,
-                    inputs=self.inputs, outputs=self.outputs,
-                    stdout=self.stdout, workflow_id=self.workflow_id,
-                    task_id=self.id)
+    def generate_workflow_id(self):
+        """Generate a unique workflow ID.
+        
+        :rtype: str
+        """
+        return uuid4().hex
+
+    def copy(self, new_id=False):
+        """Make a copy of this task.
+        
+        :param new_id: generate a new task ID
+        :type new_id: bool
+        :rtype: Task
+        """
+        if new_id:
+            return Task(name=self.name, base_command=self.base_command,
+                        hints=self.hints, requirements=self.requirements,
+                        inputs=self.inputs, outputs=self.outputs,
+                        stdout=self.stdout, workflow_id=self.workflow_id)
+        else:
+            return Task(name=self.name, base_command=self.base_command,
+                        hints=self.hints, requirements=self.requirements,
+                        inputs=self.inputs, outputs=self.outputs,
+                        stdout=self.stdout, workflow_id=self.workflow_id,
+                        task_id=self.id)
 
     def __eq__(self, other):
         """Test the equality of two tasks.
@@ -144,6 +162,7 @@ class Task:
         Task ID and dependencies do not factor into equality testing.
         :param other: the task with which to test equality
         :type other: instance of Task
+        :rtype: bool
         """
         id_sort = lambda i: i.id
         return bool(self.name == other.name and
@@ -159,15 +178,22 @@ class Task:
 
         :param other: the task with which to test inequality
         :type other: instance of Task
+        :rtype: bool
         """
         return bool(not self.__eq__(other))
 
     def __hash__(self):
-        """Return the hash value for a task."""
+        """Return the hash value for a task.
+        
+        :rtype: int
+        """
         return hash((self.id, self.workflow_id, self.name))
 
     def __repr__(self):
-        """Construct a task's string representation."""
+        """Construct a task's string representation.
+        
+        :rtype: str
+        """
         return (f"<Task id={self.id} name={self.name} base_command={self.base_command} "
                 f"hints={self.hints} requirements = {self.requirements} "
                 f"inputs={self.inputs} outputs={self.outputs} stdout={self.stdout} "
@@ -204,5 +230,14 @@ class Task:
             if input_.prefix is not None:
                 command.append(input_.prefix)
             command.append(str(input_.value))
+        
+        # Append restart parameter and checkpoint file if CheckpointRequirement specified
+        for hint in self.hints:
+            if hint.class_ == "beeflow:CheckpointRequirement":
+                if "bee_checkpoint_file__" in hint.params:
+                    if "restart_parameters" in hint.params:
+                        command.append(hint.params["restart_parameters"])
+                    command.append(hint.params["bee_checkpoint_file__"])
+                break
 
         return command

--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -148,7 +148,8 @@ class WorkflowInterface:
         metadata = self.get_task_metadata(new_task)
         self._gdb_interface.restart_task(task, new_task)
         self.set_task_metadata(new_task, metadata)
-        self.set_task_state(new_task, "RESTARTED")
+        self.set_task_state(task, "RESTARTED")
+        self.set_task_state(new_task, "READY")
         return new_task
 
     def finalize_task(self, task):

--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -136,7 +136,7 @@ class WorkflowInterface:
         new_task = task.copy(new_id=True)
         for hint in new_task.hints:
             if hint.class_ == "beeflow:CheckpointRequirement":
-                if hint["num_tries"] > 0:
+                if hint.params["num_tries"] > 0:
                     hint.params["num_tries"] -= 1
                     hint.params["bee_checkpoint_file__"] = checkpoint_file
                     break

--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -3,6 +3,8 @@
 Delegates its work to a GraphDatabaseInterface instance.
 """
 
+import re
+
 from beeflow.common.gdb_interface import GraphDatabaseInterface
 from beeflow.common.wf_data import Workflow, Task
 
@@ -145,6 +147,15 @@ class WorkflowInterface:
             raise ValueError("invalid task for checkpoint restart")
 
         new_task = task.copy(new_id=True)
+        # Pattern match on task name
+        # Append (1) if not in name already
+        # Increment number on each restart
+        match = re.match(r".+\(([0-9]+)\)$", new_task.name)
+        if not match:
+            new_task.name += "(1)"
+        else:
+            i = int(match.group(1))
+            new_task.name = re.sub(r"\([0-9]+\)", f"({i + 1})", new_task.name)
         metadata = self.get_task_metadata(task)
         self._gdb_interface.restart_task(task, new_task)
         self.set_task_metadata(new_task, metadata)

--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -133,8 +133,7 @@ class WorkflowInterface:
         :type task: Task
         :rtype: Task or None
         """
-        new_task = task.copy(new_id=True)
-        for hint in new_task.hints:
+        for hint in task.hints:
             if hint.class_ == "beeflow:CheckpointRequirement":
                 if hint.params["num_tries"] > 0:
                     hint.params["num_tries"] -= 1
@@ -145,6 +144,7 @@ class WorkflowInterface:
         else:
             raise ValueError("invalid task for checkpoint restart")
 
+        new_task = task.copy(new_id=True)
         metadata = self.get_task_metadata(task)
         self._gdb_interface.restart_task(task, new_task)
         self.set_task_metadata(new_task, metadata)

--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -148,6 +148,7 @@ class WorkflowInterface:
         metadata = self.get_task_metadata(new_task)
         self._gdb_interface.restart_task(task, new_task)
         self.set_task_metadata(new_task, metadata)
+        self.set_task_state(new_task, "RESTARTED")
         return new_task
 
     def finalize_task(self, task):

--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -145,7 +145,7 @@ class WorkflowInterface:
         else:
             raise ValueError("invalid task for checkpoint restart")
 
-        metadata = self.get_task_metadata(new_task)
+        metadata = self.get_task_metadata(task)
         self._gdb_interface.restart_task(task, new_task)
         self.set_task_metadata(new_task, metadata)
         self.set_task_state(task, "RESTARTED")

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-checkpoint/clamr_wf.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-checkpoint/clamr_wf.cwl
@@ -57,10 +57,9 @@ steps:
             #copyContainer: clamr
             copyContainer: "/usr/projects/beedev/clamr/clamr-toss.tar.gz"   
         beeflow:CheckpointRequirement:
-            enabled: true
             file_path: checkpoint_output
             file_regex: backup[0-9]*.crx 
-            restart_parameters: -R $(checkpoint_file)  
+            restart_parameters: -R
             num_tries: 3
             
   ffmpeg:

--- a/src/beeflow/tests/test_wf_interface.py
+++ b/src/beeflow/tests/test_wf_interface.py
@@ -353,7 +353,7 @@ class TestWorkflowInterface(unittest.TestCase):
                     "container_md5": "67df538c1b6893f4276d10b2af34ccfe", "job_id": 1337}
 
         self.wfi.set_task_metadata(task, metadata)
-        self.assertDictEqual(metadata, self.wfi.get_task_metadata(task, metadata.keys()))
+        self.assertDictEqual(metadata, self.wfi.get_task_metadata(task))
 
     def test_set_task_metadata(self):
         """Test the setting of task metadata."""
@@ -369,10 +369,9 @@ class TestWorkflowInterface(unittest.TestCase):
             [StepOutput("test_task/output", "File", "output.txt", "output.txt")])
         metadata = {"cluster": "fog", "crt": "charliecloud",
                     "container_md5": "67df538c1b6893f4276d10b2af34ccfe", "job_id": 1337}
-        empty_metadata = {"cluster": None, "crt": None, "container_md5": None, "job_id": None}
 
         # Metadata should be empty
-        self.assertDictEqual(empty_metadata, self.wfi.get_task_metadata(task, metadata.keys()))
+        self.assertDictEqual(dict(), self.wfi.get_task_metadata(task))
 
         self.wfi.set_task_metadata(task, metadata)
 

--- a/src/beeflow/tests/test_wf_interface.py
+++ b/src/beeflow/tests/test_wf_interface.py
@@ -123,7 +123,6 @@ class TestWorkflowInterface(unittest.TestCase):
         tasks = self._create_test_tasks()
         metadata = {"cluster": "fog", "crt": "charliecloud",
                     "container_md5": "67df538c1b6893f4276d10b2af34ccfe", "job_id": 1337}
-        empty_metadata = {"cluster": None, "crt": None, "container_md5": None, "job_id": None}
 
         # Set tasks' metadata, set state to COMPLETED
         for task in tasks:
@@ -135,7 +134,7 @@ class TestWorkflowInterface(unittest.TestCase):
 
         # States should be reset, metadata should be deleted
         for task in tasks:
-            self.assertDictEqual(empty_metadata, self.wfi.get_task_metadata(task, metadata.keys()))
+            self.assertDictEqual(dict(), self.wfi.get_task_metadata(task))
             self.assertEqual("WAITING", self.wfi.get_task_state(task))
 
         # Workflow ID should be reset
@@ -376,7 +375,7 @@ class TestWorkflowInterface(unittest.TestCase):
         self.wfi.set_task_metadata(task, metadata)
 
         # Metadata should now be populated
-        self.assertDictEqual(metadata, self.wfi.get_task_metadata(task, metadata.keys()))
+        self.assertDictEqual(metadata, self.wfi.get_task_metadata(task))
 
     def test_get_task_input(self):
         self.wfi.initialize_workflow(


### PR DESCRIPTION
Make necessary changes to implement automatic checkpoint restart feature:
- Add `restart_task()` method to WorkflowInterface, GraphDatabaseInterface, GraphDatabaseDriver, Neo4jDriver
  - Can only be invoked on `Task` object with a `Hint` of class `beeflow:CheckpointRequirement`
     - If `hint.params["num_tries"]` = 0, returns `None`
     - Creates proprietary field in `hint.params` called `bee_checkpoint_file__`, which stores the checkpoint filename
  - Creates copy of failed `Task` node with new Task ID, state set to `RESTARTED`
  - Copies failed `Task` metadata to new, restarted `Task`
  - Appends a number in parentheses to the new `Task` name, which increments on each restart
- Modify `add_dependencies()` Cypher function to take `restarted_task` boolean parameter
  - Deletes `DEPENDS_ON` relationships pointing to failed `Task` node
  - Add `RESTARTED_FROM` relationship pointing from restarted `Task` node to failed `Task` node
  - Create `DEPENDS_ON` relationships from dependent `Task` nodes to restarted `Task` node
- Change `get_task_metadata()` method to not take `keys` as parameter, just return entire dictionary (minus `state`)
- Added sanitation to `set_task_metadata()` Cypher function, fixing injection vulnerability
- `Task.command` property now appends values of checkpoint requirement `Hint` fields `restart_parameters` and `bee_checkpoint_file__` to end of command list if they exist
- Removes the "unique task name" constraint in Neo4j
- Add `test_restart_task` to `test_wf_interface.py`, fix broken metadata