### PR TITLE
Store temporary tarball in .beeflow

### DIFF
--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -178,7 +178,7 @@ def submit(wf_name: str = typer.Argument(..., help='The workflow name'),
         # Check to see if the wf_path is a tarball or a directory. Run package() if directory
         if os.path.isdir(wf_path):
             print("Detected directory instead of packaged workflow. Packaging Directory...")
-            bee_workdir = bc.get('DEFAULT', 'bee_workdir') 
+            bee_workdir = bc.get('DEFAULT', 'bee_workdir')
             package(wf_path, pathlib.Path(bee_workdir))
             tarball_path = pathlib.Path(bee_workdir + "/" + str(wf_path.name) + ".tgz")
             wf_tarball = open(tarball_path, 'rb')

--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -178,7 +178,7 @@ def submit(wf_name: str = typer.Argument(..., help='The workflow name'),
         # Check to see if the wf_path is a tarball or a directory. Run package() if directory
         if os.path.isdir(wf_path):
             print("Detected directory instead of packaged workflow. Packaging Directory...")
-            bee_workdir = bc.get('DEFAULT', 'bee_workdir') + "/archives"
+            bee_workdir = bc.get('DEFAULT', 'bee_workdir') 
             package(wf_path, pathlib.Path(bee_workdir))
             tarball_path = pathlib.Path(bee_workdir + "/" + str(wf_path.name) + ".tgz")
             wf_tarball = open(tarball_path, 'rb')


### PR DESCRIPTION
Instead of storing the temporary tarball in the archives directory, this PR will just store the tarball in the .beeflow directory. 