### PR TITLE
Delete debug log entry in query task

### DIFF
--- a/beeflow/common/worker/slurm_worker.py
+++ b/beeflow/common/worker/slurm_worker.py
@@ -144,7 +144,6 @@ class SlurmrestdWorker(BaseSlurmWorker):
         try:
             resp = self.session.get(f'{self.slurm_url}/job/{job_id}')
 
-            log.info(resp.text)
             if resp.status_code != 200:
                 raise WorkerError(f'Failed to query job {job_id}')
             data = json.loads(resp.text)


### PR DESCRIPTION
The log entry was causing considerable bloat everytime querying the state of the task happened.