### PR TITLE
Add formatting improvements to the logger and remove unused logs

### DIFF
--- a/beeflow/common/build/container_drivers.py
+++ b/beeflow/common/build/container_drivers.py
@@ -8,10 +8,12 @@ import shutil
 import subprocess
 import tempfile
 from beeflow.common.config_driver import BeeConfig as bc
-from beeflow.common.log import main_log as log
+from beeflow.common import log as bee_logging
 from beeflow.common.build.build_driver import BuildDriver
-import beeflow.common.log as bee_logging
 from beeflow.common.crt.charliecloud_driver import CharliecloudDriver as crt_driver
+
+
+log = bee_logging.setup(__name__)
 
 
 class ContainerBuildDriver(BuildDriver):
@@ -42,10 +44,6 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         :param kwargs: Dictionary of build system config options
         :type kwargs: set of build system parameters
         """
-        # Store build logs relative to bee_workdir.
-        bee_workdir = bc.get('DEFAULT', 'bee_workdir')
-        _ = bee_logging.save_log(bee_workdir=bee_workdir, log=log,
-                                 logfile='CharliecloudBuildDriver.log')
         # Store build container archive pased on config file or relative to bee_workdir if not set.
         container_archive = bc.get('builder', 'container_archive')
         self.container_archive = bc.resolve_path(container_archive)

--- a/beeflow/common/build_interfaces.py
+++ b/beeflow/common/build_interfaces.py
@@ -13,9 +13,11 @@ import sys
 from subprocess import CalledProcessError
 from beeflow.common.build.container_drivers import CharliecloudBuildDriver
 from beeflow.common.config_driver import BeeConfig as bc
-from beeflow.common.log import main_log as log
-import beeflow.common.log as bee_logging
+from beeflow.common import log as bee_logging
 from beeflow.common.build.build_driver import arg2task
+
+
+log = bee_logging.setup(__name__)
 
 
 def build_main(task):

--- a/beeflow/common/crt/charliecloud_driver.py
+++ b/beeflow/common/crt/charliecloud_driver.py
@@ -8,8 +8,10 @@ from beeflow.common.crt.crt_driver import (ContainerRuntimeDriver, ContainerRunt
 from beeflow.common.config_driver import BeeConfig as bc
 from beeflow.common.build.build_driver import task2arg
 from beeflow.common.container_path import convert_path
-from beeflow.common.log import main_log as log
-import beeflow.common.log as bee_logging
+from beeflow.common import log as bee_logging
+
+
+log = bee_logging.setup(__name__)
 
 
 class CharliecloudDriver(ContainerRuntimeDriver):
@@ -18,10 +20,8 @@ class CharliecloudDriver(ContainerRuntimeDriver):
     Creates the text for the task for using Charliecloud.
     """
 
-    def __init__(self, bee_workdir):
+    def __init__(self):
         """Create CharliecloudDriver object."""
-        # Setup logger
-        bee_logging.save_log(bee_workdir=bee_workdir, log=log, logfile='charliecloud_driver.log')
         # Retrieve Charlicloud options from configuration file.
         self.chrun_opts = bc.get('charliecloud', 'chrun_opts')
         self.cc_setup = bc.get('charliecloud', 'setup')

--- a/beeflow/common/crt_interface.py
+++ b/beeflow/common/crt_interface.py
@@ -22,8 +22,7 @@ class ContainerRuntimeInterface:
         :param crt_driver: container runtime driver (default: CharliecloudDriver)
         :type crt_driver: subclass of ContainerRuntimeDriver
         """
-        bee_workdir = bc.get('DEFAULT', 'bee_workdir')
-        self._crt_driver = crt_driver(bee_workdir)
+        self._crt_driver = crt_driver()
 
     def run_text(self, task):
         """Create text required to run the task using the container_runtime.

--- a/beeflow/common/log.py
+++ b/beeflow/common/log.py
@@ -1,194 +1,23 @@
 """Logging interface for BEE."""
-
-
 import logging
-import sys
 import os
 
 
