### PR TITLE
Add beeflow:copyContainer to container driver and useContainer example

### DIFF
--- a/src/beeflow/common/build/build_driver.py
+++ b/src/beeflow/common/build/build_driver.py
@@ -134,7 +134,7 @@ class BuildDriver(ABC):
                     (self.dockerLoad, 'dockerLoad', 6, True),
                     (self.dockerFile, 'dockerFile', 7, True),
                     (self.dockerImport, 'dockerImport', 4, True),
-                    (self.copyContainer, 'copyContainer', 3, True),
+                    (self.copyContainer, 'beeflow:copyContainer', 3, True),
                     (self.dockerImageId, 'dockerImageId', 1, False),
                     (self.containerName, 'containerName', 2, False),
                     (self.dockerOutputDirectory, 'dockerOutputDirectory', 0, False)]

--- a/src/beeflow/common/build/container_drivers.py
+++ b/src/beeflow/common/build/container_drivers.py
@@ -357,13 +357,13 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         # Need container_path to know how dockerfile should be named, else fail
         try:
             # Try to get Hints
-            hint_container_path = self.task.hints['DockerRequirement']['copyContainer']
+            hint_container_path = self.task.hints['DockerRequirement']['beeflow:copyContainer']
         except (KeyError, TypeError):
             # Task Hints are not mandatory. No container_path specified in task hints.
             hint_container_path = None
         try:
             # Try to get Requirements
-            req_container_path = self.task.requirements['DockerRequirement']['copyContainer']
+            req_container_path = self.task.requirements['DockerRequirement']['beeflow:copyContainer']
         except (KeyError, TypeError):
             # Task Requirements are not mandatory. No container_path specified in task reqs.
             req_container_path = None
@@ -375,7 +375,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
             task_container_path = hint_container_path
 
         if not task_container_path:
-            log.error("copyContainer: You must specify the path to an existing container.")
+            log.error("beeflow:copyContainer: You must specify the path to an existing container.")
             return 1
 
         if self.container_name:

--- a/src/beeflow/common/crt_drivers.py
+++ b/src/beeflow/common/crt_drivers.py
@@ -85,7 +85,7 @@ class CharliecloudDriver(ContainerRuntimeDriver):
         task_container_name = None
         # The container runtime treats hints and requirements as dicts
         hints = dict(task.hints)
-        task.requirements = dict(task.requirements)
+        requirements = dict(task.requirements)
         try:
             # Try to get Hints
             hint_container_name = hints['DockerRequirement']['containerName']
@@ -94,7 +94,7 @@ class CharliecloudDriver(ContainerRuntimeDriver):
             hint_container_name = None
         try:
             # Try to get Requirements
-            req_container_name = task.requirements['DockerRequirement']['containerName']
+            req_container_name = requirements['DockerRequirement']['containerName']
         except (KeyError, TypeError):
             # Task Requirements are not mandatory. No container_name specified in task reqs.
             req_container_name = None
@@ -105,22 +105,23 @@ class CharliecloudDriver(ContainerRuntimeDriver):
         elif hint_container_name:
             task_container_name = hint_container_name
 
-        baremetal = False
+        baremetal = True
+        use_container = None
         if task_container_name is None:
             log.info('No container name provided.')
             log.info('Assuming another DockerRequirement is runtime target.')
             runtime_target_list = []
-            # Harvest copyContainer if it exists.
+            # Harvest beeflow:copyContainer if it exists.
             task_container_path = None
             try:
                 # Try to get Hints
-                hint_container_path = hints['DockerRequirement']['copyContainer']
+                hint_container_path = hints['DockerRequirement']['beeflow:copyContainer']
             except (KeyError, TypeError):
                 # Task Hints are not mandatory. No container_path specified in task hints.
                 hint_container_path = None
             try:
                 # Try to get Requirements
