### PR TITLE
Fix status display

### DIFF
--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -83,6 +83,7 @@ To check the status of the bee components run:
     beeflow core status
 
 .. code-block::
+
     beeflow components:
     redis ... RUNNING
     scheduler ... RUNNING


### PR DESCRIPTION
Corrects the display in the documentation for ``beeflow core status``.  The code block was not displaying.