### PR TITLE
Initial task manager resiliency and error handling

### DIFF
--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -459,11 +459,9 @@ def query(wf_id: str = typer.Argument(..., callback=match_short_id)):
 
     tasks_status = resp.json()['tasks_status']
     wf_status = resp.json()['wf_status']
-    if tasks_status == 'Unavailable':
-        typer.echo(wf_status)
-    else:
-        typer.echo(wf_status)
-        typer.echo(tasks_status)
+    typer.echo(wf_status)
+    for _task_id, task_name, task_state in tasks_status:
+        typer.echo(f'{task_name}--{task_state}')
 
     logging.info('Query workflow:  {resp.text}')
     return wf_status, tasks_status

--- a/beeflow/common/build/build_driver.py
+++ b/beeflow/common/build/build_driver.py
@@ -1,27 +1,6 @@
 """Abstract base class for the handling build systems."""
 
 from abc import ABC, abstractmethod
-import jsonpickle
-
-
-def arg2task(task_arg):
-    """Convert JSON encoded task to Task object.
-
-    The build driver will expect a Task object, and the build
-    interface starts with a JSON representation of the Task object.
-    """
-    return jsonpickle.decode(task_arg)
-
-
-def task2arg(task):
-    """Convert Task object to JSON encoded string.
-
-    The build interface needs to pass Task data on the command line,
-    because each compute node needs to understand the Task description.
-    JSON format is a convenient way to describe the Task object at the
-    command line.
-    """
-    return jsonpickle.encode(task)
 
 
 class BuildDriver(ABC):

--- a/beeflow/common/build/utils.py
+++ b/beeflow/common/build/utils.py
@@ -1,0 +1,26 @@
+"""Container build utility code."""
+import jsonpickle
+
+
+def arg2task(task_arg):
+    """Convert JSON encoded task to Task object.
+
+    The build driver will expect a Task object, and the build
+    interface starts with a JSON representation of the Task object.
+    """
+    return jsonpickle.decode(task_arg)
+
+
+def task2arg(task):
+    """Convert Task object to JSON encoded string.
+
+    The build interface needs to pass Task data on the command line,
+    because each compute node needs to understand the Task description.
+    JSON format is a convenient way to describe the Task object at the
+    command line.
+    """
+    return jsonpickle.encode(task)
+
+
+class ContainerBuildError(Exception):
+    """Cotnainer build error class."""

--- a/beeflow/common/build_interfaces.py
+++ b/beeflow/common/build_interfaces.py
@@ -14,7 +14,7 @@ from subprocess import CalledProcessError
 from beeflow.common.build.container_drivers import CharliecloudBuildDriver
 from beeflow.common.config_driver import BeeConfig as bc
 from beeflow.common import log as bee_logging
-from beeflow.common.build.build_driver import arg2task
+from beeflow.common.build.utils import arg2task, ContainerBuildError
 
 
 log = bee_logging.setup(__name__)
@@ -47,9 +47,11 @@ def build_main(task):
                 return_code = return_obj.returncode
             except AttributeError:
                 return_code = int(return_obj)
-        except CalledProcessError:
+        except CalledProcessError as error:
             return_code = 1
-            log.warning(f'There was a problem executing {op_dict["op_name"]}!')
+            raise ContainerBuildError(
+                f'There was a problem executing {op_dict["op_name"]}!'
+            ) from error
         # Case 1: Not the last operation spec'd, but is a terminal operation.
         if op_dict["op_terminal"] and return_code == 0:
             op_values = [None, None, None, True]

--- a/beeflow/common/crt/charliecloud_driver.py
+++ b/beeflow/common/crt/charliecloud_driver.py
@@ -8,7 +8,7 @@ import yaml
 from beeflow.common.crt.crt_driver import (ContainerRuntimeDriver, ContainerRuntimeResult,
                                            Command, CommandType)
 from beeflow.common.config_driver import BeeConfig as bc
-from beeflow.common.build.build_driver import task2arg
+from beeflow.common.build.utils import task2arg
 from beeflow.common.container_path import convert_path
 from beeflow.common import log as bee_logging
 

