### PR TITLE
Generate WF ID pre-parsing and support CWL stderr

### DIFF
--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -128,7 +128,7 @@ def submit(wf_name: str = typer.Argument(..., help='The workflow name'),
            yaml: str = typer.Argument(..., help='filename of YAML file'),
            workdir: pathlib.Path = typer.Argument(
                ...,
-               help='working directory for workflow containing input + output files',
+               help='working directory for workflow containing input + output files'
            )):
     """
     Submit a new workflow
@@ -150,7 +150,7 @@ def submit(wf_name: str = typer.Argument(..., help='The workflow name'),
         'wf_filename': os.path.basename(wf_path).encode(),
         'main_cwl': main_cwl,
         'yaml': yaml,
-        'workdir': workdir,
+        'workdir': workdir
     }
     files = {
         'workflow_archive': wf_tarball
@@ -347,7 +347,12 @@ def copy(wf_id: str = typer.Argument(..., callback=match_short_id)):
 
 @app.command()
 def reexecute(wf_name: str = typer.Argument(..., help='The workflow name'),
-              wf_path: pathlib.Path = typer.Argument(..., help='Path to the workflow archive')):
+              wf_path: pathlib.Path = typer.Argument(..., help='Path to the workflow archive'),
+              workdir: pathlib.Path = typer.Argument(
+                  ...,
+                  help='working directory for workflow containing input + output files'
+              )):
+
     """
     Reexecute an archived workflow
     """
@@ -358,7 +363,8 @@ def reexecute(wf_name: str = typer.Argument(..., help='The workflow name'),
 
     data = {
         'wf_filename': os.path.basename(wf_path).encode(),
-        'wf_name': wf_name.encode()
+        'wf_name': wf_name.encode(), 
+        'workdir': workdir
     }
     try:
         resp = requests.put(_url(), data=data,

--- a/beeflow/common/gdb/neo4j_cypher.py
+++ b/beeflow/common/gdb/neo4j_cypher.py
@@ -90,11 +90,12 @@ def create_task(tx, task):
                     "SET t.workflow_id = $workflow_id "
                     "SET t.name = $name "
                     "SET t.base_command = $base_command "
-                    "SET t.stdout = $stdout")
+                    "SET t.stdout = $stdout "
+                    "SET t.stderr = $stderr")
 
     # Unpack requirements, hints dictionaries into flat list
     tx.run(create_query, task_id=task.id, workflow_id=task.workflow_id, name=task.name,
-           base_command=task.base_command, stdout=task.stdout)
+           base_command=task.base_command, stdout=task.stdout, stderr=task.stderr)
 
 
 def create_task_hint_nodes(tx, task):

--- a/beeflow/common/gdb/neo4j_driver.py
+++ b/beeflow/common/gdb/neo4j_driver.py
@@ -562,7 +562,7 @@ def _reconstruct_task(task_record, hints, requirements, inputs, outputs):
     rec = task_record["t"]
     return Task(name=rec["name"], base_command=rec["base_command"], hints=hints,
                 requirements=requirements, inputs=inputs, outputs=outputs, stdout=rec["stdout"],
-                workflow_id=rec["workflow_id"], task_id=rec["id"])
+                stderr=rec["stderr"], workflow_id=rec["workflow_id"], task_id=rec["id"])
 
 
 def _reconstruct_metadata(metadata_record):

--- a/beeflow/common/parser/parser.py
+++ b/beeflow/common/parser/parser.py
@@ -62,13 +62,15 @@ class CwlParser:
         except configparser.NoSectionError:
             self._wfi = WorkflowInterface()
 
-    def parse_workflow(self, cwl, job=None):
+    def parse_workflow(self, workflow_id, cwl, job=None):
         """Parse a CWL Workflow file and load it into the graph database.
 
         Returns an instance of the WorkflowInterface.
 
         :param cwl: the CWL file path
         :type cwl: str
+        :param workflow_id: the workflow ID
+        :type workflow_id: str
         :param job: the input job file (YAML or JSON)
         :type job: str
         :rtype: WorkflowInterface
@@ -112,8 +114,8 @@ class CwlParser:
         workflow_hints = self.parse_requirements(self.cwl.hints, as_hints=True)
         workflow_requirements = self.parse_requirements(self.cwl.requirements)
 
