### PR TITLE
Update TM for task update resiliency

### DIFF
--- a/beeflow/common/wf_data.py
+++ b/beeflow/common/wf_data.py
@@ -20,6 +20,9 @@ StepOutput = namedtuple("StepOutput", ["id", "type", "value", "glob"])
 Requirement = namedtuple("Requirement", ["class_", "params"])
 # CWL hint class
 Hint = namedtuple("Hint", ["class_", "params"])
+# Task state update, usually sent from the task manager
+TaskStateUpdate = namedtuple("TaskStateUpdate", ["wf_id", "task_id", "job_state",
+                                                 "task_info", "output", "metadata"])
 
 
 def generate_workflow_id():

--- a/beeflow/wf_manager/resources/wf_update.py
+++ b/beeflow/wf_manager/resources/wf_update.py
@@ -66,67 +66,60 @@ class WFUpdate(Resource):
     def __init__(self):
         """Set up arguments."""
         self.reqparse = reqparse.RequestParser()
-        self.reqparse.add_argument('wf_id', type=str, location='json',
-                                   required=True)
-        self.reqparse.add_argument('task_id', type=str, location='json',
-                                   required=True)
-        self.reqparse.add_argument('job_state', type=str, location='json',
-                                   required=True)
-        self.reqparse.add_argument('metadata', type=str, location='json',
-                                   required=False)
-        self.reqparse.add_argument('task_info', type=str, location='json',
-                                   required=False)
-        self.reqparse.add_argument('output', location='json', required=False)
+        self.reqparse.add_argument('state_updates', type=str, location='json', required=True)
 
     def put(self):
-        """Update the state of a task from the task manager."""
+        """Do a batch update of task states from the task manager."""
         db = connect_db(wfm_db, db_path)
         data = self.reqparse.parse_args()
-        wf_id = data['wf_id']
-        task_id = data['task_id']
-        job_state = data['job_state']
+        state_updates = jsonpickle.decode(data['state_updates'])
 
-        wfi = wf_utils.get_workflow_interface(wf_id)
-        task = wfi.get_task_by_id(task_id)
-        wfi.set_task_state(task, job_state)
-        db.workflows.update_task_state(task_id, wf_id, job_state)
+        for state_update in state_updates:
+            self.update_task_state(state_update, db)
+
+        return make_response(jsonify(status=('Tasks updated successfully')), 200)
+
+    def handle_metadata(self, state_update, task, wfi):
+        """Handle metadata for a task update."""
+        bee_workdir = wf_utils.get_bee_workdir()
 
         # Get metadata from update if available
-        if 'metadata' in data:
-            if data['metadata'] is not None:
-                metadata = jsonpickle.decode(data['metadata'])
-                wfi.set_task_metadata(task, metadata)
+        if state_update.metadata is not None:
+            old_metadata = wfi.get_task_metadata(task)
+            old_metadata.update(state_update.metadata)
+            wfi.set_task_metadata(task, old_metadata)
 
-        bee_workdir = wf_utils.get_bee_workdir()
         # Get output from the task
-        if 'metadata' in data:
-            if data['metadata'] is not None:
-                metadata = jsonpickle.decode(data['metadata'])
-                old_metadata = wfi.get_task_metadata(task)
-                old_metadata.update(metadata)
-                wfi.set_task_metadata(task, old_metadata)
-
-        if 'output' in data and data['output'] is not None:
+        if state_update.output is not None:
             fname = f'{wfi.workflow_id}_{task.id}_{int(time.time())}.json'
             task_output_path = os.path.join(bee_workdir, fname)
             with open(task_output_path, 'w', encoding='utf8') as fp:
-                json.dump(json.loads(data['output']), fp, indent=4)
+                json.dump(state_update.output, fp, indent=4)
 
-        if 'task_info' in data and data['task_info'] is not None:
-            task_info = jsonpickle.decode(data['task_info'])
-            checkpoint_file = task_info['checkpoint_file']
+    def handle_checkpoint_restart(self, state_update, task, wfi, db):
+        """Handle checkpoint restart for a task update.
+
+        Returns True if a checkpoint-restart was done, else False (indicating
+        that more state handling is necessary).
+        """
+        if state_update.task_info is not None:
+            checkpoint_file = state_update.task_info['checkpoint_file']
             new_task = wfi.restart_task(task, checkpoint_file)
             if new_task is None:
                 log.info('No more restarts')
