### PR TITLE
Fix workflow_completed() not accounting for restarted tasks

### DIFF
--- a/src/beeflow/common/gdb/gdb_driver.py
+++ b/src/beeflow/common/gdb/gdb_driver.py
@@ -260,7 +260,7 @@ class GraphDatabaseDriver(ABC):
     def workflow_completed(self):
         """Determine if a workflow has completed.
 
-        A workflow has completed if each of its tasks has state 'COMPLETED'.
+        A workflow has completed if each of its final tasks has state 'COMPLETED'.
 
         :rtype: bool
         """

--- a/src/beeflow/common/gdb/neo4j_cypher.py
+++ b/src/beeflow/common/gdb/neo4j_cypher.py
@@ -625,13 +625,13 @@ def reset_workflow_id(tx, new_id):
     tx.run(reset_workflow_id_query, new_id=new_id)
 
 
-def all_tasks_completed(tx):
-    """Return true if all of a workflow's tasks have state 'COMPLETED'.
+def final_tasks_completed(tx):
+    """Return true if each of a workflow's final tasks has state 'COMPLETED'.
 
     :rtype: bool
     """
     not_completed_query = ("MATCH (m:Metadata)-[:DESCRIBES]->(t:Task) "
-                           "WHERE m.state <> 'COMPLETED' "
+                           "WHERE NOT (t)<-[:DEPENDS_ON]-(:Task) AND m.state <> 'COMPLETED' "
                            "RETURN t IS NOT NULL LIMIT 1")
 
     # False if at least one task with state not 'COMPLETED'

--- a/src/beeflow/common/gdb/neo4j_cypher.py
+++ b/src/beeflow/common/gdb/neo4j_cypher.py
@@ -626,7 +626,7 @@ def reset_workflow_id(tx, new_id):
 
 
 def final_tasks_completed(tx):
-    """Return true if each of a workflow's final tasks has state 'COMPLETED'.
+    """Return true if each of a workflow's final Task nodes has state 'COMPLETED'.
 
     :rtype: bool
     """

--- a/src/beeflow/common/gdb/neo4j_cypher.py
+++ b/src/beeflow/common/gdb/neo4j_cypher.py
@@ -631,7 +631,8 @@ def final_tasks_completed(tx):
     :rtype: bool
     """
     not_completed_query = ("MATCH (m:Metadata)-[:DESCRIBES]->(t:Task) "
-                           "WHERE NOT (t)<-[:DEPENDS_ON]-(:Task) AND m.state <> 'COMPLETED' "
+                           "WHERE NOT (t)<-[:DEPENDS_ON|:RESTARTED_FROM]-(:Task) "
+                           "AND m.state <> 'COMPLETED' "
                            "RETURN t IS NOT NULL LIMIT 1")
 
     # False if at least one task with state not 'COMPLETED'

--- a/src/beeflow/common/gdb/neo4j_driver.py
+++ b/src/beeflow/common/gdb/neo4j_driver.py
@@ -345,10 +345,10 @@ class Neo4jDriver(GraphDatabaseDriver):
     def workflow_completed(self):
         """Determine if a workflow in the Neo4j database has completed.
 
-        A workflow has completed if each of its tasks has state 'COMPLETED'.
+        A workflow has completed if each of its final tasks have state 'COMPLETED'.
         :rtype: bool
         """
-        return self._read_transaction(tx.all_tasks_completed)
+        return self._read_transaction(tx.final_tasks_completed)
 
     def empty(self):
         """Determine if the Neo4j database is empty.

--- a/src/beeflow/common/gdb/neo4j_driver.py
+++ b/src/beeflow/common/gdb/neo4j_driver.py
@@ -345,7 +345,7 @@ class Neo4jDriver(GraphDatabaseDriver):
     def workflow_completed(self):
         """Determine if a workflow in the Neo4j database has completed.
 
-        A workflow has completed if each of its final tasks have state 'COMPLETED'.
+        A workflow has completed if each of its final task nodes have state 'COMPLETED'.
         :rtype: bool
         """
         return self._read_transaction(tx.final_tasks_completed)

--- a/src/beeflow/common/gdb_interface.py
+++ b/src/beeflow/common/gdb_interface.py
@@ -294,7 +294,7 @@ class GraphDatabaseInterface:
                 raise ValueError(f"unable to evaluate expression {step_input.value_from}")
 
     def workflow_completed(self):
-        """Return true if all tasks in a workflow have state 'COMPLETED', else false.
+        """Return true if all of a workflow's final tasks have completed, else false.
 
         :rtype: bool
         """

--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -331,7 +331,7 @@ class WorkflowInterface:
         self._gdb_interface.evaluate_expression(task, id, output)
 
     def workflow_completed(self):
-        """Return true if all of a workflow's tasks have completed, else false.
+        """Return true if all of a workflow's final tasks have completed, else false.
 
         :rtype: bool
         """


### PR DESCRIPTION
- Fixed bug wherein `WorkflowInterface.workflow_completed()` was checking if **all** task nodes have state `COMPLETED` to determine if a workflow had completed.
  - This did not account for restarted tasks which have state `RESTARTED`
- This method now checks if only the final tasks in the workflow have state `COMPLETED`