-        self._wfi.initialize_workflow(workflow_name, workflow_inputs, workflow_outputs,
-                                      workflow_requirements, workflow_hints)
+        self._wfi.initialize_workflow(workflow_id, workflow_name, workflow_inputs,
+                                      workflow_outputs, workflow_requirements, workflow_hints)
         for step in self.cwl.steps:
             self.parse_step(step)
 
@@ -143,16 +145,18 @@ class CwlParser:
         step_name = os.path.basename(step_id).split(".")[0]
         step_command = step_cwl.baseCommand
         step_inputs = self.parse_step_inputs(step.in_, step_cwl.inputs)
-        step_outputs = self.parse_step_outputs(step.out, step_cwl.outputs, step_cwl.stdout)
+        step_outputs = self.parse_step_outputs(step.out, step_cwl.outputs, step_cwl.stdout,
+                                               step_cwl.stderr)
         step_requirements = self.parse_requirements(step.requirements)
         step_requirements.extend(self.parse_requirements(step_cwl.requirements))
         step_hints = self.parse_requirements(step.hints, as_hints=True)
         step_hints.extend(self.parse_requirements(step_cwl.hints, as_hints=True))
         step_stdout = step_cwl.stdout
+        step_stderr = step_cwl.stderr
 
         self._wfi.add_task(step_name, base_command=step_command, inputs=step_inputs,
                            outputs=step_outputs, requirements=step_requirements,
-                           hints=step_hints, stdout=step_stdout)
+                           hints=step_hints, stdout=step_stdout, stderr=step_stderr)
 
     def parse_job(self, job):
         """Parse a CWL input job file.
@@ -220,7 +224,7 @@ class CwlParser:
         return inputs
 
     @staticmethod
-    def parse_step_outputs(cwl_out, step_outputs, stdout):
+    def parse_step_outputs(cwl_out, step_outputs, stdout, stderr):
         """Parse step outputs from CWL step output objects.
 
         :param cwl_out: the step outputs from the Workflow file
@@ -229,6 +233,8 @@ class CwlParser:
         :type step_outputs: list of CommandOutputParameter
         :param stdout: name of file to which stdout should be redirected
         :type stdout: str or None
+        :param stderr: name of file to which stderr should be redirected
+        :type stderr: str or None
         :rtype: list of StepOutput
         """
         out_short = list(map(_shortname, cwl_out))
@@ -252,6 +258,12 @@ class CwlParser:
                                       "but not specified by CommandLineTool"))
                 # Fill in glob with value of stdout
                 glob = stdout
+            elif output_type == "stderr":
+                if not stderr:
+                    raise ValueError((f"stderr capture required for step output {out} "
+                                      "but not specified by CommandLineTool"))
+                # Fill in glob with value of stderr
+                glob = stderr
             else:
                 if out_map[out].outputBinding:
                     glob = out_map[out].outputBinding.glob

--- a/beeflow/common/parser/parser.py
+++ b/beeflow/common/parser/parser.py
@@ -76,6 +76,7 @@ class CwlParser:
         :type job: str
         :rtype: WorkflowInterface
         """
+        print(f'{workflow_id} {cwl} {job}')
         self.cwl = cwl_parser.load_document(cwl)
 
         if self.cwl.class_ != "Workflow":

--- a/beeflow/common/parser/parser.py
+++ b/beeflow/common/parser/parser.py
@@ -19,7 +19,8 @@ from beeflow.common.wf_data import (InputParameter,
                                     StepInput,
                                     StepOutput,
                                     Hint,
-                                    Requirement)
+                                    Requirement,
+                                    generate_workflow_id)
 from beeflow.common.wf_interface import WorkflowInterface
 
 
@@ -332,7 +333,7 @@ def main():
     """Run the parser on a CWL Workflow and job file directly."""
     parser = CwlParser()
     args = parse_args()
-    parser.parse_workflow(args.wf_file, args.inputs)
+    parser.parse_workflow(generate_workflow_id(), args.wf_file, args.inputs)
 
 
 if __name__ == "__main__":

--- a/beeflow/common/wf_interface.py
+++ b/beeflow/common/wf_interface.py
@@ -84,9 +84,6 @@ class WorkflowInterface:
         self._gdb_interface.reset_workflow(self._workflow_id)
         self._gdb_interface.set_workflow_state('SUBMITTED')
 