-                archive_fail_workflow(db, wf_id)
-                return make_response(jsonify(status=f'Task {task_id} set to {job_state}'))
-            db.workflows.add_task(new_task.id, wf_id, new_task.name, "WAITING")
+                archive_fail_workflow(db, state_update.wf_id)
+                return True
+            db.workflows.add_task(new_task.id, state_update.wf_id, new_task.name, "WAITING")
             # Submit the restart task
             tasks = [new_task]
-            wf_utils.schedule_submit_tasks(wf_id, tasks)
-            return make_response(jsonify(status='Task {task_id} restarted'))
+            wf_utils.schedule_submit_tasks(state_update.wf_id, tasks)
+            log.info(f'Task {state_update.task_id} restarted')
+            return True
+        return False
 
-        if job_state == 'COMPLETED':
+    def handle_state_change(self, state_update, task, wfi, db):
+        """Handle a normal state change for a task."""
+        if state_update.job_state == 'COMPLETED':
             for output in task.outputs:
                 if output.glob is not None:
                     wfi.set_task_output(task, output.id, output.glob)
@@ -136,31 +129,36 @@ class WFUpdate(Resource):
             log.info(f'next tasks to run: {tasks}')
             wf_state = wfi.get_workflow_state()
             if tasks and wf_state != 'PAUSED':
-                wf_utils.schedule_submit_tasks(wf_id, tasks)
+                wf_utils.schedule_submit_tasks(state_update.wf_id, tasks)
 
             if wfi.workflow_completed():
                 log.info("Workflow Completed")
                 wf_id = wfi.workflow_id
-                archive_workflow(db, wf_id)
-                pid = db.workflows.get_gdb_pid(wf_id)
+                archive_workflow(db, state_update.wf_id)
+                pid = db.workflows.get_gdb_pid(state_update.wf_id)
                 dep_manager.kill_gdb(pid)
 
         # If the job failed and it doesn't include a checkpoint-restart hint,
         # then fail the entire workflow
-        if job_state == 'FAILED':
-            set_dependent_tasks_dep_fail(db, wfi, wf_id, task)
+        if state_update.job_state == 'FAILED':
+            set_dependent_tasks_dep_fail(db, wfi, state_update.wf_id, task)
             log.info("Workflow failed")
             log.info("Shutting down GDB")
             wf_id = wfi.workflow_id
             archive_fail_workflow(db, wf_id)
 
-        if job_state == 'BUILD_FAIL':
+        if state_update.job_state == 'BUILD_FAIL':
             log.error(f'Workflow failed due to failed container build for task {task.name}')
-            archive_fail_workflow(db, wf_id)
+            archive_fail_workflow(db, state_update.wf_id)
 
-        resp = make_response(jsonify(status=(f'Task {task_id} belonging to WF {wf_id} set to'
-                                             f'{job_state}')), 200)
-        return resp
-# Ignoring C901,R0915: "'WFUPdate.put' is too complex" - this requires a refactor
-#                      (or maybe the LOC limit is too low)
-# pylama:ignore=C901,R0915
+    def update_task_state(self, state_update, db):
+        """Update the state of a single task from the task manager."""
+        wfi = wf_utils.get_workflow_interface(state_update.wf_id)
+        task = wfi.get_task_by_id(state_update.task_id)
+        wfi.set_task_state(task, state_update.job_state)
+        db.workflows.update_task_state(state_update.task_id, state_update.wf_id,
+                                       state_update.job_state)
+
+        self.handle_metadata(state_update, task, wfi)
+        if not self.handle_checkpoint_restart(state_update, task, wfi, db):
+            self.handle_state_change(state_update, task, wfi, db)


### PR DESCRIPTION
I think this should address issues #676 and #675. This adds an update queue to store task updates from the Task Manager to ensure they aren't lost if the Workflow Manager is down.

I'm marking this WIP since we had the Task Manager resiliency meeting several weeks ago and I may have forgotten something here.