### PR TITLE
Remove the celery dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ MarkupSafe = { version = "==2.0.1" }
 neo4j = { version = "^1.7.4" }
 PyYAML = { version = "^5.1.1" }
 flask_restful = "0.3.7"
-celery = {extras = ["redis"], version = "^4.4.0"}
 redis = "^3.3.11"
 cwl-utils = "^0.16"
 pylint = { version = ">=2.3.1" }


### PR DESCRIPTION
This PR removes celery since we're not currently using it, and it introduces some vulnerabilities. 