-    def workflow_completed(self):
-        self._gdb_interface.set_workflow_state('COMPLETED')
-
     def finalize_workflow(self):
         """Deconstruct a BEE workflow."""
         self._workflow_id = None

--- a/beeflow/tests/test_parser.py
+++ b/beeflow/tests/test_parser.py
@@ -4,6 +4,7 @@
 import unittest
 
 from beeflow.common.parser import CwlParser
+from beeflow.common.wf_data import generate_workflow_id
 
 # Disable protected member access warning
 # pylama:ignore=W0212
@@ -28,24 +29,26 @@ class TestParser(unittest.TestCase):
         cwl_wfi_file = "clamr-wf/clamr_wf.cwl"
         cwl_job_yaml = "clamr-wf/clamr_job.yml"
         cwl_job_json = "clamr-wf/clamr_job.json"
+        workflow_id = generate_workflow_id()
 
         # Test workflow parsing with YAML input job file
-        wfi = self.parser.parse_workflow(cwl_wfi_file, cwl_job_yaml)
+        wfi = self.parser.parse_workflow(workflow_id, cwl_wfi_file, cwl_job_yaml)
         self.assertTrue(wfi.workflow_loaded())
 
         wfi.finalize_workflow()
         self.assertFalse(wfi.workflow_loaded())
 
-        # Test workflow parsing with YAML input job file
-        wfi = self.parser.parse_workflow(cwl_wfi_file, cwl_job_json)
+        # Test workflow parsing with JSON input job file
+        wfi = self.parser.parse_workflow(workflow_id, cwl_wfi_file, cwl_job_json)
         self.assertTrue(wfi.workflow_loaded())
 
     def test_parse_workflow_no_job(self):
         """Test parsing of a workflow without an input job file."""
         cwl_wfi_file = "cf.cwl"
+        workflow_id = generate_workflow_id()
 
         # Test workflow parsing without input job file
-        wfi = self.parser.parse_workflow(cwl_wfi_file)
+        wfi = self.parser.parse_workflow(workflow_id, cwl_wfi_file)
         self.assertTrue(wfi.workflow_loaded())
 
 

--- a/beeflow/wf_manager/resources/wf_actions.py
+++ b/beeflow/wf_manager/resources/wf_actions.py
@@ -15,7 +15,7 @@ class WFActions(Resource):
 
     def post(self, wf_id):
         """Start workflow. Send ready tasks to the task manager."""
