### PR TITLE
Fix WF State

### DIFF
--- a/src/beeflow/common/crt_drivers.py
+++ b/src/beeflow/common/crt_drivers.py
@@ -203,7 +203,6 @@ class CharliecloudDriver(ContainerRuntimeDriver):
 
         mpi_opt = '--join' if 'beeflow:MPIRequirement' in hints else ''
         command = ' '.join(task.command)
-        cc_setup = cc_setup.split()
         env_code = cc_setup if cc_setup else ''
         deployed_path = deployed_image_root + '/' + task_container_name
         pre_commands = [

--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -82,14 +82,14 @@ class WorkflowInterface:
         workflow, _ = self.get_workflow()
         self._workflow_id = workflow.generate_workflow_id()
         self._gdb_interface.reset_workflow(self._workflow_id)
-        #self._set_workflow_state('SUBMITTED')
         self._gdb_interface.set_workflow_state('SUBMITTED')
+
+    def workflow_completed(self):
+        self._gdb_interface.set_workflow_state('COMPLETED')
 
     def finalize_workflow(self):
         """Deconstruct a BEE workflow."""
         self._workflow_id = None
-        #self._set_workflow_state('COMPLETED')
-        self._gdb_interface.set_workflow_state('COMPLETED')
         self._gdb_interface.cleanup()
 
     def add_task(self, name, base_command, inputs, outputs, requirements=None, hints=None,

--- a/src/beeflow/wf_manager.py
+++ b/src/beeflow/wf_manager.py
@@ -633,9 +633,17 @@ class JobUpdate(Resource):
             if wfi.workflow_completed():
                 log.info("Workflow Completed")
 
+                workflows_dir = os.path.join(bee_workdir, 'workflows')
+                wf_id = wfi.workflow_id
+                workflow_dir = os.path.join(workflows_dir, wf_id)
+                status_path = os.path.join(workflow_dir, 'bee_wf_status')
+                with open(status_path, 'w') as status:
+                    status.write('Completed')
+                wfi.workflow_completed()
+
+
                 # Save the profile
                 wf_profiler.save()
-
                 if archive and not reexecute:
                     gdb_workdir = os.path.join(bee_workdir, 'current_gdb')
                     wf_id = wfi.workflow_id
@@ -676,7 +684,6 @@ class JobUpdate(Resource):
                     #wfi.set_task_state(task, f"RESTART FAILED: {state}")
                     #wfi.set_task_state(task, job_state)
                     state = wfi.get_task_state(task)
-                    print(f'STATE: {wfi.get_task_state(task)}')
                     resp = make_response(jsonify(status=f'Task {task_id} set to {job_state}'), 200)
                     return resp
                 else:                               


### PR DESCRIPTION
This PR fixes an issue where the workflow state wasn't getting set correctly after a workflow completed which was inhibiting #419. It also adds a new function in the wf_interface which can set a workflow's state to completed without finalizing it. Finally, this PR also fixes an issue in the crt_driver that was causing the load module step before a workflow to fail. 