-STEP_INFO = 15
-logging.addLevelName(STEP_INFO, "STEP_INFO")
-
-# We fallback to the global beeflow.log file
-__module_log__ = None
-
-
-class LogFormatter(logging.Formatter):
-    """Format a string for the log file.
-
-    This is a place to apply rich text formatting.
-
-    Level Values are:
-    DEBUG: 10
-    STEP_INFO: 15
-    INFO: 20
-    WARNING: 30
-    ERROR: 40
-    CRITICAL:50
-    """
-
-    # Log Colors
-    BOLD_CYAN = "[01;36m"
-    RESET = "[0m"
-    BOLD_YELLOW = "[01;33m"
-    BOLD_RED = "[01;31m"
-
-    log_format = {
-        "DEBUG": f"{BOLD_CYAN}%(levelname)s: %(msg)s {RESET}",
-        "STEP_INFO": "%(levelname)s: %(msg)s",
-        "INFO": "%(levelname)s: %(msg)s",
-        "WARNING": f"{BOLD_YELLOW}%(levelname)s: %(msg)s{RESET}",
-        "ERROR": f"{BOLD_RED}%(levelname)s: %(msg)s{RESET}",
-        "CRITICAL": f"{BOLD_RED}%(levelname)s: %(msg)s{RESET}",
-    }
-
-    log_format_no_colors = {
-        "DEBUG": "%(levelname)s: %(msg)s ",
-        "STEP_INFO": "%(levelname)s: %(msg)s",
-        "INFO": "%(levelname)s: %(msg)s",
-        "WARNING": "%(levelname)s: %(msg)s",
-        "ERROR": "%(levelname)s: %(msg)s",
-        "CRITICAL": "%(levelname)s: %(msg)s",
-    }
-
-    def __init__(self, colors):
-        """Initialize formatted loggers.
-
-        :param colors: Format with or without ANSI Escape Code color formatting
-        :type colors: Bool
-        """
-        super(logging.Formatter, self).__init__()
-        self.log_fmt = self.log_format if colors else self.log_format_no_colors
-
-    def format(self, record):
-        """Format record for logging.
-
-        :param record: The part of the log record to extract info from.
-        :type record: logging.LogRecord
-        """
-        fmt = self.log_fmt.get(logging.getLevelName(record.levelno))
-        return logging.Formatter(fmt).format(record)
-
-
-class BeeLogger(logging.Logger):
-    """Extend Python logger to handle custom log category."""
-
-    def step_info(self, msg, *args, **kwargs):
-        r"""Log a messagewith severity 'STEP_INFO'.
-
-        :param msg: Message to be logged
-        :type msg: string
-        :param \*args: List of non-key worded, variable length args.
-        :type \*args: list
-        :param \**kwargs: Key-worded, variable length args.
-        :type \**kwargs: dict
-        """
-        if self.isEnabledFor(STEP_INFO):
-            self._log(STEP_INFO, msg, args, **kwargs)
-
-
-class LevelFilter(logging.Filter):
-    """Filters the level that are to be accepted and rejected."""
-
-    def __init__(self, passlevels, reject):
-        """Initailize pass levels."""
-        super(logging.Filter, self).__init__()
-        self.passlevels = passlevels
-        self.reject = reject
-
-    def filter(self, record):
-        """Return True and False according to the pass levels and reject value.
-
-        :param record: Record from logs
-        :type record: logging.LogRecord
-        """
-        if self.reject:
-            return record.levelno not in self.passlevels
-        return record.levelno in self.passlevels
-
-
-def setup_logging(level="STEP_INFO", colors=True):
-    """Set up logger.
-
-    :param level: Level to be logged in logger.
-    :type level: String
-    """
-    logging.setLoggerClass(BeeLogger)
-    log_ = logging.getLogger("bee")
-    if log_.hasHandlers():
-        log_.setLevel(level)
-        return log_
-    formatter = LogFormatter(colors=colors)
-
-    # Intermediate step info goes to stdout
-    handler1 = logging.StreamHandler(sys.stdout)
-    handler1.addFilter(LevelFilter([logging.INFO, STEP_INFO], False))
-    handler1.setFormatter(formatter)
-
-    # All stepinfo goes to stdout
-    handler2 = logging.StreamHandler(sys.stdout)
-    handler2.addFilter(LevelFilter([logging.INFO, STEP_INFO], True))
-    handler2.setFormatter(formatter)
-
-    log_.addHandler(handler1)
-    log_.addHandler(handler2)
-    log_.setLevel(level)
-    return log_
-
-
-def save_log(bee_workdir, log, logfile):
-    """Set log formatter for handle and add handler to logger.
-
-    :param bc: The BeeConfig object
-    :type bc: beeflow.common.config_driver
-    :param log: The logger object
-    :type log: Logging.logger
-    :param logfile: Path for the logfile
-    :type logfile: String
-    """
-    global __module_log__
-
-    logdir = os.path.join(bee_workdir, 'logs')
-    # Make the logdir if it doesn't exist already
-    os.makedirs(logdir, exist_ok=True)
-    path = os.path.join(bee_workdir, logdir)
-    path = os.path.join(path, logfile)
-
-    handler = logging.FileHandler(path)
-    formatter = LogFormatter(colors=False)
-
-    handler.setFormatter(formatter)
-    log.addHandler(handler)
-    __module_log__ = log
-    return handler
-
-
-def catch_exception(_type, value, traceback):
-    """Catch unhandled exceptions and submit to log."""
-    # Ignore keyboard interrupts so we can close with ctrl+c
-    if issubclass(_type, KeyboardInterrupt):
-        sys.__excepthook__(_type, value, traceback)
-        return
-
-    # If we don't have a module log handler, figure out which log we need
-    if __module_log__ is None:
-        from beeflow.common.log import main_log as log
-        from beeflow.common.config_driver import BeeConfig as bc
-        bc.init()
-        bee_workdir = bc.get('DEFAULT', 'bee_workdir')
-        # Get the filename sans extension
-        path = traceback.tb_frame.f_code.co_filename
-        filename = path.split('/')[-1].rsplit('.', 1)[0]
-        save_log(bee_workdir=bee_workdir, log=log, logfile=f'{filename}.log')
-        log.critical("Uncaught exception", exc_info=(type, value, traceback))
-    else:
-        print(f'__module_log__{__module_log__}')
-        __module_log__.critical("Uncaught exception", exc_info=(_type, value, traceback))
-
-
-# Create the default log (BEE_LOG_LEVEL will be passed in by beeflow/cli.py)
+# Set the default log level (BEE_LOG_LEVEL will be passed in by beeflow/cli.py)
 LEVEL = os.getenv('BEE_LOG_LEVEL')
 LEVEL = 'DEBUG' if LEVEL is None else LEVEL