-                req_container_path = task.requirements['DockerRequirement']['copyContainer']
+                req_container_path = requirements['DockerRequirement']['beeflow:copyContainer']
             except (KeyError, TypeError):
                 # Task Requirements are not mandatory. No container_path specified in task reqs.
                 req_container_path = None
@@ -146,7 +147,7 @@ class CharliecloudDriver(ContainerRuntimeDriver):
                 hint_addr = None
             try:
                 # Try to get Requirements
-                req_addr = task.requirements['DockerRequirement']['dockerPull']
+                req_addr = requirements['DockerRequirement']['dockerPull']
             except (KeyError, TypeError):
                 # Task Requirements are not mandatory. No dockerPull image specified in task reqs.
                 req_addr = None
@@ -168,18 +169,33 @@ class CharliecloudDriver(ContainerRuntimeDriver):
             if len(runtime_target_list) == 0:
                 log.warning('No containerName specified.')
                 log.warning('Cannot be inferred from other DockerRequirements.')
-                baremetal = True
             else:
+                baremetal = False
                 # Build container name from container path.
                 task_container_name = runtime_target_list[0]
                 log.info(f'Moving with expectation: {task_container_name} is the container target')
+
+            # Check for `beeflow:useContainer` (only in hints for now)
+            try:
+                use_container = hints['DockerRequirement']['beeflow:useContainer']
+                log.info(f'Found beeflow:useContainer option. Using container {use_container}')
+                baremetal = False
+            except (KeyError, TypeError):
+                pass
 
         if baremetal:
             return ContainerRuntimeResult(env_code='', pre_commands=[],
                                           main_command=[str(arg) for arg in task.command],
                                           post_commands=[])
 
-        container_path = '/'.join([container_archive, task_container_name]) + '.tar.gz'
+        # If use_container is specified, then no copying is done and the file
+        # path is used directly
+        if use_container is not None:
+            container_path = os.path.expanduser(use_container)
+            tmp = os.path.basename(container_path)
+            task_container_name = os.path.splitext(tmp)[0]
+        else:
+            container_path = '/'.join([container_archive, task_container_name]) + '.tar.gz'
         log.info(f'Expecting container at {container_path}. Ready to deploy and run.')
 
         chrun_opts, cc_setup = self.get_cc_options()
@@ -221,7 +237,7 @@ class SingularityDriver(ContainerRuntimeDriver):
         if task.hints is not None:
             hints = dict(task.hints)
             try:
-                img = hints['DockerRequirement']['copyContainer']
+                img = hints['DockerRequirement']['beeflow:copyContainer']
                 argv = ['singularity', 'exec', img]
                 argv.extend(cmd_tasks)
                 main_command = argv

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-checkpoint/clamr_wf.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-checkpoint/clamr_wf.cwl
@@ -56,8 +56,8 @@ steps:
         DockerRequirement:
             # TODO Sort this out
             #dockerImport: clamr_img.tar.gz
-            #copyContainer: clamr
-            copyContainer: "/usr/projects/beedev/clamr/clamr-toss.tar.gz"   
+            #beeflow:copyContainer: clamr
+            beeflow:copyContainer: "/usr/projects/beedev/clamr/clamr-toss.tar.gz"
         beeflow:CheckpointRequirement:
             enabled: true
             file_path: $HOME/checkpoint_output

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-chicoma/clamr_wf.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-chicoma/clamr_wf.cwl
@@ -52,7 +52,7 @@ steps:
     out: [clamr_stdout, outdir, time_log]
     hints:
         DockerRequirement:
-            copyContainer: "/usr/projects/beedev/clamr/clamr-ffmpeg.tar.gz"
+            beeflow:copyContainer: "/usr/projects/beedev/clamr/clamr-ffmpeg.tar.gz"
 
   ffmpeg:
     run: ffmpeg.cwl
@@ -70,4 +70,4 @@ steps:
     out: [movie]
     hints:
         DockerRequirement:
-            copyContainer: "/usr/projects/beedev/clamr/clamr-ffmpeg.tar.gz"
+            beeflow:copyContainer: "/usr/projects/beedev/clamr/clamr-ffmpeg.tar.gz"

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-noyaml/lsf-charliecloud/cf-summit.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-noyaml/lsf-charliecloud/cf-summit.cwl
@@ -29,7 +29,7 @@ steps:
       baseCommand: "/CLAMR/clamr_cpuonly -n 32 -l 3 -t 5000 -i 10 -g 25 -G png"
       hints:
         DockerRequirement:
-          copyContainer: "/ccs/proj/csc420/BEE/clamr-ppc64le.tar.gz"
+          beeflow:copyContainer: "/ccs/proj/csc420/BEE/clamr-ppc64le.tar.gz"
     in:
       infile: infile
     out: [outfile]
@@ -47,7 +47,7 @@ steps:
       baseCommand: "ffmpeg -f image2 -i /home/$USER/graphics_output/graph%05d.png -r 12 -s 800x800 -pix_fmt yuv420p /home/$USER/CLAMR_movie.mp4 && ls -ld"
       hints:
         DockerRequirement:
-          copyContainer: "/ccs/proj/csc420/BEE/clamr-ppc64le.tar.gz"
+          beeflow:copyContainer: "/ccs/proj/csc420/BEE/clamr-ppc64le.tar.gz"
     in:
       infile: clamr/outfile
     out: [outfile]

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-noyaml/slurm-charliecloud/cf-darwin.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-noyaml/slurm-charliecloud/cf-darwin.cwl
@@ -29,7 +29,7 @@ steps:
       baseCommand: "/clamr/CLAMR-master/clamr_cpuonly -n 32 -l 3 -t 5000 -i 10 -g 25 -G png"
       hints:
         DockerRequirement:
-          copyContainer: "/projects/beedev/clamr-toss.tar.gz"
+          beeflow:copyContainer: "/projects/beedev/clamr-toss.tar.gz"
     in:
       infile: infile
     out: [outfile]

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-noyaml/slurm-charliecloud/cf-no-owrite.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-noyaml/slurm-charliecloud/cf-no-owrite.cwl
@@ -29,7 +29,7 @@ steps:
       baseCommand: "/clamr/CLAMR-master/clamr_cpuonly -n 32 -l 3 -t 5000 -i 10 -g 25 -G png"
       hints:
         DockerRequirement:
-          copyContainer: "/usr/projects/beedev/clamr/clamr-toss.tar.gz"
+          beeflow:copyContainer: "/usr/projects/beedev/clamr/clamr-toss.tar.gz"
     in:
       infile: infile
     out: [outfile]

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-noyaml/slurm-charliecloud/cf.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-noyaml/slurm-charliecloud/cf.cwl
@@ -29,7 +29,7 @@ steps:
       baseCommand: "/clamr/CLAMR-master/clamr_cpuonly -n 32 -l 3 -t 5000 -i 10 -g 25 -G png"
       hints:
         DockerRequirement:
-          copyContainer: "/usr/projects/beedev/clamr/clamr-toss.tar.gz"
+          beeflow:copyContainer: "/usr/projects/beedev/clamr/clamr-toss.tar.gz"
     in:
       infile: infile
     out: [outfile]

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-noyaml/slurm-charliecloud/copyContainer_containerName.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-noyaml/slurm-charliecloud/copyContainer_containerName.cwl
@@ -29,7 +29,7 @@ steps:
       baseCommand: "/clamr/CLAMR-master/clamr_cpuonly -n 32 -l 3 -t 5000 -i 10 -g 25 -G png"
       hints:
         DockerRequirement:
-          copyContainer: "/usr/projects/beedev/clamr/clamr-toss.tar.gz"
+          beeflow:copyContainer: "/usr/projects/beedev/clamr/clamr-toss.tar.gz"
           containerName: "foo"
     in:
       infile: infile

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-noyaml/slurm-singularity/cf-singularity.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-noyaml/slurm-singularity/cf-singularity.cwl
@@ -29,7 +29,7 @@ steps:
       baseCommand: "/clamr/CLAMR-master/clamr_cpuonly -n 32 -l 3 -t 5000 -i 10 -g 25 -G png"
       hints:
         DockerRequirement:
