### PR TITLE
Allow Absolute/Relative Paths for Main CWL and YAML Files

### DIFF
--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -167,7 +167,7 @@ app = typer.Typer(no_args_is_help=True, add_completion=False, cls=NaturalOrderGr
 
 
 @app.command()
-def submit(wf_name: str = typer.Argument(..., help='the workflow name'),
+def submit(wf_name: str = typer.Argument(..., help='the workflow name'),  # pylint:disable=R0915
            wf_path: pathlib.Path = typer.Argument(..., help='path to the workflow .tgz or dir'),
            main_cwl: str = typer.Argument(..., help='filename of main CWL file'),
            yaml: str = typer.Argument(..., help='filename of YAML file'),

--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -184,8 +184,8 @@ def submit(wf_name: str = typer.Argument(..., help='the workflow name'),
             bee_workdir = bc.get('DEFAULT', 'bee_workdir')
             # Copy main_cwl and yaml to tempdir and tar it up
             tempdir = tempfile.mkdtemp()
-            os.rename(tempdir, os.path.dirname(tempdir) + "/" + wf_path.name)
-            tempdir = os.path.dirname(tempdir) + "/" + wf_path.name
+            #os.rename(tempdir, os.path.dirname(tempdir) + "/" + wf_path.name)
+            #tempdir = os.path.dirname(tempdir) + "/" + wf_path.name
             tempdir_path = pathlib.Path(tempdir)
             shutil.copytree(wf_path, tempdir_path, dirs_exist_ok=True)
             main_cwl = os.path.expanduser(main_cwl)

--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -195,20 +195,6 @@ def submit(wf_name: str = typer.Argument(..., help='the workflow name'),
     if not os.path.exists(workdir):
         error_exit(f"Workflow working directory \"{workdir}\" doesn't exist")
 
-    # Make sure the main_cwl is an absolute path and exists unless wf_path is tarball
-    if os.path.isdir(wf_path):
-        main_cwl = os.path.expanduser(main_cwl)
-        main_cwl = os.path.abspath(main_cwl)
-        if not os.path.exists(main_cwl):
-            error_exit(f"Workflow CWL file \"{main_cwl}\" doesn't exist")
-
-    # Make sure the yaml is an absolute path and exists unless wf_path is tarball
-    if os.path.isdir(wf_path):
-        yaml = os.path.expanduser(yaml)
-        yaml = os.path.abspath(yaml)
-        if not os.path.exists(yaml):
-            error_exit(f"Workflow parameter YAML file \"{yaml}\" doesn't exist")
-
     # TODO: Can all of this information be sent as a file?
     data = {
         'wf_name': wf_name.encode(),

--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -195,6 +195,20 @@ def submit(wf_name: str = typer.Argument(..., help='the workflow name'),
     if not os.path.exists(workdir):
         error_exit(f"Workflow working directory \"{workdir}\" doesn't exist")
 
+    # Make sure the main_cwl is an absolute path and exists unless wf_path is tarball
+    if os.path.isdir(wf_path):
+        main_cwl = os.path.expanduser(main_cwl)
+        main_cwl = os.path.abspath(main_cwl)
+        if not os.path.exists(main_cwl):
+            error_exit(f"Workflow CWL file \"{main_cwl}\" doesn't exist")
+
+    # Make sure the yaml is an absolute path and exists unless wf_path is tarball
+    if os.path.isdir(wf_path):
+        yaml = os.path.expanduser(yaml)
+        yaml = os.path.abspath(yaml)
+        if not os.path.exists(yaml):
+            error_exit(f"Workflow parameter YAML file \"{yaml}\" doesn't exist")
+
     # TODO: Can all of this information be sent as a file?
     data = {
         'wf_name': wf_name.encode(),

--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -192,10 +192,8 @@ def submit(wf_name: str = typer.Argument(..., help='the workflow name'),
             main_cwl = os.path.abspath(main_cwl)
             yaml = os.path.expanduser(yaml)
             yaml = os.path.abspath(yaml)
-            if not pathlib.Path(tempdir + "/" + os.path.basename(main_cwl)).is_file():
-                shutil.copy2(main_cwl, tempdir_path)
-            if not pathlib.Path(tempdir + "/" + os.path.basename(yaml)).is_file():
-                shutil.copy2(yaml, tempdir_path)
+            shutil.copy2(main_cwl, tempdir_path)
+            shutil.copy2(yaml, tempdir_path)
             package(tempdir_path, pathlib.Path(bee_workdir))
             shutil.rmtree(tempdir_path)
             tarball_path = pathlib.Path(bee_workdir + "/" + str(wf_path.name) + ".tgz")

--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -203,7 +203,7 @@ def submit(wf_name: str = typer.Argument(..., help='the workflow name'),
             error_exit(f"Workflow CWL file \"{main_cwl}\" doesn't exist")
 
     # Make sure the yaml is an absolute path and exists unless wf_path is tarball
-    if os.path.isdir(wf_path) and yaml is not None:
+    if os.path.isdir(wf_path):
         yaml = os.path.expanduser(yaml)
         yaml = os.path.abspath(yaml)
         if not os.path.exists(yaml):

--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -203,7 +203,7 @@ def submit(wf_name: str = typer.Argument(..., help='the workflow name'),
             error_exit(f"Workflow CWL file \"{main_cwl}\" doesn't exist")
 
     # Make sure the yaml is an absolute path and exists unless wf_path is tarball
-    if os.path.isdir(wf_path):
+    if os.path.isdir(wf_path) and yaml is not None:
         yaml = os.path.expanduser(yaml)
         yaml = os.path.abspath(yaml)
         if not os.path.exists(yaml):

--- a/docs/sphinx/commands.rst
+++ b/docs/sphinx/commands.rst
@@ -29,7 +29,10 @@ beeclient
 **beeclient** is the command you will use to submit workflows and interact with your workflows. The following are the options:
 
 ``beeclient submit``: Submit a new workflow. By default this will also start
-jobs immediately (unless passed the ``--no-start`` option).
+jobs immediately (unless passed the ``--no-start`` option). If either the MAIN_CWL or YAML
+files are not contained immediately inside of WF_PATH, then the WF_PATH directory will
+be copied into a temporary directory and the missing files will then be copied
+into the copied WF_PATH directory before packaging and submission.
 
 Arguments:
   - WF_NAME, The workflow name  [required]

--- a/docs/sphinx/examples.rst
+++ b/docs/sphinx/examples.rst
@@ -18,8 +18,8 @@ stdout of this step is then passed as a file to two steps that ``grep`` for
 different words within the text. These can both be run in parallel. The final
 step takes the output files from the grep step and stores these into a tarball.
 
-These input values are stored in a YAML file within the workflow directory. As
-an example we have a default ``input.yml`` file that can be used. It contains:
+These input values are stored in a YAML file. As an example we have a default
+``input.yml`` file that can be used. It contains:
 
 .. code-block::
 
@@ -33,11 +33,11 @@ random words in the file. Finally an output tarball is generated with the name
 ``out.tgz``.
 
 Before running, make sure to take a look at the CWL files that form the
-workflow.  There is a main ``workflow.cwl`` file that stores the worfklow,
-specifies inputs and outputs and lists all of the workflow steps or tasks. Note
+workflow.  There is a main ``workflow.cwl`` file that specifies the workflow,
+inputs and outputs, and all of the workflow steps or tasks. Note
 that each of these steps specifies their step-specific inputs and outputs, as
 well as a ``run`` option, that in this case points to the CWL file that
-contains further information about how to execute the command. When creating a
+further specifies how to execute the command. When creating a
 workflow, you will need to create a similar workflow structure, explicitly list
 dependencies between steps and also describe how to run the steps on the
 system. For more information on writing a workflow please refer to the
@@ -77,7 +77,7 @@ Alternatively, you can also just do the following:
 .. code-block::
 
     cd $WORKDIR_PATH
-    beeclient submit $NAME examples/cat-grep-tar workflow.cwl input.yml $WORKDIR_PATH # Now submit the workflow
+    beeclient submit $NAME examples/cat-grep-tar examples/workflow.cwl examples/input.yml $WORKDIR_PATH # Now submit the workflow
 
 This will automatically do the packaging and create an archive in the
 background to be submitted.
@@ -146,12 +146,14 @@ the beeflow components, refer to :ref:`installation`.
 
 In this example, instead of packaging up the workflow cwl files directory,
 we've just listed the full path. This should auto-detect the directory and
-package it for you. Compare this with the previous example. Other than the
-commands needed, this shouldn't affect the workflow in any way.
+package it for you. Additionally, if the main_cwl and yaml files are not in
+the workflow directory, they will be copied into a temporary copy of the
+workflow directory before packaging. Compare this with the previous example.
+Other than the commands needed, this shouldn't affect the workflow in any way.
 
 .. code-block::
 
-    beeclient submit clamr-example <path to BEE>/examples/clamr-ffmpeg-build clamr_wf.cwl clamr_job.yml .
+    beeclient submit clamr-example <path to BEE>/examples/clamr-ffmpeg-build <path to main_cwl>/clamr_wf.cwl <path to yaml>/clamr_job.yml .
 
 Output:
 

--- a/docs/sphinx/wf_api.rst
+++ b/docs/sphinx/wf_api.rst
@@ -33,12 +33,12 @@ Database
 ===========================
 Task Manager Database
 ---------------------
-.. automodule:: beeflow.common.db.tm
+.. automodule:: beeflow.common.db.tm_db
    :members:
 
 Scheduler Database
 ------------------
-.. automodule:: beeflow.common.db.sched
+.. automodule:: beeflow.common.db.sched_db
    :members:
 
 Configuration

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,13 @@
 [pylama]
 format = pylint
 linters = pycodestyle,pydocstyle,pyflakes,pylint
-ignore = R0902,R0903,R0904,R0912,R0913,R0914,R0916,W0603,W1203,C0413,E0401
+ignore = R0902,R0903,R0904,R0912,R0913,R0914,R0915,R0916,W0603,W1203,C0413,E0401
 # R0902: too many instance attributes (default: 8)
 # R0903: class has too few public methods (default: 2)
 # R0904: class has too many public methods (default: 20)
 # R0912: function or method has too many logical branches (default: 12)
 # R0913: function or method takes too many arguments (default: 5)
+# R0915: function or method has too many statements (default: 50)
 # R0914: function or method has too many local variables (default: 15)
 # R0916: if-statement contains too many boolean expressions (default: 5)
 # W0603: global statement used to update a global variable

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,12 @@
 [pylama]
 format = pylint
 linters = pycodestyle,pydocstyle,pyflakes,pylint
-ignore = R0902,R0903,R0904,R0912,R0913,R0914,R0915,R0916,W0603,W1203,C0413,E0401
+ignore = R0902,R0903,R0904,R0912,R0913,R0914,R0916,W0603,W1203,C0413,E0401
 # R0902: too many instance attributes (default: 8)
 # R0903: class has too few public methods (default: 2)
 # R0904: class has too many public methods (default: 20)
 # R0912: function or method has too many logical branches (default: 12)
 # R0913: function or method takes too many arguments (default: 5)
-# R0915: function or method has too many statements (default: 50)
 # R0914: function or method has too many local variables (default: 15)
 # R0916: if-statement contains too many boolean expressions (default: 5)
 # W0603: global statement used to update a global variable


### PR DESCRIPTION
Allows for use of absolute/relative paths for `main_cwl` and `yaml` files in `beeclient submit` command, supporting autocomplete as requested in #661. This PR resolves #661.