### PR TITLE
Ensure failed tasks cause dependent tasks to fail

### DIFF
--- a/beeflow/common/integration/utils.py
+++ b/beeflow/common/integration/utils.py
@@ -248,5 +248,5 @@ def check_completed(workflow):
 
 def check_workflow_failed(workflow):
     """Ensure that the workflow completed in a Failed state."""
-    ci_assert(workflow.status == 'Failed',
+    ci_assert(workflow.status == 'Archived/Failed',
               f'workflow did not fail as expected (final status: {workflow.status})')

--- a/beeflow/common/integration/utils.py
+++ b/beeflow/common/integration/utils.py
@@ -96,6 +96,11 @@ class Workflow:
         """Get the task states of the workflow."""
         return bee_client.query(self.wf_id)[1]
 
+    def get_task_state_by_name(self, name):
+        """Get the state of a task by name."""
+        task_states = self.task_states
+        return [task_state for _, task_name, task_state in task_states if task_name == name][0]
+
     def cleanup(self):
         """Clean up any leftover workflow data."""
         # Remove the generated tarball

--- a/beeflow/common/integration_test.py
+++ b/beeflow/common/integration_test.py
@@ -210,6 +210,27 @@ def build_failure(outer_workdir):
                     f'task was not in state BUILD_FAIL as expected: {task_state}')
 
 
+@TEST_RUNNER.add()
+def dependent_tasks_fail(outer_workdir):
+    """Test that dependent tasks don't run after a failure."""
+    workdir = os.path.join(outer_workdir, uuid.uuid4().hex)
+    os.makedirs(workdir)
+    workflow = utils.Workflow('failure-dependent-tasks',
+                              'ci/test_workflows/failure-dependent-tasks',
+                              main_cwl='workflow.cwl', job_file='input.yml',
+                              workdir=workdir, containers=[])
+    yield [workflow]
+    utils.check_workflow_failed(workflow)
+    # Check each task state
+    fail_state = workflow.get_task_state_by_name('fail')
+    utils.ci_assert(fail_state == 'FAILED',
+                    f'task fail did not fail as expected: {fail_state}')
+    for task in ['dependent0', 'dependent1', 'dependent2']:
+        task_state = workflow.get_task_state_by_name(task)
+        utils.ci_assert(task_state == 'DEP_FAIL',
+                        f'task {task} did not get state DEP_FAIL as expected: {task_state}')
+
+
 @TEST_RUNNER.add(ignore=True)
 def checkpoint_restart(outer_workdir):
     """Test the clamr-ffmpeg checkpoint restart workflow."""

--- a/beeflow/common/wf_data.py
+++ b/beeflow/common/wf_data.py
@@ -287,7 +287,10 @@ class Task:
         nonpositional_inputs = []
         for input_ in self.inputs:
             if input_.value is None:
-                raise ValueError("trying to construct command for task with missing input value")
+                raise ValueError(
+                    ("trying to construct command for task with missing input value "
+                     f"(id: {input_.id})")
+                )
 
             if input_.position is not None:
                 positional_inputs.append(input_)

--- a/ci/test_workflows/failure-dependent-tasks/input.yml
+++ b/ci/test_workflows/failure-dependent-tasks/input.yml
@@ -1,0 +1,2 @@
+fname: some_file_that_doesnt_exist
+cat_argument: -n

--- a/ci/test_workflows/failure-dependent-tasks/workflow.cwl
+++ b/ci/test_workflows/failure-dependent-tasks/workflow.cwl
@@ -1,0 +1,105 @@
+cwlVersion: v1.2
+class: Workflow
+
+inputs:
+  fname: File
+  cat_argument: string
+
+outputs:
+  fail_stdout:
+    type: File
+    outputSource: fail/fail_stdout
+  dependent0_stdout:
+    type: File
+    outputSource: dependent0/dependent_stdout
+  dependent1_stdout:
+    type: File
+    outputSource: dependent1/dependent_stdout
+  dependent2_stdout:
+    type: File
+    outputSource: dependent2/dependent_stdout
+
+steps:
+  fail:
+    run:
+      class: CommandLineTool
+      baseCommand: [ls]
+      stdout: fail.txt
+      inputs:
+        fname:
+          type: File
+          inputBinding:
+            position: 1
+      outputs:
+        fail_stdout:
+          type: stdout
+    in:
+      fname: fname
+    out: [fail_stdout]
+  # Two duplicate tasks that depend on the task above, which should fail and cause these to not run.
+  dependent0:
+    run:
+      cwlVersion: v1.2
+      class: CommandLineTool
+      baseCommand: [cat]
+      stdout: dependent.txt
+      inputs:
+        cat_argument:
+          type: string
+          inputBinding:
+            position: 1
+        file_to_cat:
+          type: File
+          inputBinding:
+            position: 1
+      outputs:
+        dependent_stdout:
+          type: stdout
+    in:
+      file_to_cat: fail/fail_stdout
+      cat_argument: cat_argument
+    out: [dependent_stdout]
+  dependent1:
+    run:
+      cwlVersion: v1.2
+      class: CommandLineTool
+      baseCommand: [cat]
+      stdout: dependent1.txt
+      inputs:
+        cat_argument:
+          type: string
+          inputBinding:
+            position: 1
+        file_to_cat:
+          type: File
+          inputBinding:
+            position: 2
+      outputs:
+        dependent_stdout:
+          type: stdout
+    in:
+      cat_argument: cat_argument
+      file_to_cat: fail/fail_stdout
+    out: [dependent_stdout]
+  dependent2:
+    run:
+      cwlVersion: v1.2
+      class: CommandLineTool
+      baseCommand: [cat]
+      stdout: dependent1.txt
+      inputs:
+        cat_argument:
+          type: string
+          inputBinding:
+            position: 1
+        file_to_cat:
+          type: File
+          inputBinding:
+            position: 2
+      outputs:
+        dependent_stdout:
+          type: stdout
+    in:
+      cat_argument: cat_argument
+      file_to_cat: dependent1/dependent_stdout
+    out: [dependent_stdout]


### PR DESCRIPTION
This should address issue #688. When a task fails, all dependent tasks will get a state of `DEP_FAIL` and the workflow will fail without running anything else. 