-          copyContainer: "/usr/projects/beedev/clamr/clamr-toss.simg"
+          beeflow:copyContainer: "/usr/projects/beedev/clamr/clamr-toss.simg"
     in:
       infile: infile
     out: [outfile]

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-singularity/clamr_wf.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-singularity/clamr_wf.cwl
@@ -54,8 +54,8 @@ steps:
         DockerRequirement:
             # TODO Sort this out
             #dockerImport: clamr_img.tar.gz
-            #copyContainer: clamr
-            copyContainer: "/usr/projects/beedev/clamr/clamr-toss.simg"
+            #beeflow:copyContainer: clamr
+            beeflow:copyContainer: "/usr/projects/beedev/clamr/clamr-toss.simg"
 
   ffmpeg:
     run: ffmpeg.cwl

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-summit/clamr_wf.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-summit/clamr_wf.cwl
@@ -54,8 +54,8 @@ steps:
         DockerRequirement:
             # TODO Sort this out
             #dockerImport: clamr_img.tar.gz
-            #copyContainer: clamr
-            copyContainer: "/ccs/proj/csc420/BEE/clamr-ppc64le.tar.gz"
+            #beeflow:copyContainer: clamr
+            beeflow:copyContainer: "/ccs/proj/csc420/BEE/clamr-ppc64le.tar.gz"
 
   ffmpeg:
     run: ffmpeg.cwl
@@ -72,4 +72,4 @@ steps:
     out: [movie]
     hints:
       DockerRequirement:
