### PR TITLE
Issue#711/fix alternate main cwl

### DIFF
--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -201,13 +201,12 @@ def submit(wf_name: str = typer.Argument(..., help='the workflow name'),  # pyli
             if not yaml_path.exists():
                 error_exit(f'YAML file {yaml} does not exist')
 
+            # Packaging in temp dir, after copying alternate cwl_main or yaml file
             cwl_indir = is_parent(wf_path, main_cwl_path)
             yaml_indir = is_parent(wf_path, yaml_path)
             tempdir_path = pathlib.Path(tempfile.mkdtemp())
-            # If all files are in the wf_path use that for packaging
             if cwl_indir and yaml_indir:
                 package_path = package(wf_path, tempdir_path)
-            # If using alternate cwl and/or yaml copy and package from the temp dir
             else:
                 tempdir_wf_path = pathlib.Path(tempdir_path / wf_path.name)
                 shutil.copytree(wf_path, tempdir_wf_path, dirs_exist_ok=False)

--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -250,7 +250,7 @@ VALIDATOR.option('task_manager', 'container_runtime', attrs={'default': 'Charlie
                  info='container runtime to use for configuration')
 VALIDATOR.option('task_manager', 'runner_opts', attrs={'default': ''},
                  info='special runner options to pass to the runner opts')
-VALIDATOR.option('task_manager', 'background_interval', attrs={'default': 10},
+VALIDATOR.option('task_manager', 'background_interval', attrs={'default': 5},
                  validator=int,
                  info='interval at which the task manager processes queues and updates states')
 


### PR DESCRIPTION
This addresses issue #711 by parsing the workflow after moving the wf cwl directory to a tmp directory and copying the alternate files in then packaging and parsing the new package. Previously, the workflow was parsed directly from the workflow path before copying the alternate files. 