### PR TITLE
Error handling

### DIFF
--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -8,9 +8,11 @@ import os
 import sys
 import logging
 import inspect
-import shutil
 import pathlib
+import shutil
 import subprocess
+import textwrap
+import time
 import jsonpickle
 import requests
 import typer
@@ -41,21 +43,43 @@ class ClientError(Exception):
         self.args = args
 
 
-def error_exit(msg):
+def error_exit(msg, include_caller=True):
     """Print a message and exit or raise an error with that message."""
-    caller_func = str.capitalize(inspect.stack()[1].function)
-    msg = caller_func + ': ' + msg
+    if include_caller:
+        caller_func = str.capitalize(inspect.stack()[1].function)
+        msg = caller_func + ': ' + msg
     if _INTERACTIVE:
-        typer.secho(msg, fg=typer.colors.RED)
+        typer.secho(msg, fg=typer.colors.RED, file=sys.stderr)
         sys.exit(1)
     else:
         # Raise an error so that client libraries can handle it
         raise ClientError(msg) from None
 
 
+def error_handler(resp): # noqa (this is an error handler, it doesn't need to return an expression)
+    """Handle a 500 error in a response."""
+    if resp.status_code != 500:
+        return resp
+    data = resp.json()
+    if 'error' not in data:
+        return resp
+    error = data['error']
+    error_file = f'bee-error-{int(time.time())}.log'
+    # Save the args and exception info to the file
+    with open(error_file, 'w', encoding='utf-8') as fp:
+        fp.write(f'args: {" ".join(sys.argv)}\n')
+        fp.write(error)
+    msg = ('An error occurred with the WFM. Please save your workflow and the '
+           f'error log "{error_file}". If possible, please report this to the '
+           'BEE development team.')
+    msg = textwrap.fill(msg)
+    error_exit(msg, include_caller=False)
+
+
 def _wfm_conn():
     """Return a connection to the WFM."""
-    return Connection(bc.get('workflow_manager', 'socket'))
+    return Connection(bc.get('workflow_manager', 'socket'),
+                      error_handler=error_handler)
 
 
 def _url():
@@ -77,7 +101,7 @@ def check_short_id_collision():
     conn = _wfm_conn()
     resp = conn.get(_url(), timeout=60)
     if resp.status_code != requests.codes.okay:  # pylint: disable=no-member
-        error_exit("Checking for ID collision failed: {resp.status_code}")
+        error_exit(f"Checking for ID collision failed: {resp.status_code}")
 
     workflow_list = jsonpickle.decode(resp.json()['workflow_list'])
     if workflow_list:

