### PR TITLE
Correct WIP and no ci label usage

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,12 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    types: [opened, synchronize, edited]
+    types: [opened, synchronize, edited, labeled, unlabeled]
     branches: [main, develop]
 
 jobs:
   docs:
+    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP (no-ci)')) && !(contains(github.event.pull_request.labels.*.name, 'WIP (lint-only)')) }}
     name: Build Docs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ env: {}
 
 jobs:
   integration-test:
-    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP') || contains(github.event.pull_request.labels.*.name, 'lint-only')) }}
+    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP (no-ci)')) && !(contains(github.event.pull_request.labels.*.name, 'WIP (lint-only)')) }}
     name: BEE Integration Test
     strategy:
       matrix:

--- a/.github/workflows/pylama.yml
+++ b/.github/workflows/pylama.yml
@@ -7,11 +7,12 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    types: [opened, synchronize, edited]
+    types: [opened, synchronize, edited, labeled, unlabeled]
     branches: [main, develop]
 
 jobs:
   pylama:
+    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP (no-ci)')) }}
     name: PyLama Lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ env: {}
 
 jobs:
   integration-test:
-    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP') || contains(github.event.pull_request.labels.*.name, 'lint-only')) }}
+    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP (no-ci)')) && !(contains(github.event.pull_request.labels.*.name, 'WIP (lint-only)')) }}
     name: BEE Unit Tests
     env:
       # Unit tests are only run with Slurm right now


### PR DESCRIPTION
This PR fixes github actions to run  CI on 'WIP' labeled PR's and not on PR's with 'no ci' label.
Also the 'WIP (no-lint)' will only run pylama.

Addresses #821 