### PR TITLE
Add check for 'no ci' label

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,7 +14,7 @@ env: {}
 
 jobs:
   integration-test:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'WIP') }}
+    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP') || contains(github.event.pull_request.labels.*.name, 'no ci')) }}
     name: BEE Integration Test
     # Note: Needs to run on 22.04 or later since slurmrestd doesn't seem to be
     # available on 20.04

--- a/.github/workflows/pylama.yml
+++ b/.github/workflows/pylama.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   pylama:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'WIP') }}
+    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP') || contains(github.event.pull_request.labels.*.name, 'no ci')) }}
     name: PyLama Lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ env: {}
 
 jobs:
   integration-test:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'WIP') }}
+    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP') || contains(github.event.pull_request.labels.*.name, 'no ci')) }}
     name: BEE Unit Tests
     # Note: Needs to run on 22.04 or later since slurmrestd doesn't seem to be
     # available on 20.04


### PR DESCRIPTION
This should ensure that CI is not run when the `no ci` label is added to a PR.