### PR TITLE
Remove Jinja2 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ python = ">=3.8.3,<=3.11"
 
 # Package dependencies
 Flask = { version = "^2.0" }
-Jinja2 = { version = "<3.1" }
 neo4j = { version = "^1.7.4" }
 PyYAML = { version = "^6.0.1" }
 flask_restful = "0.3.9"


### PR DESCRIPTION
Jinja2 is no longer used to generate batch scripts.