### PR TITLE
Fix issues building the documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ gunicorn = "^20.1.0"
 typer = "^0.5.0"
 # Seems to be required for Flux
 cffi = "^1.15.1"
+jinja2 = "<3.1"
 celery = { version = "^5.3.4", extras = ["redis", "sqlalchemy"] }
 
 # Cloud optional dependencies


### PR DESCRIPTION
The error in building the last documentation, seems to stem from the issue documented here: https://github.com/readthedocs/readthedocs.org/issues/9038

I added a constraint as recommended by that thread to our pyproject.toml to fix that. 

I tested that fix in a virtual github codespace. 