-        copyContainer: "/ccs/proj/csc420/BEE/clamr-ppc64le.tar.gz"
+        beeflow:copyContainer: "/ccs/proj/csc420/BEE/clamr-ppc64le.tar.gz"

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-use-container/README.md
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-use-container/README.md
@@ -1,0 +1,10 @@
+# CLAMR - FFMPEG workflow using CWL
+
+clamr_wf.cwl - the main cwl.
+calmr_job.yml - yaml file for values used by the cwl files.
+clamr.cwl - cwl file for the clamr step.
+ffmpeg.cwl - cwl file for the ffmpeg step.
+
+The values in these files run on fog a LANL cluster, using the container runtime Charliecloud. Fog uses slurm as the workload scheduler.
+
+

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-use-container/clamr.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-use-container/clamr.cwl
@@ -1,0 +1,83 @@
+# -*- mode: YAML; -*-
+
+class: CommandLineTool
+cwlVersion: v1.0
+
+baseCommand: /clamr/CLAMR-master/clamr_cpuonly
+# This is the stdout field which makes all stdout be captured in this file
+# stderr is not currently implemented but it is also a thing
+stdout: clamr_stdout.txt
+# Arguments to the command
+inputs:
+  amr_type:
+    # ? means the argument is optional
+    # All of the ? here are legacy from the original CWL
+    type: string?
+    # Declare extra options
+    # We support prefix and position
+    inputBinding:
+      # Prefix is the flag for cli command
+      prefix: -A
+  grid_res:
+    type: int?
+    inputBinding:
+      prefix: -n
+  max_levels:
+    type: int?
+    inputBinding:
+      prefix: -l
+  time_steps:
+    type: int?
+    inputBinding:
+      prefix: -t
+  output_steps:
+    type: int?
+    inputBinding:
+      prefix: -i
+  graphic_steps:
+    type: int?
+    inputBinding:
+      prefix: -g
+  graphics_type:
+    type: string?
+    inputBinding:
+      prefix: -G
+  rollback_images:
+    type: int?
+    inputBinding:
+      prefix: -b
+  checkpoint_disk_interval:
+    type: int?
+    inputBinding:
+      prefix: -c
+  checkpoint_mem_interval:
+    type: int?
+    inputBinding:
+      prefix: -C
+  hash_method:
+    type: string?
+    inputBinding:
+      prefix: -e
+  
+outputs:
+  # Captures stdout. Name is arbitrary.
+  clamr_stdout:
+    # type is syntactic sugar to just grab the output file defined above
+    # stdout:
+    #     type: File
+    #     outputBinding: 
+    #       glob: clamr_stdout.txt
+    #     stdout is easy shorthand
+    type: stdout
+  outdir:
+    # directory is just another type. Scan the files for a directory with the name specified in glob
+    # If you add a wildcard, it'd do expansion
+    type: Directory
+    outputBinding:
+      # Glob can be either a constant string or have a wildcard 
+      # TODO verify CWLs glob support
+      glob: $HOME/graphics_output/graph%05d.png
+  time_log:
+    type: File
+    outputBinding:
+      glob: total_execution_time.log

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-use-container/clamr_job.json
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-use-container/clamr_job.json
@@ -1,0 +1,13 @@
+{
+  "grid_resolution": 32,
+  "max_levels": 3,
+  "time_steps": 5000,
+  "steps_between_outputs": 10,
+  "steps_between_graphics": 25,
+  "graphics_type": "png",
+  "input_format": "image2",
+  "frame_rate": 12,
+  "frame_size": "800x800",
+  "pixel_format": "yuv420p",
+  "output_filename": "CLAMR_movie.mp4"
+}

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-use-container/clamr_job.yml
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-use-container/clamr_job.yml
@@ -1,0 +1,18 @@
+# Inputs for CLAMR
+# /clamr/CLAMR-master/clamr_cpuonly -n 32 -l 3 -t 5000 -i 10 -g 25 -G png
+
+grid_resolution: 32
+max_levels: 3
+time_steps: 5000
+steps_between_outputs: 10
+steps_between_graphics: 25
+graphics_type: png
+
+# Inputs for FFMPEG
+#ffmpeg -f image2 -r 12 -s 800x800 -pix_fmt yuv420p $HOME/CLAMR_movie.mp4
+
+input_format: image2
+frame_rate: 12
+frame_size: 800x800
+pixel_format: yuv420p
+output_filename: $HOME/CLAMR_movie.mp4

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-use-container/clamr_wf.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-use-container/clamr_wf.cwl
@@ -52,10 +52,7 @@ steps:
     out: [clamr_stdout, outdir, time_log]
     hints:
         DockerRequirement:
-            # TODO Sort this out
-            #dockerImport: clamr_img.tar.gz
-            #beeflow:copyContainer: clamr
-            beeflow:copyContainer: "/usr/projects/beedev/clamr/clamr-toss.tar.gz"
+            beeflow:useContainer: "/usr/projects/beedev/clamr/clamr-toss.tar.gz"
 
   ffmpeg:
     run: ffmpeg.cwl

--- a/src/beeflow/data/cwl/bee_workflows/clamr-wf-use-container/ffmpeg.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/clamr-wf-use-container/ffmpeg.cwl
@@ -1,0 +1,44 @@
+# -*- mode: YAML; -*-
+
+class: CommandLineTool
+cwlVersion: v1.0
+
+baseCommand: ffmpeg -y
+inputs:
+  input_format:
+    type: string?
+    inputBinding:
+      prefix: -f
+      position: 1
+  ffmpeg_input:
+    type: Directory
+    inputBinding:
+      prefix: -i
+      position: 2
+      valueFrom: $(self.path + "/graph%05d.png")
+  frame_rate:
+    type: int?
+    inputBinding:
+      prefix: -r
+      position: 3
+  frame_size:
+    type: string?
+    inputBinding:
+      prefix: -s
+      position: 4
+  pixel_format:
+    type: string?
+    inputBinding:
+      prefix: -pix_fmt
+      position: 5
+  output_file:
+    type: string
+    inputBinding:
+      position: 6
+
+outputs:
+  movie:
+    type: File
+    outputBinding:
+      glob: $(inputs.output_file)
+      # glob: CLAMR_movie.mp4

