### PR TITLE
Slurm command line worker

### DIFF
--- a/beeflow/cli.py
+++ b/beeflow/cli.py
@@ -24,6 +24,9 @@ from beeflow.common.config_driver import BeeConfig as bc
 from beeflow.common import cli_connection
 
 
+bc.init()
+
+
 class ComponentManager:
     """Component manager class."""
 
@@ -140,6 +143,12 @@ def open_log(component):
     return open(log, 'a', encoding='utf-8')
 
 
+# Slurmrestd will be started only if we're running with Slurm and
+# slurm::use_commands is not True
+NEED_SLURMRESTD = (bc.get('DEFAULT', 'workload_scheduler') == 'Slurm'
+                   and not bc.get('slurm', 'use_commands'))
+
+
 @MGR.component('wf_manager', ('scheduler',))
 def start_wfm():
     """Start the WFM."""
@@ -149,7 +158,12 @@ def start_wfm():
                                 sock_path, stdout=fp, stderr=fp)
 
 
-@MGR.component('task_manager', ('slurmrestd',))
+TM_DEPS = []
+if NEED_SLURMRESTD:
+    TM_DEPS.append('slurmrestd')
+
+
+@MGR.component('task_manager', TM_DEPS)
 def start_task_manager():
     """Start the TM."""
     fp = open_log('task_manager')
@@ -168,21 +182,22 @@ def start_scheduler():
 
 
 # Workflow manager and task manager need to be opened with PIPE for their stdout/stderr
-@MGR.component('slurmrestd')
-def start_slurm_restd():
-    """Start BEESlurmRestD. Returns a Popen process object."""
-    bee_workdir = bc.get('DEFAULT', 'bee_workdir')
-    slurmrestd_log = '/'.join([bee_workdir, 'logs', 'restd.log'])
-    slurm_socket = bc.get('slurmrestd', 'slurm_socket')
-    openapi_version = bc.get('slurmrestd', 'openapi_version')
-    slurm_args = f'-s openapi/{openapi_version}'
-    subprocess.run(['rm', '-f', slurm_socket], check=True)
-    # log.info("Attempting to open socket: {}".format(slurm_socket))
-    fp = open(slurmrestd_log, 'w', encoding='utf-8') # noqa
-    cmd = ['slurmrestd']
-    cmd.extend(slurm_args.split())
-    cmd.append(f'unix:{slurm_socket}')
-    return subprocess.Popen(cmd, stdout=fp, stderr=fp)
+if NEED_SLURMRESTD:
+    @MGR.component('slurmrestd')
+    def start_slurm_restd():
+        """Start BEESlurmRestD. Returns a Popen process object."""
+        bee_workdir = bc.get('DEFAULT', 'bee_workdir')
+        slurmrestd_log = '/'.join([bee_workdir, 'logs', 'restd.log'])
+        slurm_socket = bc.get('slurm', 'slurmrestd_socket')
+        openapi_version = bc.get('slurm', 'openapi_version')
+        slurm_args = f'-s openapi/{openapi_version}'
+        subprocess.run(['rm', '-f', slurm_socket], check=True)
+        # log.info("Attempting to open socket: {}".format(slurm_socket))
+        fp = open(slurmrestd_log, 'w', encoding='utf-8') # noqa
+        cmd = ['slurmrestd']
+        cmd.extend(slurm_args.split())
+        cmd.append(f'unix:{slurm_socket}')
+        return subprocess.Popen(cmd, stdout=fp, stderr=fp)
 
 
 def handle_terminate(signum, stack): # noqa
@@ -206,9 +221,6 @@ def check_dependencies():
     # Check for Charliecloud and it's version
     if not shutil.which('ch-run'):
         warn('Charliecloud is not loaded. Please ensure that it is accessible on your path.')
-        sys.exit(1)
-    if not shutil.which('slurmrestd'):
-        warn('slurmrestd is not available. Please ensure that it is accessible on your path.')
         sys.exit(1)
     cproc = subprocess.run(['ch-run', '-V'], capture_output=True, text=True,
                            check=True)
