### PR TITLE
Fix documentation generation errors

### DIFF
--- a/doc/sphinx/wf_api.rst
+++ b/doc/sphinx/wf_api.rst
@@ -1,102 +1,107 @@
 BEEflow API
 **************************
-..
-    Builder (Container)
-    ===========================
-    Build Interfaces
-    ---------------------------
-    .. automodule:: beeflow.common.build_interfaces
-       :members:
 
-    Build Driver
-    ---------------------------
-    .. automodule:: beeflow.common.build.build_driver
-       :members:
+Builder (Container)
+===========================
 
-    Build Container Drivers
-    --------------------------
-    .. automodule:: beeflow.common.build.container_drivers
-       :members:
+Build Interfaces
+---------------------------
+.. automodule:: beeflow.common.build_interfaces
+   :members:
 
-    Configuration
-    ===========================
-    .. automodule:: beeflow.common.config_driver
-       :members:
+Build Driver
+---------------------------
+.. automodule:: beeflow.common.build.build_driver
+   :members:
 
-    Container Runtime
-    ===========================
+Build Container Drivers
+--------------------------
+.. automodule:: beeflow.common.build.container_drivers
+   :members:
 
-    Container Runtime Drivers
-    ---------------------------
-    .. automodule:: beeflow.common.crt_drivers
-       :members:
+Configuration
+===========================
+.. automodule:: beeflow.common.config_driver
+   :members:
 
-    Container Runtime Interface
-    ---------------------------
-    .. automodule:: beeflow.common.crt_interface
-       :members:
+Container Runtime
+===========================
 
-    Graph Database
-    ===========================
-    Graph Database Driver
-    ---------------------------
-    .. automodule:: beeflow.common.gdb.gdb_driver
-       :members:
+Container Runtime Drivers
+---------------------------
+.. automodule:: beeflow.common.crt_drivers
+   :members:
 
-    Graph Database Interface
-    ---------------------------
-    .. automodule:: beeflow.common.gdb_interface
-       :members:
+Container Runtime Interface
+---------------------------
+.. automodule:: beeflow.common.crt_interface
+   :members:
 
-    Neo4j Cypher Module
-    ---------------------------
-    .. automodule:: beeflow.common.gdb.neo4j_cypher
-       :members:
+Graph Database
+===========================
 
-    Neo4j Driver
-    ---------------------------
-    .. automodule:: beeflow.common.gdb.neo4j_driver
-       :members:
+Graph Database Driver
+---------------------------
+.. automodule:: beeflow.common.gdb.gdb_driver
+   :members:
 
-    Logging
-    ========================
-    .. automodule:: beeflow.common.log
-       :members:
+Graph Database Interface
+---------------------------
+.. automodule:: beeflow.common.gdb_interface
+   :members:
 
-    Parser (CWL)
-    ========================
-    .. automodule:: beeflow.common.parser.parser
-       :members:
+Neo4j Cypher Module
+---------------------------
+.. automodule:: beeflow.common.gdb.neo4j_cypher
+   :members:
 
-    Worker
-    ===========================
-    .. automodule:: beeflow.common.worker.worker
+Neo4j Driver
+---------------------------
+.. automodule:: beeflow.common.gdb.neo4j_driver
+   :members:
 
-    LSF Worker
-    ---------------------------
-    .. automodule:: beeflow.common.worker.lsf_worker
+Logging
+========================
+.. automodule:: beeflow.common.log
+   :members:
 
-    Simple Worker
-    ---------------------------
-    .. automodule:: beeflow.common.worker.simple_worker
+Parser (CWL)
+========================
+.. automodule:: beeflow.common.parser.parser
+   :members:
 
-    Slurm Worker
-    ---------------------------
-    .. automodule:: beeflow.common.worker.slurm_worker
+Worker
+===========================
+.. automodule:: beeflow.common.worker.worker
+   :members:
 
-    Worker Interface
-    ---------------------------
-    .. automodule:: beeflow.common.worker_interface
+LSF Worker
+---------------------------
+.. automodule:: beeflow.common.worker.lsf_worker
+   :members:
 
