### PR TITLE
Force requests version to < 2.29.0 to fix breaking change with urllib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ flask_restful = "0.3.9"
 cwl-utils = "^0.16"
 APScheduler = "^3.6.3"
 jsonpickle = "^2.2.0"
+# Fix for urllib3 2.0 breaking change (similar error to this https://github.com/docker/docker-py/issues/3113)
+requests = "<2.29.0"
 requests-unixsocket = "^0.3.0"
 python-daemon = "^2.3.1"
 gunicorn = "^20.1.0"


### PR DESCRIPTION
This should hopefully fix a problem with an update to urllib3/requests.

I think we need to look more into how our pyproject.toml lists dependencies. This seems to happen a lot when one of our dependencies does an update and it breaks our code.