### PR TITLE
Document and fix client cwl paths

### DIFF
--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -175,8 +175,10 @@ app.add_typer(config_driver.app, name='config')
 @app.command()
 def submit(wf_name: str = typer.Argument(..., help='the workflow name'),  # pylint:disable=R0915
            wf_path: pathlib.Path = typer.Argument(..., help='path to the workflow .tgz or dir'),
-           main_cwl: str = typer.Argument(..., help='filename of main CWL file'),
-           yaml: str = typer.Argument(..., help='filename of YAML file'),
+           main_cwl: str = typer.Argument(...,
+           help='main CWL filename (using CWL tarball), path of main CWL (using CWL directory)'),
+           yaml: str = typer.Argument(...,
+           help='yaml filename (using CWL tarball), path of yaml file (using CWL directory)'),
            workdir: pathlib.Path = typer.Argument(...,
            help='working directory for workflow containing input + output files',),
            no_start: bool = typer.Option(False, '--no-start', '-n',

--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -176,9 +176,10 @@ app.add_typer(config_driver.app, name='config')
 def submit(wf_name: str = typer.Argument(..., help='the workflow name'),  # pylint:disable=R0915
            wf_path: pathlib.Path = typer.Argument(..., help='path to the workflow .tgz or dir'),
            main_cwl: str = typer.Argument(...,
-           help='main CWL filename (using CWL tarball), path of main CWL (using CWL directory)'),
+           help='filename of main CWL (if using CWL tarball), ' +
+                'path of main CWL (if using CWL directory)'),
            yaml: str = typer.Argument(...,
-           help='yaml filename (using CWL tarball), path of yaml file (using CWL directory)'),
+           help='yaml filename (if using CWL tarball), path of yaml file (if using CWL directory)'),
            workdir: pathlib.Path = typer.Argument(...,
            help='working directory for workflow containing input + output files',),
            no_start: bool = typer.Option(False, '--no-start', '-n',

--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -177,9 +177,10 @@ def submit(wf_name: str = typer.Argument(..., help='the workflow name'),  # pyli
            wf_path: pathlib.Path = typer.Argument(..., help='path to the workflow .tgz or dir'),
            main_cwl: str = typer.Argument(...,
            help='filename of main CWL (if using CWL tarball), ' +
-                'path of main CWL (if using CWL directory)'),
+           'path of main CWL (if using CWL directory)'),
            yaml: str = typer.Argument(...,
-           help='yaml filename (if using CWL tarball), path of yaml file (if using CWL directory)'),
+           help='filename of yaml file (if using CWL tarball), ' +
+           'path of yaml file (if using CWL directory)'),
            workdir: pathlib.Path = typer.Argument(...,
            help='working directory for workflow containing input + output files',),
            no_start: bool = typer.Option(False, '--no-start', '-n',

--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -176,11 +176,11 @@ app.add_typer(config_driver.app, name='config')
 def submit(wf_name: str = typer.Argument(..., help='the workflow name'),  # pylint:disable=R0915
            wf_path: pathlib.Path = typer.Argument(..., help='path to the workflow .tgz or dir'),
            main_cwl: str = typer.Argument(...,
-           help='filename of main CWL (if using CWL tarball), ' +
-           'path of main CWL (if using CWL directory)'),
+           help='filename of main CWL (if using CWL tarball), '
+           + 'path of main CWL (if using CWL directory)'),
            yaml: str = typer.Argument(...,
-           help='filename of yaml file (if using CWL tarball), ' +
-           'path of yaml file (if using CWL directory)'),
+           help='filename of yaml file (if using CWL tarball), '
+           + 'path of yaml file (if using CWL directory)'),
            workdir: pathlib.Path = typer.Argument(...,
            help='working directory for workflow containing input + output files',),
            no_start: bool = typer.Option(False, '--no-start', '-n',

--- a/docs/sphinx/commands.rst
+++ b/docs/sphinx/commands.rst
@@ -42,8 +42,8 @@ into the copied WF_PATH directory before packaging and submission.
 Arguments:
   - WF_NAME, The workflow name  [required]
   - WF_PATH, Path to the workflow CWL tarball or directory  [required]
-  - MAIN_CWL, main CWL filename (if using CWL tarball), path of main CWL file (if using CWL directory) [required]
-  - YAML, yaml filename (if using CWL tarball), path of yaml file (if using CWL directory) [required]
+  - MAIN_CWL, filename of main CWL (if using CWL tarball), path of main CWL (if using CWL directory) [required]
+  - YAML, filename of yaml file (if using CWL tarball), path of yaml file (if using CWL directory) [required]
   - WORKDIR, working directory for workflow containing input + output files [required]
   - ``--no-start``, don't start the workflow immediately
 

--- a/docs/sphinx/commands.rst
+++ b/docs/sphinx/commands.rst
@@ -42,8 +42,8 @@ into the copied WF_PATH directory before packaging and submission.
 Arguments:
   - WF_NAME, The workflow name  [required]
   - WF_PATH, Path to the workflow CWL tarball or directory  [required]
-  - MAIN_CWL, main CWL filename (using CWL tarball), path of main CWL file (using CWL directory) [required]
-  - YAML, yaml filename (using CWL tarball), path of yaml file (using CWL directory) [required]
+  - MAIN_CWL, main CWL filename (if using CWL tarball), path of main CWL file (if using CWL directory) [required]
+  - YAML, yaml filename (if using CWL tarball), path of yaml file (if using CWL directory) [required]
   - WORKDIR, working directory for workflow containing input + output files [required]
   - ``--no-start``, don't start the workflow immediately
 

--- a/docs/sphinx/commands.rst
+++ b/docs/sphinx/commands.rst
@@ -42,8 +42,8 @@ into the copied WF_PATH directory before packaging and submission.
 Arguments:
   - WF_NAME, The workflow name  [required]
   - WF_PATH, Path to the workflow CWL tarball or directory  [required]
-  - MAIN_CWL, filename of main CWL file  [required]
-  - YAML, filename of YAML file  [required]
+  - MAIN_CWL, main CWL filename (using CWL tarball), path of main CWL file (using CWL directory) [required]
+  - YAML, yaml filename (using CWL tarball), path of yaml file (using CWL directory) [required]
   - WORKDIR, working directory for workflow containing input + output files [required]
   - ``--no-start``, don't start the workflow immediately
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hpc-beeflow"
-version = "0.1.6rc1"
+version = "0.1.6"
 description = "A software package for containerizing HPC applications and managing job workflows"
 
 


### PR DESCRIPTION
Fix documentation and help text in bee_client, so user will know whether to use a path or filename for the CWL main and yaml files. 