### PR TITLE
Pylama exclusion review

### DIFF
--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -440,9 +440,3 @@ def main():
 
 if __name__ == "__main__":
     app()
-
-# Pylint is reporting no member for requests.codes even when they exist
-#     ignoring them line by line
-# Ignore using with for open files; used to send command.
-# Ignore W0511: This is a TODO that should be addressed later
-# pylama:ignore=R1732,W0511

--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -440,3 +440,7 @@ def main():
 
 if __name__ == "__main__":
     app()
+
+# Ignore W0511: This allows us to have TODOs in the code
+# Ignore R1732: Significant code restructuring required to fix
+# pylama:ignore=W0511,R1732

--- a/beeflow/cloud_launcher.py
+++ b/beeflow/cloud_launcher.py
@@ -205,8 +205,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-# Ignore R1732: Using a 'with' statement for resource allocation doesn't really apply here. We'd
-#               need to completely restructure the code to use it, but it's something to think
-#               about later on.
-# Ignore W0511: This TODO needs to be addressed later on, perhaps with a restructure of this code.
-# pylama:ignore=R1732,W0511

--- a/beeflow/cloud_launcher.py
+++ b/beeflow/cloud_launcher.py
@@ -205,3 +205,6 @@ def main():
 
 if __name__ == '__main__':
     main()
+# Ignore R1732: Significant code restructuring required to fix
+# Ignore W0511: This allows us to have TODOs in the code
+# pylama:ignore=W0511,R1732

--- a/beeflow/common/build/container_drivers.py
+++ b/beeflow/common/build/container_drivers.py
@@ -423,5 +423,3 @@ class SingularityBuildDriver(ContainerBuildDriver):
         param_output_directory may be used to override DockerRequirement
         specs.
         """
-# Ignore W0231: linter doesn't know about abstract classes, it's ok to now call the parent __init__
-# pylama:ignore=W0231

--- a/beeflow/common/build/container_drivers.py
+++ b/beeflow/common/build/container_drivers.py
@@ -423,3 +423,5 @@ class SingularityBuildDriver(ContainerBuildDriver):
         param_output_directory may be used to override DockerRequirement
         specs.
         """
+# Ignore W0231: linter doesn't know about abstract classes, it's ok to now call the parent __init__
+# pylama:ignore=W0231

--- a/beeflow/common/cloud/cloud.py
+++ b/beeflow/common/cloud/cloud.py
@@ -7,6 +7,3 @@ class CloudError(Exception):
     def __init__(self, msg):
         """Cloud error constructor."""
         self.msg = msg
-# Ignore W0231: This is a user-defined exception so the base class doesn't
-#               usually need to be called.
-# pylama:ignore=W0231

--- a/beeflow/common/cloud/google.py
+++ b/beeflow/common/cloud/google.py
@@ -39,6 +39,3 @@ class GoogleProvider(provider.Provider):
             res = call.execute()
             print(res)
             time.sleep(2)
-# Ignore E1101: Pylama notes that self._api doesn't have an 'instances' member.
-#               I believe this is set at runtime by googleapiclient.
-# pylama:ignore=E1101

--- a/beeflow/common/gdb/neo4j_driver.py
+++ b/beeflow/common/gdb/neo4j_driver.py
@@ -577,4 +577,3 @@ def _reconstruct_metadata(metadata_record):
     rec = metadata_record["m"]
     return {key: val for key, val in rec.items() if key != "state"}
 
-# pylama:ignore=E1129

--- a/beeflow/common/gdb/neo4j_driver.py
+++ b/beeflow/common/gdb/neo4j_driver.py
@@ -577,3 +577,5 @@ def _reconstruct_metadata(metadata_record):
     rec = metadata_record["m"]
     return {key: val for key, val in rec.items() if key != "state"}
 
+# Ignore E1129: External module is missing proper resource context manager methods.
+# pylama:ignore=E1129

--- a/beeflow/common/worker/worker.py
+++ b/beeflow/common/worker/worker.py
@@ -134,6 +134,3 @@ class Worker(ABC):
         :type job_id: int
         :rtype: string
         """
-
-# Ignore W0511: Ignore TODOs since we will want to address this later.
-# pylama:ignore=W0511

--- a/beeflow/common/worker/worker.py
+++ b/beeflow/common/worker/worker.py
@@ -134,3 +134,6 @@ class Worker(ABC):
         :type job_id: int
         :rtype: string
         """
+
+# Ignore W0511: This allows us to have TODOs in the code
+# pylama:ignore=W0511

--- a/beeflow/scheduler/algorithms.py
+++ b/beeflow/scheduler/algorithms.py
@@ -262,3 +262,6 @@ def choose(algorithm=None, default_algorithm=None, **kwargs):
     if algorithm is not None:
         cls = algorithm_objects[algorithm]
     return AlgorithmLogWrapper(cls, **kwargs)
+
+# Ignore W0511: This allows us to have TODOs in the code
+# pylama:ignore=W0511