@@ -291,6 +303,8 @@ def start(foreground: bool = typer.Option(False, '--foreground', '-F',
     beeflow_log = log_fname('beeflow')
     check_dependencies()
     sock_path = bc.get('DEFAULT', 'beeflow_socket')
+    if bc.get('DEFAULT', 'workload_scheduler') == 'Slurm' and not NEED_SLURMRESTD:
+        print('Not using slurmrestd')
     # Note: there is a possible race condition here, however unlikely
     if os.path.exists(sock_path):
         # Try to contact for a status
@@ -367,7 +381,6 @@ def version_callback(version: bool = False):
 
 def main():
     """Start the beeflow app."""
-    bc.init()
     app()
 
 

--- a/beeflow/cli.py
+++ b/beeflow/cli.py
@@ -304,7 +304,7 @@ def start(foreground: bool = typer.Option(False, '--foreground', '-F',
     check_dependencies()
     sock_path = bc.get('DEFAULT', 'beeflow_socket')
     if bc.get('DEFAULT', 'workload_scheduler') == 'Slurm' and not NEED_SLURMRESTD:
-        print('Not using slurmrestd')
+        warn('Not using slurmrestd. Command-line interface will be used.')
     # Note: there is a possible race condition here, however unlikely
     if os.path.exists(sock_path):
         # Try to contact for a status

--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -209,6 +209,8 @@ def validate_nonnegative_int(value):
     return i
 
 
+# NOTE: You must use validate_bool for all boolean values (since just using
+#       bool, as in bool('False'), gives True for any string of length > 0)
 def validate_bool(value):
     """Validate a boolean value."""
     return str(value).lower() == 'true'
@@ -402,13 +404,16 @@ VALIDATOR.option('builder', 'container_archive',
 VALIDATOR.option('builder', 'container_type', attrs={'default': 'charliecloud'},
                  info='container type to use')
 # Slurmrestd (depends on DEFAULT:workload_scheduler == Slurm)
-VALIDATOR.section('slurmrestd', info='Configuration section for Slurmrestd.',
+VALIDATOR.section('slurm', info='Configuration section for Slurm.',
                   depends_on=('DEFAULT', 'workload_scheduler', 'Slurm'))
+VALIDATOR.option('slurm', 'use_commands', validator=validate_bool,
+                 attrs={'default': shutil.which('slurmrestd') is None},
+                 info='if set, use slurm cli commands instead of slurmrestd')
 DEFAULT_SLURMRESTD_SOCK = join_path('/tmp', f'slurm_{USER}_{random.randint(1, 10000)}.sock')
-VALIDATOR.option('slurmrestd', 'slurm_socket', validator=validate_parent_dir,
+VALIDATOR.option('slurm', 'slurmrestd_socket', validator=validate_parent_dir,
                  attrs={'default': DEFAULT_SLURMRESTD_SOCK},
                  info='socket location')
-VALIDATOR.option('slurmrestd', 'openapi_version', attrs={'default': 'v0.0.37'},
+VALIDATOR.option('slurm', 'openapi_version', attrs={'default': 'v0.0.37'},
                  info='openapi version to use for slurmrestd')
 # Scheduler
 VALIDATOR.section('scheduler', info='Scheduler configuration section.')

--- a/beeflow/common/worker/slurm_worker.py
+++ b/beeflow/common/worker/slurm_worker.py
@@ -16,20 +16,8 @@ from beeflow.common.worker.worker import (Worker, WorkerError)
 log = bee_logging.setup(__name__)
 
 
-class SlurmWorker(Worker):
-    """The Worker for systems where Slurm is the Work Load Manager."""
-
-    def __init__(self, bee_workdir, openapi_version, **kwargs):
-        """Create a new Slurm Worker object."""
-        super().__init__(bee_workdir, **kwargs)
-        # Pull slurm socket configs from kwargs (Uses getpass.getuser() instead
-        # of os.getlogin() because of an issue with using getlogin() without a
-        # controlling terminal)
-        self.slurm_socket = kwargs.get('slurm_socket', f'/tmp/slurm_{getpass.getuser()}.sock')
-        self.session = requests_unixsocket.Session()
-        encoded_path = urllib.parse.quote(self.slurm_socket, safe="")
-        # Note: Socket path is encoded, http request is not generally.
-        self.slurm_url = f"http+unix://{encoded_path}/slurm/{openapi_version}"
+class BaseSlurmWorker(Worker):
+    """Base slurm worker code."""
 
     def build_text(self, task):
         """Build text for task script; use template if it exists."""
@@ -77,11 +65,42 @@ class SlurmWorker(Worker):
             script_f.close()
         return task_script
 
-    @staticmethod
-    def query_job(job_id, session, slurm_url):
-        """Query slurm for job status."""
+    def submit_job(self, script):
+        """Worker submits job-returns (job_id, job_state)."""
+        res = subprocess.run(['sbatch', '--parsable', script], text=True,  # noqa if we use check=True here, then we can't see stderr
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if res.returncode != 0:
+            raise WorkerError(f'Failed to submit job: {res.stderr}')
+        job_id = int(res.stdout)
+        job_state = self.query_task(job_id)
+        return job_id, job_state
+
+    def submit_task(self, task):
+        """Worker builds & submits script."""
+        task_script = self.write_script(task)
+        job_id, job_state = self.submit_job(task_script)
+        return job_id, job_state
+
+
+class SlurmrestdWorker(BaseSlurmWorker):
+    """Worker class for when slurmrestd is available."""
+
+    def __init__(self, bee_workdir, openapi_version, **kwargs):
+        """Create a new Slurmrestd Worker object."""
+        super().__init__(bee_workdir, **kwargs)
+        # Pull slurm socket configs from kwargs (Uses getpass.getuser() instead
+        # of os.getlogin() because of an issue with using getlogin() without a
+        # controlling terminal)
+        self.slurm_socket = kwargs.get('slurm_socket', f'/tmp/slurm_{getpass.getuser()}.sock')
+        self.session = requests_unixsocket.Session()
+        encoded_path = urllib.parse.quote(self.slurm_socket, safe="")
+        # Note: Socket path is encoded, http request is not generally.
+        self.slurm_url = f"http+unix://{encoded_path}/slurm/{openapi_version}"
+
+    def query_task(self, job_id):
+        """Worker queries job; returns job_state."""
         try:
-            resp = session.get(f'{slurm_url}/job/{job_id}')
+            resp = self.session.get(f'{self.slurm_url}/job/{job_id}')
 
             if resp.status_code != 200:
                 raise WorkerError(f'Failed to query job {job_id}')
@@ -95,27 +114,6 @@ class SlurmWorker(Worker):
                 raise WorkerError(f'Failed to query job {job_id}') from exc
         except requests.exceptions.ConnectionError:
             job_state = "NOT_RESPONDING"
-        return job_state
-
-    def submit_job(self, script, session, slurm_url):
-        """Worker submits job-returns (job_id, job_state)."""
-        res = subprocess.run(['sbatch', '--parsable', script], text=True,  # noqa if we use check=True here, then we can't see stderr
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if res.returncode != 0:
-            raise WorkerError(f'Failed to submit job: {res.stderr}')
-        job_id = int(res.stdout)
-        job_state = self.query_job(job_id, session, slurm_url)
-        return job_id, job_state
-
-    def submit_task(self, task):
-        """Worker builds & submits script."""
-        task_script = self.write_script(task)
-        job_id, job_state = self.submit_job(task_script, self.session, self.slurm_url)
-        return job_id, job_state
-
-    def query_task(self, job_id):
-        """Worker queries job; returns job_state."""
-        job_state = self.query_job(job_id, self.session, self.slurm_url)
         return job_state
 
     def cancel_task(self, job_id):
@@ -136,6 +134,72 @@ class SlurmWorker(Worker):
             raise WorkerError(errmsg) from exc
         job_state = "CANCELLED"
         return job_state
+
+
+class SlurmCLIWorker(BaseSlurmWorker):
+    """Slurm worker interface that uses the CLI."""
+
+    def query_task(self, job_id):
+        """Query job state for the task."""
+        # Use scontrol since it gives a lot of useful info
+        try:
+            res = subprocess.run(['scontrol', 'show', 'job', str(job_id)],
+                                 text=True, check=True, stdout=subprocess.PIPE)
+        except subprocess.CalledProcessError:
+            raise WorkerError(
+                f'Failed to query job {job_id}'
+            ) from None
+
+        def parse_key_val(pair):
+            """Parse the key-value pair."""
+            i = pair.find('=')
+            return (pair[:i], pair[i + 1:])
+
+        # Output is in a space-separated list of 'key=value' pairs
+        pairs = res.stdout.split()
+        key_vals = dict(parse_key_val(pair) for pair in pairs)
+        log.info(f'Job {job_id} info: {key_vals}')
+        return key_vals['JobState']
+
+    def cancel_task(self, job_id):
+        """Cancel task with job_id; returns job_state."""
+        try:
+            subprocess.run(['scancel', str(job_id)], text=True, check=True)
+        except subprocess.CalledProcessError:
+            raise WorkerError(f'Failed to cancel job {job_id}') from None
+        return 'CANCELLED'
+
+
+class SlurmWorker(Worker):
+    """Main slurm worker class."""
+
+    def __init__(self, use_commands, **kwargs):
+        """Construct the slurm worker.
+
+        :param use_commands: whether or not to use Slurm's CLI
+        :type use_commands: bool
+        """
+        super().__init__(**kwargs)
+        if use_commands:
+            self._inner = SlurmCLIWorker(**kwargs)
+        else:
+            self._inner = SlurmrestdWorker(**kwargs)
+
+    def build_text(self, task):
+        """Build text for task script; use template if it exists."""
+        return self._inner.build_text(task)
+
+    def submit_task(self, task):
+        """Worker submits task; returns job_id, job_state."""
+        return self._inner.submit_task(task)
+
+    def cancel_task(self, job_id):
+        """Cancel task with job_id; returns job_state."""
+        return self._inner.cancel_task(job_id)
+
+    def query_task(self, job_id):
+        """Query job state for the task."""
+        return self._inner.query_task(job_id)
 
 
 def check_slurm_error(data, msg):

--- a/beeflow/task_manager.py
+++ b/beeflow/task_manager.py
@@ -331,8 +331,9 @@ worker_kwargs = {
     'runner_opts': bc.get('task_manager', 'runner_opts'),
 }
 if WLS == 'Slurm':
-    worker_kwargs['slurm_socket'] = bc.get('slurmrestd', 'slurm_socket')
-    worker_kwargs['openapi_version'] = bc.get('slurmrestd', 'openapi_version')
+    worker_kwargs['use_commands'] = bc.get('slurm', 'use_commands')
+    worker_kwargs['slurm_socket'] = bc.get('slurm', 'slurmrestd_socket')
+    worker_kwargs['openapi_version'] = bc.get('slurm', 'openapi_version')
 worker = WorkerInterface(worker_class, **worker_kwargs)
 
 api.add_resource(TaskSubmit, '/bee_tm/v1/task/submit/')

--- a/beeflow/tests/test_slurm_worker.py
+++ b/beeflow/tests/test_slurm_worker.py
@@ -19,7 +19,7 @@ from beeflow.common.wf_data import Task
 # Timeout (seconds) for waiting on tasks
 TIMEOUT = 150
 # Extra slurmrestd arguments. This may be something to take on the command line
-OPENAPI_VERSION = bc.get('slurmrestd', 'openapi_version')
+OPENAPI_VERSION = bc.get('slurm', 'openapi_version')
 GOOD_TASK = Task(name='good-task', base_command=['sleep', '3'], hints=[],
                  requirements=[], inputs=[], outputs=[], stdout='', stderr='',
                  workflow_id=uuid.uuid4().hex)

--- a/beeflow/tests/test_slurm_worker.py
+++ b/beeflow/tests/test_slurm_worker.py
@@ -42,104 +42,86 @@ def wait_state(worker_iface, job_id, state):
     return last_state
 
 
-def setup_slurm_worker(fn):
-    """Add a decorator to set up the worker interface and slurmrestd."""
-
-    def decorator():
-        """Decorate the input function."""
-        slurm_socket = f'/tmp/{uuid.uuid4().hex}.sock'
-        bee_workdir = os.path.expanduser(f'~/{uuid.uuid4().hex}.tmp')
-        os.mkdir(bee_workdir)
-        proc = subprocess.Popen(f'slurmrestd -s openapi/{OPENAPI_VERSION} unix:{slurm_socket}',
-                                shell=True)
-        time.sleep(1)
-        worker_iface = WorkerInterface(worker=SlurmWorker, container_runtime='Charliecloud',
-                                       slurm_socket=slurm_socket, bee_workdir=bee_workdir,
-                                       openapi_version=OPENAPI_VERSION,
-                                       job_template=bc.get('task_manager', 'job_template'))
-        fn(worker_iface)
-        time.sleep(1)
-        proc.kill()
-
-    return decorator
+@pytest.fixture(params=[True, False], ids=['slurm-commands', 'slurmrestd'])
+def slurm_worker(request):
+    """Slurm worker fixture."""
+    slurm_socket = f'/tmp/{uuid.uuid4().hex}.sock'
+    bee_workdir = os.path.expanduser(f'~/{uuid.uuid4().hex}.tmp')
+    os.mkdir(bee_workdir)
+    proc = subprocess.Popen(f'slurmrestd -s openapi/{OPENAPI_VERSION} unix:{slurm_socket}',
+                            shell=True)
+    time.sleep(1)
+    worker_iface = WorkerInterface(worker=SlurmWorker, container_runtime='Charliecloud',
+                                   slurm_socket=slurm_socket, bee_workdir=bee_workdir,
+                                   openapi_version=OPENAPI_VERSION,
+                                   job_template=bc.get('task_manager', 'job_template'),
+                                   use_commands=request.param)
+    yield worker_iface
+    time.sleep(1)
+    proc.kill()
 
 
-def setup_worker_iface(fn):
-    """Add a decorator that creates the worker interface but not slurmrestd."""
-
-    def decorator():
-        """Decorate the input function."""
-        slurm_socket = f'/tmp/{uuid.uuid4().hex}.sock'
-        bee_workdir = os.path.expanduser(f'~/{uuid.uuid4().hex}.tmp')
-        os.mkdir(bee_workdir)
-        worker_iface = WorkerInterface(worker=SlurmWorker, container_runtime='Charliecloud',
-                                       slurm_socket=slurm_socket, bee_workdir=bee_workdir,
-                                       openapi_version=OPENAPI_VERSION,
-                                       job_template=bc.get('task_manager', 'job_template'))
-        fn(worker_iface)
-
-    return decorator
+@pytest.fixture
+def slurmrestd_worker_no_daemon():
+    """Fixture that creates the worker interface but not slurmrestd."""
+    slurm_socket = f'/tmp/{uuid.uuid4().hex}.sock'
+    bee_workdir = os.path.expanduser(f'~/{uuid.uuid4().hex}.tmp')
+    os.mkdir(bee_workdir)
+    yield WorkerInterface(worker=SlurmWorker, container_runtime='Charliecloud',
+                          slurm_socket=slurm_socket, bee_workdir=bee_workdir,
+                          openapi_version=OPENAPI_VERSION,
+                          job_template=bc.get('task_manager', 'job_template'),
+                          use_commands=False)
 
 
-@setup_slurm_worker
-def test_good_task(worker_iface):
+def test_good_task(slurm_worker):
     """Test submission of a good task."""
-    job_id, last_state = worker_iface.submit_task(GOOD_TASK)
+    job_id, last_state = slurm_worker.submit_task(GOOD_TASK)
     assert last_state == 'PENDING'
-    last_state = wait_state(worker_iface, job_id, 'PENDING')
+    last_state = wait_state(slurm_worker, job_id, 'PENDING')
     if last_state == 'RUNNING':
-        last_state = wait_state(worker_iface, job_id, 'RUNNING')
+        last_state = wait_state(slurm_worker, job_id, 'RUNNING')
     if last_state == 'COMPLETING':
-        last_state = wait_state(worker_iface, job_id, 'COMPLETING')
+        last_state = wait_state(slurm_worker, job_id, 'COMPLETING')
     assert last_state == 'COMPLETED'
 
 
-@setup_slurm_worker
-def test_bad_task(worker_iface):
+def test_bad_task(slurm_worker):
     """Test submission of a bad task."""
-    job_id, last_state = worker_iface.submit_task(BAD_TASK)
+    job_id, last_state = slurm_worker.submit_task(BAD_TASK)
     assert last_state == 'PENDING'
-    last_state = wait_state(worker_iface, job_id, 'PENDING')
+    last_state = wait_state(slurm_worker, job_id, 'PENDING')
     if last_state == 'RUNNING':
-        last_state = wait_state(worker_iface, job_id, 'RUNNING')
+        last_state = wait_state(slurm_worker, job_id, 'RUNNING')
     if last_state == 'COMPLETING':
-        last_state = wait_state(worker_iface, job_id, 'COMPLETING')
+        last_state = wait_state(slurm_worker, job_id, 'COMPLETING')
     assert last_state == 'FAILED'
 
 
-@setup_slurm_worker
-def test_query_bad_job_id(worker_iface):
+def test_query_bad_job_id(slurm_worker):
     """Test querying a bad job ID."""
     with pytest.raises(WorkerError):
-        worker_iface.query_task(888)
+        slurm_worker.query_task(888)
 
 
-@setup_slurm_worker
-def test_cancel_good_job(worker_iface):
+def test_cancel_good_job(slurm_worker):
     """Cancel a good job."""
-    job_id, _ = worker_iface.submit_task(GOOD_TASK)
-    job_state = worker_iface.cancel_task(job_id)
+    job_id, _ = slurm_worker.submit_task(GOOD_TASK)
+    job_state = slurm_worker.cancel_task(job_id)
     assert job_state == 'CANCELLED'
 
 
-# This test is broken in CI, but works locally. I'm commenting it out for now
-# @setup_slurm_worker
-# def test_cancel_bad_job_id(worker_iface):
-#    """Cancel a non-existent job."""
-#    with pytest.raises(WorkerError):
-#        worker_iface.cancel_task(888)
-
-
-@setup_worker_iface
-def test_no_slurmrestd(worker_iface):
+def test_no_slurmrestd(slurmrestd_worker_no_daemon):
     """Test without running slurmrestd."""
-    job_id, state = worker_iface.submit_task(GOOD_TASK)
+    worker = slurmrestd_worker_no_daemon
+    job_id, state = worker.submit_task(GOOD_TASK)
     assert state == 'NOT_RESPONDING'
-    assert worker_iface.query_task(job_id) == 'NOT_RESPONDING'
-    assert worker_iface.cancel_task(job_id) == 'NOT_RESPONDING'
+    assert worker.query_task(job_id) == 'NOT_RESPONDING'
+    assert worker.cancel_task(job_id) == 'NOT_RESPONDING'
 # Ignoring R1732: This is not what we need to do with the Popen of slurmrestd above;
 #                 using a with statement doesn't kill the process immediately but just
 #                 waits for it to complete and slurmrestd never will unless we kill it.
 # Ignoring E402: "module level import not at top of file" - this is required for
 #                bee config
-# pylama:ignore=R1732,E402
+# Ignoring W0621: Redefinition of names is required for pytest
+# pylama:ignore=R1732,E402,W0621

--- a/ci/bee_install.sh
+++ b/ci/bee_install.sh
@@ -77,8 +77,10 @@ container_output_path = /tmp
 container_type = charliecloud
 container_archive = $HOME/container_archive
 
-[slurmrestd]
-slurm_socket = /tmp/slurm.sock
+[slurm]
+# Just test slurmrestd in CI for now
+use_commands = False
+slurmrestd_socket = /tmp/slurm.sock
 openapi_version = v0.0.37
 EOF
 printf "\n\n"


### PR DESCRIPTION
I think this should address issue #635. It renames the slurmrestd config section to `slurm` and adds a new `use_commands` option that gets set by beecfg.

I'd like to test this somehow, although it probably wouldn't be feasible to do in CI without adding too much time. 