--- a/beeflow/common/crt/singularity_driver.py
+++ b/beeflow/common/crt/singularity_driver.py
@@ -4,7 +4,7 @@ Creates text for tasks using Singularity.
 """
 
 from beeflow.common.crt.crt_driver import (ContainerRuntimeDriver, ContainerRuntimeResult, Command)
-from beeflow.common.build.build_driver import task2arg
+from beeflow.common.build.utils import task2arg
 
 
 class SingularityDriver(ContainerRuntimeDriver):

--- a/beeflow/common/integration/utils.py
+++ b/beeflow/common/integration/utils.py
@@ -91,6 +91,11 @@ class Workflow:
         """Get the status of the workflow."""
         return bee_client.query(self.wf_id)[0]
 
+    @property
+    def task_states(self):
+        """Get the task states of the workflow."""
+        return bee_client.query(self.wf_id)[1]
+
     def cleanup(self):
         """Clean up any leftover workflow data."""
         # Remove the generated tarball
@@ -234,3 +239,9 @@ def check_path_exists(path):
 def check_completed(workflow):
     """Ensure the workflow has a completed status."""
     ci_assert(workflow.status == 'Archived', f'Bad workflow status {workflow.status}')
+
+
+def check_workflow_failed(workflow):
+    """Ensure that the workflow completed in a Failed state."""
+    ci_assert(workflow.status == 'Failed',
+              f'Workflow did not fail as expected (final status: {workflow.status})')

--- a/beeflow/common/integration/utils.py
+++ b/beeflow/common/integration/utils.py
@@ -238,10 +238,10 @@ def check_path_exists(path):
 
 def check_completed(workflow):
     """Ensure the workflow has a completed status."""
-    ci_assert(workflow.status == 'Archived', f'Bad workflow status {workflow.status}')
+    ci_assert(workflow.status == 'Archived', f'bad workflow status {workflow.status}')
 
 
 def check_workflow_failed(workflow):
     """Ensure that the workflow completed in a Failed state."""
     ci_assert(workflow.status == 'Failed',
-              f'Workflow did not fail as expected (final status: {workflow.status})')
+              f'workflow did not fail as expected (final status: {workflow.status})')

--- a/beeflow/common/integration_test.py
+++ b/beeflow/common/integration_test.py
@@ -194,6 +194,20 @@ def multiple_workflows(outer_workdir):
         utils.check_path_exists(path)
 
 
+@TEST_RUNNER.add()
+def build_failure(outer_workdir):
+    """Test running a workflow with a bad container."""
+    workdir = os.path.join(outer_workdir, uuid.uuid4().hex)
+    os.makedirs(workdir)
+    workflow = utils.Workflow('build-failure', 'ci/test_workflows/build-failure',
+                              main_cwl='workflow.cwl', job_file='input.yml',
+                              workdir=workdir, containers=[])
+    yield [workflow]
+    utils.check_workflow_failed(workflow)
+    # Only one task
+    util.ci_assert(workflow.task_states[0][2] == 'BUILD_FAILED')
+
+
 @TEST_RUNNER.add(ignore=True)
 def checkpoint_restart(outer_workdir):
     """Test the clamr-ffmpeg checkpoint restart workflow."""
@@ -220,8 +234,7 @@ def checkpoint_restart_failure(outer_workdir):
                               main_cwl='workflow.cwl', job_file='input.yml',
                               workdir=workdir, containers=[])
     yield [workflow]
-    utils.ci_assert(workflow.status == 'Failed',
-                    f'Workflow did not fail as expected (final status: {workflow.status})')
+    utils.check_workflow_failed(workflow)
 
 
 def test_input_callback(arg):

--- a/beeflow/common/integration_test.py
+++ b/beeflow/common/integration_test.py
@@ -205,7 +205,9 @@ def build_failure(outer_workdir):
     yield [workflow]
     utils.check_workflow_failed(workflow)
     # Only one task
-    util.ci_assert(workflow.task_states[0][2] == 'BUILD_FAILED')
+    task_state = workflow.task_states[0][2]
+    utils.ci_assert(task_state == 'BUILD_FAIL',
+                    f'task was not in state BUILD_FAIL as expected: {task_state}')
 
 
 @TEST_RUNNER.add(ignore=True)

--- a/beeflow/task_manager/background.py
+++ b/beeflow/task_manager/background.py
@@ -7,6 +7,7 @@ import traceback
 import jsonpickle
 from beeflow.task_manager import utils
 from beeflow.common import log as bee_logging
+from beeflow.common.build.utils import ContainerBuildError
 from beeflow.common.build_interfaces import build_main
 
 
@@ -49,6 +50,10 @@ def submit_task(db, worker, task):
         # place job in queue to monitor
         db.job_queue.push(task=task, job_id=job_id, job_state=job_state)
         # update_task_metadata(task.id, task_metadata)
+    except ContainerBuildError as err:
+        job_state = 'BUILD_FAIL'
+        log.error(f'Failed to build container for {task.name}: {err}')
+        log.error(f'{task.name} state: {job_state}')
     except Exception as err:  # noqa (we have to catch everything here)
         # Set job state to failed
         job_state = 'SUBMIT_FAIL'

--- a/beeflow/tests/test_wf_manager.py
+++ b/beeflow/tests/test_wf_manager.py
@@ -190,7 +190,8 @@ def test_workflow_status(client, mocker, setup_teardown_workflow, temp_db):
     temp_db.workflows.add_task(124, WF_ID, 'task', "RUNNING")
 
     resp = client().get(f'/bee_wfm/v1/jobs/{WF_ID}')
-    assert 'RUNNING' in resp.json['tasks_status']
+    tasks_status = resp.json['tasks_status']
+    assert tasks_status[0][2] == 'RUNNING' or tasks_status[1][2] == 'RUNNING'
 
 
 def test_cancel_workflow(client, mocker, setup_teardown_workflow, temp_db):

--- a/beeflow/wf_manager/resources/wf_actions.py
+++ b/beeflow/wf_manager/resources/wf_actions.py
@@ -42,13 +42,11 @@ class WFActions(Resource):
         if not tasks:
             log.info(f"Bad query for wf {wf_id}.")
             wf_status = 'No workflow with that ID is currently loaded'
-            tasks_status.append('Unavailable')
             resp = make_response(jsonify(tasks_status=tasks_status,
                                  wf_status=wf_status, status='not found'), 404)
 
         for task in tasks:
-            tasks_status.append(f"{task.name}--{task.state}")
-        tasks_status = '\n'.join(tasks_status)
+            tasks_status.append((task.id, task.name, task.state))
         wf_status = db.workflows.get_workflow_state(wf_id)
 
         resp = make_response(jsonify(tasks_status=tasks_status,

--- a/ci/test_workflows/build-failure/Dockerfile.build-failure
+++ b/ci/test_workflows/build-failure/Dockerfile.build-failure
@@ -1,0 +1,3 @@
+FROM some_nonexistent_container
+
+RUN touch /file

--- a/ci/test_workflows/build-failure/input.yml
+++ b/ci/test_workflows/build-failure/input.yml
@@ -1,0 +1,1 @@
+fname: /file

--- a/ci/test_workflows/build-failure/workflow.cwl
+++ b/ci/test_workflows/build-failure/workflow.cwl
@@ -1,0 +1,32 @@
+# Dummy workflow designed to fail at the container build stage
+class: Workflow
+cwlVersion: v1.2
+
+inputs:
+  fname: string
+
+outputs:
+  step0_stdout:
+    type: File
+    outputSource: step0/step0_stdout
+
+steps:
+  step0:
+    run:
+      class: CommandLineTool
+      baseCommand: ls
+      stdout: step0_stdout.txt
+      inputs:
+        fname:
+          type: string
+          inputBinding: {}
+      outputs:
+        step0_stdout:
+          type: stdout
+    in:
+      fname: fname
+    out: [step0_stdout]
+    hints:
+      DockerRequirement:
+        dockerFile: "Dockerfile.build-failure"
+        beeflow:containerName: "build-failure"


### PR DESCRIPTION
These are some initial changes to improve resiliency and error-handling in the task manager. This doesn't completely resolve issues #675 and #676, but I thought I'd open this now since these changes are relatively self-contained. Rusty and I discussed those issues and we were thinking it might be best to have a longer discussion about them and the interaction between the task manager and the workflow manager.

Also, I think this should resolve #550. The builder should now be throwing exceptions when it fails to build or pull a container. I added an integration test case for an invalid container build.