### PR TITLE
Redis locale fix

### DIFF
--- a/beeflow/client/core.py
+++ b/beeflow/client/core.py
@@ -228,6 +228,7 @@ def init_components():
         # strings.
         env = dict(os.environ)
         env['LANG'] = 'C'
+        env['LC_ALL'] = 'C'
         return subprocess.Popen(cmd, env=env, stdout=log, stderr=log)
 
     # Workflow manager and task manager need to be opened with PIPE for their stdout/stderr
@@ -251,7 +252,7 @@ def init_components():
     return mgr
 
 
-MIN_CHARLIECLOUD_VERSION = (0, 34)
+MIN_CHARLIECLOUD_VERSION = (0, 33)
 
 
 def version_str(version):

--- a/beeflow/client/core.py
+++ b/beeflow/client/core.py
@@ -252,7 +252,7 @@ def init_components():
     return mgr
 
 
-MIN_CHARLIECLOUD_VERSION = (0, 33)
+MIN_CHARLIECLOUD_VERSION = (0, 34)
 
 
 def version_str(version):


### PR DESCRIPTION
This PR fixes an error that occurs on certain systems where the redis containers fails to start with a `Failed to configure LOCALE for invalid locale name` message. This PR fixes it by additionally setting `LANG_ALL` which will override any other localization settings if `LANG` doesn't work with the container configuration. 