-        wfi = wf_utils.get_workflow_interface()
+        wfi = wf_utils.get_workflow_interface(wf_id)
         state = wfi.get_workflow_state()
         if state in ('RUNNING', 'PAUSED', 'COMPLETED'):
             resp = make_response(jsonify(msg='Cannot start workflow it is '

--- a/beeflow/wf_manager/resources/wf_list.py
+++ b/beeflow/wf_manager/resources/wf_list.py
@@ -5,7 +5,6 @@ This contains endpoints forsubmitting, starting, and reexecuting workflows.
 
 import os
 import shutil
-import tempfile
 import subprocess
 import jsonpickle
 
@@ -20,9 +19,10 @@ from beeflow.common.parser import CwlParser
 from beeflow.wf_manager.resources import wf_utils
 from beeflow.wf_manager.common import dep_manager
 from beeflow.wf_manager.common import wf_db
+from beeflow.common import wf_data
 
 
-def parse_workflow(workflow_dir, main_cwl, yaml_file):
+def parse_workflow(wf_id, workflow_dir, main_cwl, yaml_file):
     """Run the parser."""
     parser = CwlParser()
     parse_msg = "Unable to parse workflow." \
@@ -32,22 +32,18 @@ def parse_workflow(workflow_dir, main_cwl, yaml_file):
     if yaml_file is not None:
         yaml_path = os.path.join(workflow_dir, yaml_file)
         try:
-            wfi = parser.parse_workflow(cwl_path, yaml_path)
+            wfi = parser.parse_workflow(wf_id, cwl_path, yaml_path)
         except AttributeError:
             log.error('Unable to parse')
             resp = make_response(jsonify(msg=parse_msg, status='error'), 418)
             return resp
     else:
         try:
-            wfi = parser.parse_workflow(cwl_path)
+            wfi = parser.parse_workflow(wf_id, cwl_path)
         except AttributeError:
             resp = make_response(jsonify(msg=parse_msg, status='error'), 418)
             return resp
     return wfi
-
-
-def create_dep_container():
-    """Create new dependency container if one does not currently exist."""
 
 
 # def initialize_wf_profiler(wf_name):
@@ -60,15 +56,15 @@ def create_dep_container():
 #    wf_profiler = WorkflowProfiler(wf_name, output_path)
 
 
-def extract_wf_temp(filename, workflow_archive):
-    """Extract a workflow into a temporary directory."""
-    # Make a temp directory to store the archive
-    tmp_path = tempfile.mkdtemp()
-    archive_path = os.path.join(tmp_path, filename)
+def extract_wf(wf_id, filename, workflow_archive):
+    """Extract a workflow into the workflow directory."""
+    wf_utils.create_workflow_dir(wf_id)
+    wf_dir = wf_utils.get_workflow_dir(wf_id)
+    archive_path = os.path.join(wf_dir, filename)
     workflow_archive.save(archive_path)
-    # Extract to tmp directory
-    subprocess.run(['tar', '-xf', archive_path, '-C', tmp_path], check=False)
-    return tmp_path
+    subprocess.run(['tar', '-xf', archive_path, '-C', wf_dir], check=False)
+    cwl_dir = os.path.join(wf_dir, filename.split('.')[0])
+    return cwl_dir
 
 
 class WFList(Resource):
@@ -110,8 +106,6 @@ class WFList(Resource):
         # None if not sent
         yaml_file = data['yaml']
 
-        dep_manager.kill_gdb()
-        dep_manager.remove_current_run()
         try:
             dep_manager.create_image()
         except dep_manager.NoContainerRuntime:
@@ -120,33 +114,13 @@ class WFList(Resource):
             resp = make_response(jsonify(msg=crt_message, status='error'), 418)
             return resp
 
-        # Remove the current run directory in the bee workdir
-
-        # Save the workflow temporarily to this folder for the parser
-        # This is a temporary measure until we can get the worflow ID before a parse
-        temp_dir = extract_wf_temp(wf_filename, wf_tarball)
+        wf_id = wf_data.generate_workflow_id()
+        wf_dir = extract_wf(wf_id, wf_filename, wf_tarball)
         dep_manager.start_gdb()
         dep_manager.wait_gdb(log, 10)
-
-        wf_path = os.path.join(temp_dir, wf_filename[:-4])
-        wfi = parse_workflow(wf_path, main_cwl, yaml_file)
-
+        wfi = parse_workflow(wf_id, wf_dir, main_cwl, yaml_file)
         # initialize_wf_profiler(wf_name)
         # Save the workflow to the workflow_id dir in the beeflow dir
-        wf_id = wfi.workflow_id
-        bee_workdir = wf_utils.get_bee_workdir()
-        workflow_dir = os.path.join(bee_workdir, 'workflows', wf_id)
-        os.makedirs(workflow_dir)
-
-        # Copy workflow files to later archive
-        for workflow_file in os.listdir(temp_dir):
-            f_path = os.path.join(temp_dir, workflow_file)
-            if os.path.isfile(f_path):
-                shutil.copy(f_path, workflow_dir)
-
-        # We've parsed and added temp files to wf directory so we can chuck it
-        shutil.rmtree(temp_dir, ignore_errors=True)
-
         wf_utils.create_wf_metadata(wf_id, wf_name)
         _, tasks = wfi.get_workflow()
         for task in tasks:
@@ -164,15 +138,16 @@ class WFList(Resource):
                                location='form')
         reqparser.add_argument('wf_filename', type=str, required=True,
                                location='form')
+        reqparser.add_argument('workdir', type=str, required=True,
+                               location='form')
         reqparser.add_argument('workflow_archive', type=FileStorage, required=False,
                                location='files')
-
         data = reqparser.parse_args()
         workflow_archive = data['workflow_archive']
         wf_filename = data['wf_filename']
         wf_name = data['wf_name']
+        wf_workdir = data['workdir']
 
-        dep_manager.kill_gdb()
         try:
             dep_manager.create_image()
         except dep_manager.NoContainerRuntime:
@@ -181,32 +156,33 @@ class WFList(Resource):
             resp = make_response(jsonify(msg=crt_message, status='error'), 418)
             return resp
 
-        # Remove the current run directory in the bee workdir
-        dep_manager.remove_current_run()
-
-        tmp_dir = extract_wf_temp(wf_filename, workflow_archive)
-
-        archive_dir = wf_filename.split('.')[0]
-        gdb_path = os.path.join(tmp_dir, archive_dir, 'gdb')
-        bee_workdir = wf_utils.get_bee_workdir()
-        gdb_workdir = os.path.join(bee_workdir, 'current_run')
-        shutil.copytree(gdb_path, gdb_workdir)
-        shutil.rmtree(tmp_dir)
+        wf_id = wf_data.generate_workflow_id()
+        extract_wf(wf_id, wf_filename, workflow_archive)
         # Launch new container with bindmounted GDB
         dep_manager.start_gdb(reexecute=True)
         dep_manager.wait_gdb(log, 10)
         wfi = wf_utils.get_workflow_interface()
+        wfi.reset_workflow()
+        #archive_dir = wf_filename.split('.')[0]
+        #gdb_path = os.path.join(tmp_dir, archive_dir, 'gdb')
+        #bee_workdir = wf_utils.get_bee_workdir()
+        #gdb_workdir = os.path.join(bee_workdir, 'current_run')
+        #shutil.copytree(gdb_path, gdb_workdir)
+        #shutil.rmtree(tmp_dir)
 
         # Reset the workflow state and generate a new workflow ID
-        wfi.reset_workflow()
-        wf_id = wfi.workflow_id
+        #wf_id = wfi.workflow_id
 
         # Save the workflow to the workflow_id dir
-        wf_id = wfi.workflow_id
-        workflow_dir = os.path.join(bee_workdir, 'workflows', wf_id)
-        os.makedirs(workflow_dir)
+        #wf_id = wfi.workflow_id
+        # workflow_dir = os.path.join(bee_workdir, 'workflows', wf_id)
+        #os.makedirs(workflow_dir)
         wf_utils.create_wf_metadata(wf_id, wf_name)
-
+        _, tasks = wfi.get_workflow()
+        for task in tasks:
+            metadata = wfi.get_task_metadata(task)
+            metadata['workdir'] = wf_workdir
+            wfi.set_task_metadata(task, metadata)
         # Return the wf_id and created
         resp = make_response(jsonify(msg='Workflow uploaded', status='ok',
                              wf_id=wf_id), 201)

--- a/beeflow/wf_manager/resources/wf_utils.py
+++ b/beeflow/wf_manager/resources/wf_utils.py
@@ -22,7 +22,13 @@ def get_workflows_dir():
     return workflows_dir
 
 
-def create_wf_dir(wf_id):
+def get_workflow_dir(wf_id):
+    """Get the workflows directory from beeflow."""
+    workflow_dir = os.path.join(get_workflows_dir(), wf_id)
+    return workflow_dir
+
+
+def create_workflow_dir(wf_id):
     """Create the workflows directory."""
     workflows_dir = get_workflows_dir()
     workflow_dir = os.path.join(workflows_dir, wf_id)


### PR DESCRIPTION
One major refactor and one new feature are added by this PR, which resolves #540:
1. Workflow IDs must be generated before parsing and assigned to the corresponding workflow via the parser. This change was made to accommodate the need to create a workflow directory using the workflow ID before parsing.
2. Support for specifying capture of `stderr` to a file in the CWL parser and graph database, akin to `stdout` which is already supported.

Main changes:
- `generate_workflow_id()` is now a function in `beeflow.common.wf_data`
- The `Workflow` class initializer and `WorkflowInterface.initialize_workflow()` now take a mandatory argument `workflow_id`.
- Likewise, `CwlParser.parse_workflow()` also takes a mandatory argument `workflow_id`, which is likely a breaking change for other components.
- The `Task` class now takes an optional argument `stderr`
- The Neo4j `Task` node now stores an additional property `stderr`.
  - When querying the database, the value of the `stderr` property is assigned back to the recreated `Task` object.
- `beeflow.tests.test_wf_interface` and `beeflow.tests.test_parser` have been updated and are passing.