--- a/beeflow/scheduler/algorithms.py
+++ b/beeflow/scheduler/algorithms.py
@@ -262,10 +262,3 @@ def choose(algorithm=None, default_algorithm=None, **kwargs):
     if algorithm is not None:
         cls = algorithm_objects[algorithm]
     return AlgorithmLogWrapper(cls, **kwargs)
-# Ignoring E0211: This is how the class is designed right now, we should think about changing this
-#                 however.
-# Ignoring W0511: A number of these TODO's are hinted at in issue #333, but I don't want to remove
-#                 them from the code until this issue is fully addressed.
-# Ignoring R0903: Too few public methods, not sure how this calculated and this will be fixed with
-#                 issue #333
-# pylama:ignore=E0211,C0415,W0511,R0903

--- a/beeflow/scheduler/resource_allocation.py
+++ b/beeflow/scheduler/resource_allocation.py
@@ -259,5 +259,3 @@ class Allocation(serializable.Serializable):
         :type data: dict
         """
         return Allocation(**data)
-# Ignore W0511: This is related to issue #333.
-# pylama:ignore=W0511

--- a/beeflow/scheduler/resource_allocation.py
+++ b/beeflow/scheduler/resource_allocation.py
@@ -259,3 +259,6 @@ class Allocation(serializable.Serializable):
         :type data: dict
         """
         return Allocation(**data)
+
+# Ignore W0511: This allows us to have TODOs in the code
+# pylama:ignore=W0511

--- a/beeflow/scheduler/scheduler.py
+++ b/beeflow/scheduler/scheduler.py
@@ -142,5 +142,5 @@ def create_app():
     os.makedirs(conf.workdir, exist_ok=True)
     return flask_app
 
-# Ignore todo's or pylama fails
+# Ignore W0511: This allows us to have TODOs in the code
 # pylama:ignore=W0511

--- a/beeflow/task_manager.py
+++ b/beeflow/task_manager.py
@@ -355,6 +355,5 @@ api.add_resource(TaskActions, '/bee_tm/v1/task/')
 #    flask_app.logger.addHandler(handler)
 #    flask_app.run(debug=False, port=str(tm_listen_port))
 
-# Ignoring CO413 beeflow modules must be loaded after bc.init()
 # Ignoring W0703: Catching general exception is ok for failed submit and cancel.
-# pylama:ignore=C0413,W0703
+# pylama:ignore=W0703

--- a/beeflow/tests/test_db_sched.py
+++ b/beeflow/tests/test_db_sched.py
@@ -38,4 +38,6 @@ def test_clear(temp_db):
 
     db.resources.clear()
     assert len(list(db.resources)) == 0
+# Ignore W0621: PyLama complains about redefining 'temp_db' from the outer
+#               scope. This is how pytest fixtures work.
 # pylama:ignore=W0621

--- a/beeflow/tests/test_parser.py
+++ b/beeflow/tests/test_parser.py
@@ -7,8 +7,6 @@ from beeflow.common.parser import CwlParser
 from beeflow.common.wf_data import generate_workflow_id
 from beeflow.tests.mocks import MockWFI
 
-# Disable protected member access warning
-# pylama:ignore=W0212
 
 REPO_PATH = Path(*Path(__file__).parts[:-3])
 

--- a/beeflow/tests/test_wf_interface.py
+++ b/beeflow/tests/test_wf_interface.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python3
 """Unit test module for the BEE workflow interface module."""
 
-# Disable protected member access warning
-# pylama:ignore=W0212
-
 import unittest
 
 from beeflow.common.config_driver import BeeConfig as bc
@@ -661,3 +658,5 @@ class TestWorkflowInterface(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+# Ignore W0212: Access required for unit tests
+# pylama:ignore=W0212

--- a/beeflow/tests/test_wf_manager.py
+++ b/beeflow/tests/test_wf_manager.py
@@ -185,4 +185,4 @@ def test_resume_workflow(client, mocker, setup_teardown_workflow):
     resp = client().patch(f'/bee_wfm/v1/jobs/{WF_ID}', json=request)
     assert resp.json['status'] == 'Workflow Resumed'
     assert resp.status_code == 200
-# pylama:ignore=W0613,W0621
+# pylama:ignore=W0621,W0613


### PR DESCRIPTION
This PR cleans up some of the pylama exclusions which no longer apply since their issues have been fixed, and keeps the exclusions which are still necessary. Many of the exclusions which were kept are related to "#TODO" comment style documentation, and semantics which are necessary for unit testing. 

During this work I also found a few exclusions which will remain despite the advice because it will require a significant rework of some code in order to be in compliance. 
As an example, we should at some point fix any pylama R1732 issues in the code. Which talks about using "with structures" and a context manager for allocating resources. 
Secondly we should also eventually fix all of the pylama W0611 issues. This has to deal with catching exceptions at a level which is too general and therefore causes us to hide the underlying issue when the exception occurs. 
