### PR TITLE
Remove 'no ci' label check, add 'lint-only' check, and force pylama to run on every PR

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ env: {}
 
 jobs:
   integration-test:
-    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP') || contains(github.event.pull_request.labels.*.name, 'no ci')) }}
+    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP') || contains(github.event.pull_request.labels.*.name, 'lint-only')) }}
     name: BEE Integration Test
     # Note: Needs to run on 22.04 or later since slurmrestd doesn't seem to be
     # available on 20.04

--- a/.github/workflows/pylama.yml
+++ b/.github/workflows/pylama.yml
@@ -7,12 +7,11 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    types: [opened, synchronize, edited, labeled, unlabeled]
+    types: [opened, synchronize, edited]
     branches: [main, develop]
 
 jobs:
   pylama:
-    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP') || contains(github.event.pull_request.labels.*.name, 'no ci')) }}
     name: PyLama Lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ env: {}
 
 jobs:
   integration-test:
-    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP') || contains(github.event.pull_request.labels.*.name, 'no ci')) }}
+    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP') || contains(github.event.pull_request.labels.*.name, 'lint-only')) }}
     name: BEE Unit Tests
     # Note: Needs to run on 22.04 or later since slurmrestd doesn't seem to be
     # available on 20.04


### PR DESCRIPTION
This replaces the `no ci` label check with a check for `lint-only` instead. Since the pylama lint only takes a few seconds to run it should be ok to run it on every commit/update to a PR.