--- a/src/beeflow/data/cwl/bee_workflows/comd-mpi/comd.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/comd-mpi/comd.cwl
@@ -30,7 +30,7 @@ steps:
     hints:
       DockerRequirement:
         # dockerPull: "jtronge/comd:latest"
-        copyContainer: "/usr/projects/beedev/comd/comd-x86_64.tar.gz"
+        beeflow:copyContainer: "/usr/projects/beedev/comd/comd-x86_64.tar.gz"
       beeflow:MPIRequirement:
         nodes: 8
         ntasks: 8

--- a/src/beeflow/data/cwl/bee_workflows/simple-workflows/grep-wordcount/gc.cwl
+++ b/src/beeflow/data/cwl/bee_workflows/simple-workflows/grep-wordcount/gc.cwl
@@ -34,7 +34,7 @@ steps:
       baseCommand: "sh -c 'grep integer lorem.txt > grepout.txt;sleep 15;ls -l|grep grepout.txt'"
       hints:
         DockerRequirement:
-          copyContainer: "/usr/projects/beedev/toss-tiny-3-5.tar"
+          beeflow:copyContainer: "/usr/projects/beedev/toss-tiny-3-5.tar"
     in:
       pattern: pattern
       infile: infile
@@ -54,7 +54,7 @@ steps:
       baseCommand: "sh -c 'ls -l;sleep 10; wc -l grepout.txt > counts.txt'"
       hints:
         DockerRequirement:
-          copyContainer: "/usr/projects/beedev/toss-tiny-3-5.tar"
+          beeflow:copyContainer: "/usr/projects/beedev/toss-tiny-3-5.tar"
     in:
       infile: grep/outfile
     out: [outfile]

--- a/src/beeflow/data/cwl/cwl_validation/grep-wordcount/gc.cwl
+++ b/src/beeflow/data/cwl/cwl_validation/grep-wordcount/gc.cwl
@@ -34,7 +34,7 @@ steps:
       baseCommand: grep
       hints:
         DockerRequirement:
-          copyContainer: "/usr/projects/beedev/toss-tiny-3-5.tar"
+          beeflow:copyContainer: "/usr/projects/beedev/toss-tiny-3-5.tar"
     in:
       pattern: pattern
       infile: infile
@@ -54,7 +54,7 @@ steps:
       baseCommand: "wc -l"
       hints:
         DockerRequirement:
-          copyContainer: "/usr/projects/beedev/toss-tiny-3-5.tar"
+          beeflow:copyContainer: "/usr/projects/beedev/toss-tiny-3-5.tar"
     in:
       infile: grep/outfile
     out: [outfile]

--- a/src/beeflow/wf_manager.py
+++ b/src/beeflow/wf_manager.py
@@ -666,7 +666,7 @@ class JobUpdate(Resource):
                         submit_tasks_tm(tasks)
 
         elif job_state == "FAILED" or job_state == "TIMEOUT":
-            if 'task_info' in data:
+            if 'task_info' in data and data['task_info'] is not None:
                 task_info = jsonpickle.decode(data['task_info'])
                 checkpoint_file = task_info['checkpoint_file']
                 new_task = wfi.restart_task(task, checkpoint_file)


### PR DESCRIPTION
This should address issue #470. I'm marking this as WIP right now since I need to do a couple more tests.

Also I realized that I was wrong about where we can add CWL extensions. Looking further at [Arvado's extensions](https://doc.arvados.org/v2.4/user/cwl/cwl-extensions.html), I see that they use a `arv:dockerCollectionPDH` underneath `DockerRequirement`.

I also noticed that other CWL engines use a `$namespaces` parameter within the CWL file to indicate extensions namespaces. We probably want to look at this a little more because it may affect how compatible our CWL is with other implementations. I may make an issue for this.