--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -197,6 +197,9 @@ def submit(wf_name: str = typer.Argument(..., help='The workflow name'),
         error_exit('Could not reach WF Manager.')
 
     if resp.status_code != requests.codes.created:  # pylint: disable=no-member
+        if resp.status_code == 400:
+            data = resp.json()
+            error_exit(data['msg'])
         error_exit(f"Submit for {wf_name} failed. Please check the WF Manager.")
 
     check_short_id_collision()

--- a/beeflow/common/api.py
+++ b/beeflow/common/api.py
@@ -1,0 +1,12 @@
+"""BeeApi wrapper around Flask-Restful for handling exceptions."""
+import traceback
+from flask import make_response, jsonify
+from flask_restful import Api
+
+
+class BeeApi(Api):
+    """Wrapper around Flask-Restful's API to catch exceptions."""
+
+    def handle_error(self, e):
+        """Handle an error or exception."""
+        return make_response(jsonify(error=traceback.format_exc()), 500)

--- a/beeflow/common/api.py
+++ b/beeflow/common/api.py
@@ -7,6 +7,6 @@ from flask_restful import Api
 class BeeApi(Api):
     """Wrapper around Flask-Restful's API to catch exceptions."""
 
-    def handle_error(self, e):
+    def handle_error(self, e):  # noqa (conflict on naming in base class vs. following convention)
         """Handle an error or exception."""
         return make_response(jsonify(error=traceback.format_exc()), 500)

--- a/beeflow/common/connection.py
+++ b/beeflow/common/connection.py
@@ -1,6 +1,7 @@
 """Connection class for connecting to other components over a socket."""
 import urllib
 import os
+import requests
 
 import requests_unixsocket
 
@@ -8,11 +9,13 @@ import requests_unixsocket
 class Connection:
     """Connection for sending/receiving requests from a component."""
 
-    def __init__(self, socket, prefix=None):
+    def __init__(self, socket, prefix=None, error_handler=None):
         """Construct a new connection from a socket path."""
         self._socket_path = urllib.parse.quote(socket, safe='')
         self._session = requests_unixsocket.Session()
         self._prefix = prefix
+        self._error_handler = (error_handler if error_handler is not None
+                               else lambda resp: resp)
 
     def _full_url(self, path):
         """Get the full url for a path."""
@@ -22,22 +25,33 @@ class Connection:
             path = os.path.join(self._prefix, path)
         return os.path.join(f'http+unix://{self._socket_path}', path)
 
+    def handle_error(self, resp):
+        """Handle an error, if there is one."""
+        if resp.status_code != requests.codes.okay:  # noqa (pylama can't find the okay member)
+            return self._error_handler(resp)
+        return resp
+
     def get(self, path, *pargs, **kwargs):
         """Do an HTTP GET request."""
-        return self._session.get(self._full_url(path), *pargs, **kwargs)
+        return self.handle_error(self._session.get(self._full_url(path),
+                                                   *pargs, **kwargs))
 
     def put(self, path, *pargs, **kwargs):
         """Do an HTTP PUT request."""
-        return self._session.put(self._full_url(path), *pargs, **kwargs)
+        return self.handle_error(self._session.put(self._full_url(path),
+                                                   *pargs, **kwargs))
 
     def post(self, path, *pargs, **kwargs):
         """Do an HTTP POST request."""
-        return self._session.post(self._full_url(path), *pargs, **kwargs)
+        return self.handle_error(self._session.post(self._full_url(path),
+                                                    *pargs, **kwargs))
 
     def delete(self, path, *pargs, **kwargs):
         """Do an HTTP DELETE request."""
-        return self._session.delete(self._full_url(path), *pargs, **kwargs)
+        return self.handle_error(self._session.delete(self._full_url(path),
+                                                      *pargs, **kwargs))
 
     def patch(self, path, *pargs, **kwargs):
         """Do an HTTP PATCH request."""
-        return self._session.patch(self._full_url(path), *pargs, **kwargs)
+        return self.handle_error(self._session.patch(self._full_url(path),
+                                                     *pargs, **kwargs))

--- a/beeflow/common/parser/__init__.py
+++ b/beeflow/common/parser/__init__.py
@@ -1,3 +1,3 @@
 """Init code for parser."""
 
-from beeflow.common.parser.parser import CwlParser # noqa
+from beeflow.common.parser.parser import CwlParser, CwlParseError # noqa

--- a/beeflow/common/parser/parser.py
+++ b/beeflow/common/parser/parser.py
@@ -12,6 +12,7 @@ import json
 import os
 import yaml
 import cwl_utils.parser.cwl_v1_2 as cwl_parser
+from schema_salad.exceptions import ValidationException  # noqa (pylama can't find the exception)
 
 from beeflow.common.config_driver import BeeConfig as bc
 from beeflow.common.wf_data import (InputParameter,
@@ -37,6 +38,14 @@ type_map = {
     "File": str,
     "Directory": str,
 }
+
+
+class CwlParseError(Exception):
+    """Parser error class."""
+
+    def __init__(self, *args):
+        """Create a parser error."""
+        self.args = args
 
 
 class CwlParser:
@@ -75,10 +84,13 @@ class CwlParser:
         :rtype: WorkflowInterface
         """
         self.path = cwl_path
-        self.cwl = cwl_parser.load_document(cwl_path)
+        try:
+            self.cwl = cwl_parser.load_document(cwl_path)
+        except ValidationException as err:
+            raise CwlParseError(*err.args) from None
 
         if self.cwl.class_ != "Workflow":
-            raise ValueError(f"{os.path.basename(cwl_path)} class must be Workflow")
+            raise CwlParseError(f"{os.path.basename(cwl_path)} class must be Workflow")
 
         if job:
             # Parse input job params into self.params
@@ -100,8 +112,8 @@ class CwlParser:
             if input_id not in self.params:
                 return None
             if not isinstance(self.params[input_id], type_map[type_]):
-                raise ValueError("Input/param types do not match: "
-                                 f"{input_id}/{self.params[input_id]}")
+                raise CwlParseError("Input/param types do not match: "
+                                    f"{input_id}/{self.params[input_id]}")
             return self.params[input_id]
 
         workflow_name = os.path.basename(cwl_path).split(".")[0]
@@ -140,7 +152,7 @@ class CwlParser:
             step_id = _shortname(step.id)
 
         if step_cwl.class_ != "CommandLineTool":
-            raise ValueError(f"Step {step.id} class must be CommandLineTool")
+            raise CwlParseError(f"Step {step.id} class must be CommandLineTool")
 
         step_name = os.path.basename(step_id).split(".")[0]
         step_command = step_cwl.baseCommand
@@ -171,13 +183,14 @@ class CwlParser:
             with open(job, encoding="utf-8") as fp:
                 self.params = json.load(fp)
         else:
-            raise ValueError("Unsupported input job file extension")
+            raise CwlParseError("Unsupported input job file extension (only .yml "
+                                "and .json supported)")
 
         for k, v in self.params.items():
             if not isinstance(k, str):
-                raise ValueError(f"Invalid input job key: {str(k)}")
+                raise CwlParseError(f"Invalid input job key: {str(k)}")
             if not isinstance(v, (str, int, float)):
-                raise ValueError(f"Invalid input job parameter type: {type(v)}")
+                raise CwlParseError(f"Invalid input job parameter type: {type(v)}")
 
     @staticmethod
     def parse_step_inputs(cwl_in, step_inputs):
@@ -200,7 +213,8 @@ class CwlParser:
             # be set by the GDB later
             if _shortname(step_input.id) not in source_map.keys():
                 if isinstance(step_input.type, str) and step_input.default is None:
-                    raise ValueError(f"required input {_shortname(step_input.id)} not satisfied")
+                    raise CwlParseError(f"required input {_shortname(step_input.id)} "
+                                        "not satisfied")
                 continue
 
             if isinstance(step_input.type, str):
@@ -244,14 +258,14 @@ class CwlParser:
         outputs = []
         for out in out_short:
             if out not in out_map.keys():
-                raise ValueError(f"specified step output {out} not produced by CommandLineTool")
+                raise CwlParseError(f"specified step output {out} not produced by CommandLineTool")
 
             output_type = out_map[out].type
             glob = None
             if output_type == "stdout":
                 if not stdout:
-                    raise ValueError((f"stdout capture required for step output {out} "
-                                      "but not specified by CommandLineTool"))
+                    raise CwlParseError(f"stdout capture required for step output {out} "
+                                        "but not specified by CommandLineTool")
                 # Fill in glob with value of stdout
                 glob = stdout
             else:
@@ -280,9 +294,14 @@ class CwlParser:
                 # Load in the dockerfile at parse time
                 if 'dockerFile' in items:
                     base_path = os.path.dirname(self.path)
-                    path = os.path.join(base_path, items['dockerFile'])
-                    with open(path, encoding='utf-8') as fp:
-                        items['dockerFile'] = fp.read()
+                    docker_file = items['dockerFile']
+                    path = os.path.join(base_path, docker_file)
+                    try:
+                        with open(path, encoding='utf-8') as fp:
+                            items['dockerFile'] = fp.read()
+                    except FileNotFoundError:
+                        msg = f'Could not find the docker file: {docker_file}'
+                        raise CwlParseError(msg) from None
                 reqs.append(Hint(req['class'], items))
         else:
             for req in requirements:

--- a/beeflow/scheduler/algorithms.py
+++ b/beeflow/scheduler/algorithms.py
@@ -99,6 +99,7 @@ class Backfill(Algorithm):
     scheduling algorithm.
     """
 
+    @staticmethod
     def load(**kwargs):
         """Load algorithm configuration, if necessary."""
 

--- a/beeflow/wf_manager/wf_manager.py
+++ b/beeflow/wf_manager/wf_manager.py
@@ -1,7 +1,7 @@
 """Start up the workflow manager connecting all of the endpoints."""
 
 from flask import Flask
-from flask_restful import Api
+from beeflow.common.api import BeeApi
 from beeflow.common.config_driver import BeeConfig as bc
 
 from beeflow.wf_manager.resources.wf_list import WFList
@@ -16,7 +16,7 @@ import beeflow.common.log as bee_logging
 def create_app():
     """Create flask app object and add REST endpoints."""
     app = Flask(__name__)
-    api = Api(app)
+    api = BeeApi(app)
 
     # Add endpoints
     api.add_resource(WFList, '/bee_wfm/v1/jobs/')


### PR DESCRIPTION
This is one attempt to make error messages a little easier to work with for the user.

I modified the parser so that whenever it has an error, it throws a `CwlParseError`. The wf_manager catches this, saves the error message and then passes it back to the client in a 400 error response.

Error messages are still a little cryptic, since it sometimes prints the random directory where we untarred the workflow, but I think we can worry about this later.