### PR TITLE
Update examples.rst

### DIFF
--- a/docs/sphinx/examples.rst
+++ b/docs/sphinx/examples.rst
@@ -192,7 +192,7 @@ pre-processing building phase and will only be performed once. In this example
 both steps use the container that is built in the pre-processing stage. Once
 the build has been completed the Charliecloud image will be in the container
 archive location specified in the builder section of the bee configuration
-file. You can list contents of the configuration file using ``bee config show``.
+file. You can list contents of the configuration file using ``beeflow config show``.
 
 The status of the workflow will progress to completion and can be queried as
 shown:
@@ -242,7 +242,7 @@ Output:
 
 The archived workflow with associated job outputs will be in the
 **bee_workdir**. See the default section of your configuration file (to list
-configuration file contents run ``bee config show``). This workflow also produces
+configuration file contents run ``beeflow config show``). This workflow also produces
 output from CLAMR and ffmpeg in the directory where you submitted the workflow :
 
 .. code-block::


### PR DESCRIPTION
In the _Getting Started - Example Workflows_ section under the _CLAMR workflow examples (containerized application)_ portion, two instances stating to use `bee config show` to list configuration file contents were changed to `beeflow config show`.