-    Workflow Data Structures
-    ========================
-    .. automodule:: beeflow.common.wf_data
-       :members:
-       :special-members:
+Simple Worker
+---------------------------
+.. automodule:: beeflow.common.worker.simple_worker
+   :members:
+
+Slurm Worker
+---------------------------
+.. automodule:: beeflow.common.worker.slurm_worker
+   :members:
+
+Worker Interface
+---------------------------
+.. automodule:: beeflow.common.worker_interface
+   :members:
+
+Workflow Data Structures
+========================
+.. automodule:: beeflow.common.wf_data
+   :members:
+   :special-members:
 
 Workflow Interface
 ==================
 .. automodule:: beeflow.common.wf_interface
    :members:
-
-

--- a/src/beeflow/common/crt_drivers.py
+++ b/src/beeflow/common/crt_drivers.py
@@ -203,7 +203,6 @@ class CharliecloudDriver(ContainerRuntimeDriver):
 
         mpi_opt = '--join' if 'beeflow:MPIRequirement' in hints else ''
         command = ' '.join(task.command)
-        cc_setup = cc_setup.split()
         env_code = cc_setup if cc_setup else ''
         deployed_path = deployed_image_root + '/' + task_container_name
         pre_commands = [

--- a/src/beeflow/common/crt_drivers.py
+++ b/src/beeflow/common/crt_drivers.py
@@ -11,6 +11,11 @@ from beeflow.common.build.build_driver import task2arg
 from beeflow.cli import log
 import beeflow.common.log as bee_logging
 
+# The bc object must be created before importing other parts of BEE
+# This is needed to generate Sphinx documentation
+if not bc.ready():
+    bc.init()
+
 USERCONFIG = bc.userconfig_path()
 
 bee_workdir = bc.get('DEFAULT', 'bee_workdir')

--- a/src/beeflow/common/gdb/neo4j_cypher.py
+++ b/src/beeflow/common/gdb/neo4j_cypher.py
@@ -360,7 +360,7 @@ def set_workflow_state(tx, state):
     """Get workflow state from the Neo4j database.
 
     :param state: the state the workflow will be set to
-    type state: str
+    :type state: str
     """
     state_query = "MATCH (w:Workflow) SET w.state = $state"
     

--- a/src/beeflow/common/wf_interface.py
+++ b/src/beeflow/common/wf_interface.py
@@ -82,14 +82,14 @@ class WorkflowInterface:
         workflow, _ = self.get_workflow()
         self._workflow_id = workflow.generate_workflow_id()
         self._gdb_interface.reset_workflow(self._workflow_id)
-        #self._set_workflow_state('SUBMITTED')
         self._gdb_interface.set_workflow_state('SUBMITTED')
+
+    def workflow_completed(self):
+        self._gdb_interface.set_workflow_state('COMPLETED')
 
     def finalize_workflow(self):
         """Deconstruct a BEE workflow."""
         self._workflow_id = None
-        #self._set_workflow_state('COMPLETED')
-        self._gdb_interface.set_workflow_state('COMPLETED')
         self._gdb_interface.cleanup()
 
     def add_task(self, name, base_command, inputs, outputs, requirements=None, hints=None,

--- a/src/beeflow/wf_manager.py
+++ b/src/beeflow/wf_manager.py
@@ -633,9 +633,17 @@ class JobUpdate(Resource):
             if wfi.workflow_completed():
                 log.info("Workflow Completed")
 
+                workflows_dir = os.path.join(bee_workdir, 'workflows')
+                wf_id = wfi.workflow_id
+                workflow_dir = os.path.join(workflows_dir, wf_id)
+                status_path = os.path.join(workflow_dir, 'bee_wf_status')
+                with open(status_path, 'w') as status:
+                    status.write('Completed')
+                wfi.workflow_completed()
+
+
                 # Save the profile
                 wf_profiler.save()
-
                 if archive and not reexecute:
                     gdb_workdir = os.path.join(bee_workdir, 'current_gdb')
                     wf_id = wfi.workflow_id
@@ -676,7 +684,6 @@ class JobUpdate(Resource):
                     #wfi.set_task_state(task, f"RESTART FAILED: {state}")
                     #wfi.set_task_state(task, job_state)
                     state = wfi.get_task_state(task)
-                    print(f'STATE: {wfi.get_task_state(task)}')
                     resp = make_response(jsonify(status=f'Task {task_id} set to {job_state}'), 200)
                     return resp
                 else:                               


### PR DESCRIPTION
* Fixes error causing build, crt, and worker documentation to fail to generate
  * Added `bc.init()` line to `crt_drivers.py`
* Fixes docstrings in worker modules failing to be parsed
* Fixes malformed docstring `type` field in `neo4j_cypher.py`
* Merges changes from `develop` branch