### PR TITLE
Allow removal of a workflow with any Archive status

### DIFF
--- a/beeflow/client/bee_client.py
+++ b/beeflow/client/bee_client.py
@@ -374,7 +374,7 @@ def remove(wf_id: str = typer.Argument(..., callback=match_short_id)):
 
     wf_status = get_wf_status(wf_id)
     print(f"Workflow Status is {wf_status}")
-    if wf_status in ('Cancelled', 'Archived', 'Paused'):
+    if wf_status in ('Cancelled', 'Paused') or 'Archived' in wf_status:
         verify = f"All stored information for workflow {_short_id(wf_id)} will be removed."
         verify += "\nContinue to remove? yes(y)/no(n): """
         response = input(verify)


### PR DESCRIPTION
When attempting to remove a workflow with the new Archive/Failed status, it was not allowed because beeflow wasn't aware of this status and thought the workflow might be running. This PR now allows any workflow with a status containing Archive to be removed.