-main_log = setup_logging(level=LEVEL)
-# Ignore C0415 Import outside toplevel we only do this if we don't have a log handler
-# pylama:ignore=C0415
+
+
+def setup(name):
+    """Set up and return logger.
+
+    :param name: Name to be used for logger (best would be __name__)
+    :type level: String
+    """
+    log = logging.getLogger(name)
+    log.setLevel(LEVEL)
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter('[%(asctime)s] %(name)s:%(funcName)s(): %(msg)s'))
+    log.addHandler(handler)
+    return log

--- a/beeflow/common/worker/lsf_worker.py
+++ b/beeflow/common/worker/lsf_worker.py
@@ -6,8 +6,6 @@ Builds command for submitting batch job.
 import subprocess
 
 from beeflow.common.worker.worker import Worker
-from beeflow.common.log import main_log as log
-import beeflow.common.log as bee_logging
 
 
 class LSFWorker(Worker):
@@ -16,8 +14,6 @@ class LSFWorker(Worker):
     def __init__(self, bee_workdir, **kwargs):
         """Create a new LSF Worker object."""
         super().__init__(bee_workdir, **kwargs)
-        # Setup logger
-        bee_logging.save_log(bee_workdir=bee_workdir, log=log, logfile='LSFWorker.log')
 
         # Table of LSF states for translation to BEE states
         self.bee_states = {'PEND': 'PENDING',

--- a/beeflow/common/worker/slurm_worker.py
+++ b/beeflow/common/worker/slurm_worker.py
@@ -11,8 +11,6 @@ import requests_unixsocket
 import requests
 
 from beeflow.common.worker.worker import (Worker, WorkerError)
-from beeflow.common.log import main_log as log
-import beeflow.common.log as bee_logging
 
 
 class SlurmWorker(Worker):
@@ -29,8 +27,6 @@ class SlurmWorker(Worker):
         encoded_path = urllib.parse.quote(self.slurm_socket, safe="")
         # Note: Socket path is encoded, http request is not generally.
         self.slurm_url = f"http+unix://{encoded_path}/slurm/v0.0.35"
-        # Setup logger
-        bee_logging.save_log(bee_workdir=bee_workdir, log=log, logfile='SlurmWorker.log')
 
     def write_script(self, task):
         """Build task script; returns filename of script."""

--- a/beeflow/common/worker/worker.py
+++ b/beeflow/common/worker/worker.py
@@ -3,8 +3,11 @@
 from abc import ABC, abstractmethod
 import os
 import jinja2
-from beeflow.common.log import main_log as log
+from beeflow.common import log as bee_logging
 from beeflow.common.crt_interface import ContainerRuntimeInterface
+
+
+log = bee_logging.setup(__name__)
 
 
 # Import all implemented container runtime drivers now

--- a/beeflow/scheduler/algorithms.py
+++ b/beeflow/scheduler/algorithms.py
@@ -4,6 +4,7 @@ Code implementing scheduling algorithms, such as FCFS, Backfill, etc.
 """
 
 import abc
+import os
 import time
 
 from beeflow.scheduler import resource_allocation
@@ -270,6 +271,8 @@ class AlgorithmLogWrapper:
         results out to a log file.
         """
         self.cls.schedule_all(tasks, resources, **self.kwargs)
+        # Make the directory, just in case it doesn't exist already
+        os.makedirs(os.path.dirname(self.alloc_logfile), exist_ok=True)
         with open(self.alloc_logfile, 'a', encoding='utf-8') as fp:
             print('; Log start at', time.time(), file=fp)
             # curr_allocs = []

--- a/beeflow/scheduler/scheduler.py
+++ b/beeflow/scheduler/scheduler.py
@@ -2,7 +2,6 @@
 """REST Interface for the BEE Scheduler."""
 
 import argparse
-import sys
 import os
 
 from flask import Flask, request
@@ -12,11 +11,12 @@ from beeflow.scheduler import algorithms
 from beeflow.scheduler import task
 from beeflow.scheduler import resource_allocation
 from beeflow.common.config_driver import BeeConfig as bc
-from beeflow.common.log import main_log as log
 from beeflow.common.db import sched
-import beeflow.common.log as bee_logging
+from beeflow.common import log as bee_logging
 
-sys.excepthook = bee_logging.catch_exception
+
+log = bee_logging.setup(__name__)
+
 
 flask_app = Flask(__name__)
 api = Api(flask_app)
@@ -136,8 +136,6 @@ def create_app():
     """Create the Flask app for the scheduler."""
     # TODO: Refactor this to actually create the app here
     conf = load_config_values()
-    workdir = bc.get('DEFAULT', 'bee_workdir')
-    bee_logging.save_log(bee_workdir=workdir, log=log, logfile='scheduler.log')
     flask_app.sched_conf = conf
     # Load algorithm data
     algorithms.load(**vars(conf))

--- a/beeflow/task_manager.py
+++ b/beeflow/task_manager.py
@@ -25,16 +25,15 @@ bc.init()
 
 print(sys.argv)
 
-from beeflow.common.log import main_log as log
+from beeflow.common import log as bee_logging
 from beeflow.common.build_interfaces import build_main
-import beeflow.common.log as bee_logging
 from beeflow.common.worker_interface import WorkerInterface
 from beeflow.common.connection import Connection
 import beeflow.common.worker as worker_pkg
 from beeflow.common.db import tm
 
-sys.excepthook = bee_logging.catch_exception
 
+log = bee_logging.setup(__name__)
 
 runtime = bc.get('task_manager', 'container_runtime')
 

--- a/beeflow/wf_manager/common/dep_manager.py
+++ b/beeflow/wf_manager/common/dep_manager.py
@@ -10,12 +10,12 @@ import signal
 import subprocess
 import getpass
 
-import beeflow.common.log as bee_logging
+from beeflow.common import log as bee_logging
 from beeflow.wf_manager.resources import wf_utils
 from beeflow.common.config_driver import BeeConfig as bc
 
 
-dep_log = bee_logging.setup_logging(level='DEBUG')
+dep_log = bee_logging.setup(__name__)
 
 
 class NoContainerRuntime(Exception):

--- a/beeflow/wf_manager/resources/wf_actions.py
+++ b/beeflow/wf_manager/resources/wf_actions.py
@@ -2,8 +2,11 @@
 
 from flask import make_response, jsonify
 from flask_restful import Resource, reqparse
-from beeflow.common.log import main_log as log
+from beeflow.common import log as bee_logging
 from beeflow.wf_manager.resources import wf_utils
+
+
+log = bee_logging.setup(__name__)
 
 
 class WFActions(Resource):

--- a/beeflow/wf_manager/resources/wf_list.py
+++ b/beeflow/wf_manager/resources/wf_list.py
@@ -13,13 +13,16 @@ from flask import make_response, jsonify
 from werkzeug.datastructures import FileStorage
 from flask_restful import Resource, reqparse
 
-from beeflow.common.log import main_log as log
+from beeflow.common import log as bee_logging
 # from beeflow.common.wf_profiler import WorkflowProfiler
 from beeflow.common.parser import CwlParser, CwlParseError
 
 from beeflow.wf_manager.resources import wf_utils
 from beeflow.wf_manager.common import dep_manager
 from beeflow.wf_manager.common import wf_db
+
+
+log = bee_logging.setup(__name__)
 
 
 def parse_workflow(workflow_dir, main_cwl, yaml_file):

--- a/beeflow/wf_manager/resources/wf_update.py
+++ b/beeflow/wf_manager/resources/wf_update.py
@@ -10,7 +10,10 @@ import jsonpickle
 from flask import make_response, jsonify
 from flask_restful import Resource, reqparse
 from beeflow.wf_manager.resources import wf_utils
-from beeflow.common.log import main_log as log
+from beeflow.common import log as bee_logging
+
+
+log = bee_logging.setup(__name__)
 
 
 def archive_workflow(wf_id):

--- a/beeflow/wf_manager/wf_manager.py
+++ b/beeflow/wf_manager/wf_manager.py
@@ -8,9 +8,7 @@ from beeflow.wf_manager.resources.wf_list import WFList
 from beeflow.wf_manager.resources.wf_actions import WFActions
 from beeflow.wf_manager.resources.wf_update import WFUpdate
 
-from beeflow.common.log import main_log as log
 from beeflow.wf_manager.resources import wf_utils
-import beeflow.common.log as bee_logging
 
 
 def create_app():
@@ -29,5 +27,4 @@ if __name__ == '__main__':
     flask_app = create_app()
     wfm_listen_port = bc.get('workflow_manager', 'listen_port')
     bee_workdir = wf_utils.get_bee_workdir()
-    handler = bee_logging.save_log(bee_workdir=bee_workdir, log=log, logfile='wf_manager.log')
     flask_app.run(debug=False, port=str(wfm_listen_port))


### PR DESCRIPTION
This removes some of the existing log code and changes the log format to be '[timestamp] module_path:function() message'. The code for creating extra logs, such as in the container driver or slurm worker, has been removed since it was being duplicated in logs for the main components.

Also, if you want to use a log with this, you'll need to call the `setup()` function, something like this:

```
log = bee_logging.setup(__name__)
```