### PR TITLE
Add a subsection for Slurm job output

### DIFF
--- a/docs/sphinx/advanced_usage.rst
+++ b/docs/sphinx/advanced_usage.rst
@@ -29,11 +29,12 @@ script will go to files in
     The task/step name used within the workflow submission
 
 Within this directory, you can find the submission script and two output files
-for stderr (extensions ``.err``) and stdout (extension ``.out``).
+for stderr (extension ``.err``) and stdout (extension ``.out``).
 
-If something bad happens, such as if BEE fails unexpectedly, then you may want
-to wrap up these output files as well as BEE's general logs and send them to a
-BEE developer for further inspection.
+If something bad happens, such as if BEE fails unexpectedly, then you may need
+to examine these output files. Sometimes the error may have to do with the
+environment or with a task's requirements. If you're unable to find the cause
+of the problem, then you should contact the BEE developers.
 
 .. _Jinja file:
 

--- a/docs/sphinx/advanced_usage.rst
+++ b/docs/sphinx/advanced_usage.rst
@@ -10,7 +10,9 @@ output from other helping programs, such as the container runtime and the batch
 scheduler itself. Sometimes this output can be useful when diagnosing runtime
 failures. In most cases you shouldn't need to use this unless the error is
 outside of your program (this often includes environment-related and
-setup/installation issues).
+setup/installation issues). Note, to allow for better provenance, this output
+is also saved when archiving a workflow. This is also one reason why the
+specific path below should not be changed unless you know what you're doing.
 
 When using the default template (see `Jinja file`_), outputs from the batch
 script will go to files in

--- a/docs/sphinx/advanced_usage.rst
+++ b/docs/sphinx/advanced_usage.rst
@@ -1,5 +1,37 @@
 Advanced Usage
-**********************
+**************
+
+Command and Job Output
+----------------------
+
+When BEE submits steps of a workflow, by default the output from the underlying
+batch scheduler (Slurm, LSF, etc.) will be saved by BEE. This includes all
+output from other helping programs, such as the container runtime and the batch
+scheduler itself. Sometimes this output can be useful when diagnosing runtime
+failures. In most cases you shouldn't need to use this unless the error is
+outside of your program (this often includes environment-related and
+setup/installation issues).
+
+When using the default template (see `Jinja file`_), outputs from the batch
+script will go to files in
+``$bee_workdir/workflows/$workflow_id/$task_name-$task_id``:
+
+``$bee_workdir``
+    BEE's workdir, which is set in the bee.conf file and by default is
+    ``$HOME/.beeflow``
+``$workflow_id``
+    The same ID used to start the workflow
+``$task_id``
+    A randomly generated UUID which BEE uses to keep track of the task
+``$task_name``
+    The task/step name used within the workflow submission
+
+Within this directory, you can find the submission script and two output files
+for stderr (extensions ``.err``) and stdout (extension ``.out``).
+
+If something bad happens, such as if BEE fails unexpectedly, then you may want
+to wrap up these output files as well as BEE's general logs and send them to a
+BEE developer for further inspection.
 
 .. _Jinja file:
 


### PR DESCRIPTION
This adds details on how to find job output for tasks of a workflow.