### PR TITLE
validate shell environment in pre/post script files

### DIFF
--- a/beeflow/common/parser/parser.py
+++ b/beeflow/common/parser/parser.py
@@ -282,7 +282,7 @@ class CwlParser:
 
     def _read_requirement_file(self, key, items, state=0):
         """Read in a requirement file and replace it in the parsed items.
-        
+
         :param state: tracks if pre/post script capability is enabled
         :type state: 0 is default, 1 is True
         """

--- a/beeflow/common/parser/parser.py
+++ b/beeflow/common/parser/parser.py
@@ -294,10 +294,10 @@ class CwlParser:
         except FileNotFoundError:
             msg = f'Could not find a file for {key}: {fname}'
             raise CwlParseError(msg) from None
-        
-        if (state == 1):
+
+        if state == 1:
             self._validate_prepost_script_env(key, items, fname)
-        
+
     def _validate_prepost_script_env(self, key, items, fname):
         """Validate the pre/post script files by checking for shebang line.
 
@@ -306,9 +306,8 @@ class CwlParser:
         env_decl = []
         for line in items[key].splitlines():
             env_decl.append(line)
-        if not(env_decl[0].startswith("#!")):
+        if not env_decl[0].startswith("#!"):
             print("File does not contain shebang line: ", fname)
-            #raise Exception("File does not contain shebang line: ", fname)
 
     def parse_requirements(self, requirements, as_hints=False):
         """Parse CWL hints/requirements.

--- a/beeflow/common/parser/parser.py
+++ b/beeflow/common/parser/parser.py
@@ -284,7 +284,8 @@ class CwlParser:
         """Read in a requirement file and replace it in the parsed items.
 
         :param state: tracks if pre/post script capability is enabled
-        :type state: 0 is default, 1 is True
+        :type state: int
+        :rtype state: 0 is default, 1 is True
         """
         base_path = os.path.dirname(self.path)
         fname = items[key]
@@ -302,13 +303,15 @@ class CwlParser:
     def _validate_prepost_script_env(self, key, items, fname):
         """Validate the pre/post script files by checking for shebang line.
 
-        Return error if shell environment is not defined.
+        :param fname: name of pre/post script file
+        :type fname: str
         """
         env_decl = []
         for line in items[key].splitlines():
             env_decl.append(line)
         if not env_decl[0].startswith("#!"):
-            print("File does not contain shebang line: ", fname)
+            msg = f'File {fname} does not contain shebang line'
+            raise CwlParseError(msg) from None
 
     def parse_requirements(self, requirements, as_hints=False):
         """Parse CWL hints/requirements.

--- a/beeflow/common/parser/parser.py
+++ b/beeflow/common/parser/parser.py
@@ -310,7 +310,7 @@ class CwlParser:
         for line in items[key].splitlines():
             env_decl.append(line)
         if not env_decl[0].startswith("#!"):
-            msg = f'File {fname} does not contain shebang line'
+            msg = f'No shebang line found in {fname}'
             raise CwlParseError(msg) from None
 
     def parse_requirements(self, requirements, as_hints=False):

--- a/beeflow/common/parser/parser.py
+++ b/beeflow/common/parser/parser.py
@@ -280,8 +280,9 @@ class CwlParser:
 
         return outputs
 
-    def _read_requirement_file(self, key, items, state = 0):
+    def _read_requirement_file(self, key, items, state=0):
         """Read in a requirement file and replace it in the parsed items.
+        
         :param state: tracks if pre/post script capability is enabled
         :type state: 0 is default, 1 is True
         """
@@ -334,9 +335,9 @@ class CwlParser:
                 if 'dockerFile' in items:
                     self._read_requirement_file('dockerFile', items)
                 if 'pre_script' in items and items['enabled']:
-                    self._read_requirement_file('pre_script', items, state = 1)
+                    self._read_requirement_file('pre_script', items, state=1)
                 if 'post_script' in items and items['enabled']:
-                    self._read_requirement_file('post_script', items, state = 1)
+                    self._read_requirement_file('post_script', items, state=1)
                 if 'beeflow:bindMounts' in items:
                     self._read_requirement_file('beeflow:bindMounts', items)
                 reqs.append(Hint(req['class'], items))

--- a/beeflow/common/parser/parser.py
+++ b/beeflow/common/parser/parser.py
@@ -280,13 +280,8 @@ class CwlParser:
 
         return outputs
 
-    def _read_requirement_file(self, key, items, state=0):
-        """Read in a requirement file and replace it in the parsed items.
-
-        :param state: tracks if pre/post script capability is enabled
-        :type state: int
-        :rtype state: 0 is default, 1 is True
-        """
+    def _read_requirement_file(self, key, items):
+        """Read in a requirement file and replace it in the parsed items."""
         base_path = os.path.dirname(self.path)
         fname = items[key]
         path = os.path.join(base_path, fname)
@@ -296,8 +291,7 @@ class CwlParser:
         except FileNotFoundError:
             msg = f'Could not find a file for {key}: {fname}'
             raise CwlParseError(msg) from None
-
-        if state == 1:
+        if key in {'pre_script', 'post_script'}:
             self._validate_prepost_script_env(key, items, fname)
 
     def _validate_prepost_script_env(self, key, items, fname):
@@ -306,9 +300,7 @@ class CwlParser:
         :param fname: name of pre/post script file
         :type fname: str
         """
-        env_decl = []
-        for line in items[key].splitlines():
-            env_decl.append(line)
+        env_decl = items[key].splitlines()
         if not env_decl[0].startswith("#!"):
             msg = f'No shebang line found in {fname}'
             raise CwlParseError(msg) from None
@@ -338,9 +330,9 @@ class CwlParser:
                 if 'dockerFile' in items:
                     self._read_requirement_file('dockerFile', items)
                 if 'pre_script' in items and items['enabled']:
-                    self._read_requirement_file('pre_script', items, state=1)
+                    self._read_requirement_file('pre_script', items)
                 if 'post_script' in items and items['enabled']:
-                    self._read_requirement_file('post_script', items, state=1)
+                    self._read_requirement_file('post_script', items)
                 if 'beeflow:bindMounts' in items:
                     self._read_requirement_file('beeflow:bindMounts', items)
                 reqs.append(Hint(req['class'], items))

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-build_script/post_run.sh
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-build_script/post_run.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 echo "After run"

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-build_script/pre_run.sh
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-build_script/pre_run.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 echo "Before run"

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/Dockerfile.clamr-ffmpeg
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/Dockerfile.clamr-ffmpeg
@@ -1,0 +1,12 @@
+# Dockerfile.clamr-ffmpeg
+# Developed on Chicoma @lanl
+# Patricia Grubel <pagrubel@lanl.gov>
+
+FROM debian:11
+
+
+RUN apt-get update && \
+    apt-get install -y wget gnupg git cmake ffmpeg g++ make openmpi-bin libopenmpi-dev libpng-dev libpng16-16 libpng-tools imagemagick libmagickwand-6.q16-6 libmagickwand-6.q16-dev
+
+RUN git clone https://github.com/lanl/CLAMR.git
+RUN cd CLAMR && cmake . && make clamr_cpuonly

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/README.md
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/README.md
@@ -1,0 +1,13 @@
+# CLAMR - FFMPEG workflow using CWL
+
+This workflow uses the DockerRequirements dockerFile and beeflow:containerNameto build the clamr and ffmpeg in a container.
+
+```
+clamr_wf.cwl - the main cwl  
+calmr_job.yml - yaml file for values used by the cwl files   
+clamr.cwl - cwl file for the clamr step
+ffmpeg.cwl - cwl file for the ffmpeg step
+```
+
+
+

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/clamr.cwl
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/clamr.cwl
@@ -1,0 +1,72 @@
+# -*- mode: YAML; -*-
+
+class: CommandLineTool
+cwlVersion: v1.0
+
+baseCommand: /CLAMR/clamr_cpuonly
+# This is the stdout field which makes all stdout be captured in this file
+stdout: clamr_stdout.txt
+# Arguments to the command
+inputs:
+  amr_type:
+    # ? means the argument is optional
+    # All of the ? here are legacy from the original CWL
+    type: string?
+    # Declare extra options
+    # We support prefix and position
+    inputBinding:
+      # Prefix is the flag for cli command
+      prefix: -A
+  grid_res:
+    type: int?
+    inputBinding:
+      prefix: -n
+  max_levels:
+    type: int?
+    inputBinding:
+      prefix: -l
+  time_steps:
+    type: int?
+    inputBinding:
+      prefix: -t
+  output_steps:
+    type: int?
+    inputBinding:
+      prefix: -i
+  graphic_steps:
+    type: int?
+    inputBinding:
+      prefix: -g
+  graphics_type:
+    type: string?
+    inputBinding:
+      prefix: -G
+  rollback_images:
+    type: int?
+    inputBinding:
+      prefix: -b
+  checkpoint_disk_interval:
+    type: int?
+    inputBinding:
+      prefix: -c
+  checkpoint_mem_interval:
+    type: int?
+    inputBinding:
+      prefix: -C
+  hash_method:
+    type: string?
+    inputBinding:
+      prefix: -e
+  
+outputs:
+  # Captures stdout. Name is arbitrary.
+  clamr_stdout:
+    type: stdout
+  outdir:
+    type: Directory
+    outputBinding:
+      glob: graphics_output/graph%05d.png
+  time_log:
+    type: File
+    outputBinding:
+      glob: total_execution_time.log

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/clamr_job.json
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/clamr_job.json
@@ -1,0 +1,13 @@
+{
+  "grid_resolution": 32,
+  "max_levels": 3,
+  "time_steps": 5000,
+  "steps_between_outputs": 10,
+  "steps_between_graphics": 25,
+  "graphics_type": "png",
+  "input_format": "image2",
+  "frame_rate": 12,
+  "frame_size": "800x800",
+  "pixel_format": "yuv420p",
+  "output_filename": "CLAMR_movie.mp4"
+}

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/clamr_job.yml
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/clamr_job.yml
@@ -1,0 +1,18 @@
+# Inputs for CLAMR
+# /CLAMR/clamr_cpuonly -n 32 -l 3 -t 5000 -i 10 -g 25 -G png
+
+grid_resolution: 32
+max_levels: 3
+time_steps: 5000
+steps_between_outputs: 10
+steps_between_graphics: 25
+graphics_type: png
+
+# Inputs for FFMPEG
+#ffmpeg -f image2 -r 12 -s 800x800 -pix_fmt yuv420p CLAMR_movie.mp4
+
+input_format: image2
+frame_rate: 12
+frame_size: 800x800
+pixel_format: yuv420p
+output_filename: CLAMR_movie.mp4

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/clamr_wf.cwl
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/clamr_wf.cwl
@@ -1,0 +1,78 @@
+# -*- mode: YAML; -*-
+
+class: Workflow
+cwlVersion: v1.0
+
+# Main 3 components of workflow are inputs, outputs, and steps
+
+inputs:
+# All inputs go here for each step. No way to break them up.
+# We should talk to the CWL people about that. 
+##### CLAMR inputs #####
+# takes ID:Type syntax
+  grid_resolution: int
+  max_levels: int
+  time_steps: int
+  steps_between_outputs: int
+  steps_between_graphics: int
+  graphics_type: string
+##### FFMPEG inputs #####
+  input_format: string
+  frame_rate: int
+  frame_size: string
+  pixel_format: string
+  output_filename: string
+
+outputs:
+# Outputs for all the steps
+  clamr_stdout:
+    type: File
+    outputSource: clamr/clamr_stdout
+  clamr_time_log:
+    type: File
+    outputSource: clamr/time_log
+  clamr_movie:
+    type: File
+    outputSource: ffmpeg/movie
+  ffmpeg_stderr:
+    type: File
+    outputSource: ffmpeg/ffmpeg_stderr
+
+steps:
+  clamr:
+    run: clamr.cwl
+    in:
+      grid_res: grid_resolution
+      max_levels: max_levels
+      time_steps: time_steps
+      output_steps: steps_between_outputs
+      graphic_steps: steps_between_graphics
+      graphics_type: graphics_type
+    out: [clamr_stdout, outdir, time_log]
+    hints:
+        beeflow:ScriptRequirement:
+            enabled: true
+            pre_script: "pre_run.sh"
+            post_script: "post_run.sh"
+        DockerRequirement:
+            dockerFile: "Dockerfile.clamr-ffmpeg"
+            beeflow:containerName: "clamr-ffmpeg"
+
+  ffmpeg:
+    run: ffmpeg.cwl
+    in:
+      input_format: input_format
+      # input syntax is name: <step>/dependent_object
+      ffmpeg_input: clamr/outdir
+      frame_rate: frame_rate
+      frame_size: frame_size
+      pixel_format: pixel_format
+      # Setting output file with file_name
+      # output_filename set in wf inputs
+      output_file: output_filename
+    # Multiple outputs can be in array
+    out: [movie, ffmpeg_stderr]
+    hints:
+        DockerRequirement:
+            dockerFile: "Dockerfile.clamr-ffmpeg"
+            beeflow:containerName: "clamr-ffmpeg"

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/ffmpeg.cwl
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/ffmpeg.cwl
@@ -1,0 +1,49 @@
+# -*- mode: YAML; -*-
+
+class: CommandLineTool
+cwlVersion: v1.0
+
+baseCommand: ffmpeg -y
+
+stderr: ffmpeg_stderr.txt
+
+inputs:
+  input_format:
+    type: string?
+    inputBinding:
+      prefix: -f
+      position: 1
+  ffmpeg_input:
+    type: Directory
+    inputBinding:
+      prefix: -i
+      position: 2
+      valueFrom: $("/graph%05d.png")
+  frame_rate:
+    type: int?
+    inputBinding:
+      prefix: -r
+      position: 3
+  frame_size:
+    type: string?
+    inputBinding:
+      prefix: -s
+      position: 4
+  pixel_format:
+    type: string?
+    inputBinding:
+      prefix: -pix_fmt
+      position: 5
+  output_file:
+    type: string
+    inputBinding:
+      position: 6
+
+outputs:
+  movie:
+    type: File
+    outputBinding:
+      glob: $(inputs.output_file)
+      # glob: CLAMR_movie.mp4
+  ffmpeg_stderr:
+    type: stderr

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/post_run.sh
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/post_run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "After run"

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/post_run.sh
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/post_run.sh
@@ -1,3 +1,1 @@
-#!/bin/bash
-
 echo "After run"

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/pre_run.sh
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/pre_run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Before run"

--- a/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/pre_run.sh
+++ b/beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/pre_run.sh
@@ -1,3 +1,1 @@
-#!/bin/bash
-
 echo "Before run"

--- a/beeflow/tests/test_parser.py
+++ b/beeflow/tests/test_parser.py
@@ -60,7 +60,7 @@ class TestParser(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             self.parser.parse_workflow(workflow_id, cwl_wf_file, cwl_job_yaml)
 
-        self.assertEqual(context.exception.args[0], "File pre_run.sh does not contain shebang line")
+        self.assertEqual(context.exception.args[0], "No shebang line found in pre_run.sh")
 
     def test_parse_workflow_json(self):
         """Test parsing of workflow with a JSON input job file."""

--- a/beeflow/tests/test_parser.py
+++ b/beeflow/tests/test_parser.py
@@ -50,6 +50,20 @@ class TestParser(unittest.TestCase):
         for task in tasks:
             self.assertEqual(task.workflow_id, workflow_id)
 
+    def test_parse_workflow_validate_script(self):
+        """Test parsing of workflow with a YAML input job file and validate pre/post script files."""
+        cwl_wf_file = find("beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/clamr_wf.cwl") #noqa
+        cwl_job_yaml = find("beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/clamr_job.yml") #noqa
+
+        workflow_id = generate_workflow_id()
+
+        workflow, tasks = self.parser.parse_workflow(workflow_id, cwl_wf_file, cwl_job_yaml)
+
+        self.assertEqual(workflow, WORKFLOW_GOLD)
+        self.assertListEqual(tasks, TASKS_GOLD_VALIDATE_SCRIPT)
+        for task in tasks:
+            self.assertEqual(task.workflow_id, workflow_id)
+
     def test_parse_workflow_json(self):
         """Test parsing of workflow with a JSON input job file."""
         cwl_wf_file = find("examples/clamr-ffmpeg-build/clamr_wf.cwl")
@@ -132,6 +146,65 @@ TASKS_GOLD_SCRIPT = [
         base_command='/CLAMR/clamr_cpuonly',
         hints=[Hint(class_='DockerRequirement', params={'dockerFile': '# Dockerfile.clamr-ffmpeg\n# Developed on Chicoma @lanl\n# Patricia Grubel <pagrubel@lanl.gov>\n\nFROM debian:11\n\n\nRUN apt-get update && \\\n    apt-get install -y wget gnupg git cmake ffmpeg g++ make openmpi-bin libopenmpi-dev libpng-dev libpng16-16 libpng-tools imagemagick libmagickwand-6.q16-6 libmagickwand-6.q16-dev\n\nRUN git clone https://github.com/lanl/CLAMR.git\nRUN cd CLAMR && cmake . && make clamr_cpuonly\n', 'beeflow:containerName': 'clamr-ffmpeg'}), #noqa
                Hint(class_='beeflow:ScriptRequirement', params={'enabled': True, 'pre_script': 'echo "Before run"\n', 'post_script': 'echo "After run"\n'})], #noqa
+        requirements=[],
+        inputs=[StepInput(id='graphic_steps', type='int', value=None, default=None,
+                          source='steps_between_graphics', prefix='-g', position=None,
+                          value_from=None),
+                StepInput(id='graphics_type', type='string', value=None, default=None,
+                          source='graphics_type', prefix='-G', position=None, value_from=None),
+                StepInput(id='grid_res', type='int', value=None, default=None,
+                          source='grid_resolution', prefix='-n', position=None, value_from=None),
+                StepInput(id='max_levels', type='int', value=None, default=None,
+                          source='max_levels', prefix='-l', position=None, value_from=None),
+                StepInput(id='output_steps', type='int', value=None, default=None,
+                          source='steps_between_outputs', prefix='-i', position=None,
+                          value_from=None),
+                StepInput(id='time_steps', type='int', value=None, default=None,
+                          source='time_steps', prefix='-t', position=None, value_from=None)],
+        outputs=[StepOutput(id='clamr/clamr_stdout', type='stdout', value=None,
+                            glob='clamr_stdout.txt'),
+                 StepOutput(id='clamr/outdir', type='Directory', value=None,
+                            glob='graphics_output/graph%05d.png'),
+                 StepOutput(id='clamr/time_log', type='File', value=None,
+                            glob='total_execution_time.log')],
+        stdout='clamr_stdout.txt',
+        stderr=None,
+        workflow_id=WORKFLOW_GOLD.id
+    ),
+    Task(
+        name='ffmpeg',
+        base_command='ffmpeg -y',
+        hints=[Hint(class_='DockerRequirement', params={'dockerFile': '# Dockerfile.clamr-ffmpeg\n# Developed on Chicoma @lanl\n# Patricia Grubel <pagrubel@lanl.gov>\n\nFROM debian:11\n\n\nRUN apt-get update && \\\n    apt-get install -y wget gnupg git cmake ffmpeg g++ make openmpi-bin libopenmpi-dev libpng-dev libpng16-16 libpng-tools imagemagick libmagickwand-6.q16-6 libmagickwand-6.q16-dev\n\nRUN git clone https://github.com/lanl/CLAMR.git\nRUN cd CLAMR && cmake . && make clamr_cpuonly\n', 'beeflow:containerName': 'clamr-ffmpeg'})], # noqa
+        requirements=[],
+        inputs=[StepInput(id='ffmpeg_input', type='Directory', value=None, default=None,
+                          source='clamr/outdir', prefix='-i', position=2,
+                          value_from='$("/graph%05d.png")'),
+                StepInput(id='frame_rate', type='int', value=None, default=None,
+                          source='frame_rate', prefix='-r', position=3, value_from=None),
+                StepInput(id='frame_size', type='string', value=None, default=None,
+                          source='frame_size', prefix='-s', position=4, value_from=None),
+                StepInput(id='input_format', type='string', value=None, default=None,
+                          source='input_format', prefix='-f', position=1, value_from=None),
+                StepInput(id='output_file', type='string', value=None, default=None,
+                          source='output_filename', prefix=None, position=6, value_from=None),
+                StepInput(id='pixel_format', type='string', value=None, default=None,
+                          source='pixel_format', prefix='-pix_fmt', position=5, value_from=None)],
+        outputs=[StepOutput(id='ffmpeg/movie', type='File', value=None,
+                            glob='$(inputs.output_file)'),
+                 StepOutput(id='ffmpeg/ffmpeg_stderr', type='stderr', value=None,
+                            glob='ffmpeg_stderr.txt')],
+        stdout=None,
+        stderr='ffmpeg_stderr.txt',
+        workflow_id=WORKFLOW_GOLD.id)
+]
+
+
+TASKS_GOLD_VALIDATE_SCRIPT = [
+    Task(
+        name='clamr',
+        base_command='/CLAMR/clamr_cpuonly',
+        hints=[Hint(class_='DockerRequirement', params={'dockerFile': '# Dockerfile.clamr-ffmpeg\n# Developed on Chicoma @lanl\n# Patricia Grubel <pagrubel@lanl.gov>\n\nFROM debian:11\n\n\nRUN apt-get update && \\\n    apt-get install -y wget gnupg git cmake ffmpeg g++ make openmpi-bin libopenmpi-dev libpng-dev libpng16-16 libpng-tools imagemagick libmagickwand-6.q16-6 libmagickwand-6.q16-dev\n\nRUN git clone https://github.com/lanl/CLAMR.git\nRUN cd CLAMR && cmake . && make clamr_cpuonly\n', 'beeflow:containerName': 'clamr-ffmpeg'}), #noqa
+               Hint(class_='beeflow:ScriptRequirement', params={'enabled': True, 'pre_script': '#!/bin/bash\n\necho "Before run"\n', 'post_script': '#!/bin/bash\n\necho "After run"\n'})], #noqa
         requirements=[],
         inputs=[StepInput(id='graphic_steps', type='int', value=None, default=None,
                           source='steps_between_graphics', prefix='-g', position=None,

--- a/beeflow/tests/test_parser.py
+++ b/beeflow/tests/test_parser.py
@@ -57,12 +57,10 @@ class TestParser(unittest.TestCase):
 
         workflow_id = generate_workflow_id()
 
-        workflow, tasks = self.parser.parse_workflow(workflow_id, cwl_wf_file, cwl_job_yaml)
+        with self.assertRaises(Exception) as context:
+            self.parser.parse_workflow(workflow_id, cwl_wf_file, cwl_job_yaml)
 
-        self.assertEqual(workflow, WORKFLOW_GOLD)
-        self.assertListEqual(tasks, TASKS_GOLD_VALIDATE_SCRIPT)
-        for task in tasks:
-            self.assertEqual(task.workflow_id, workflow_id)
+        self.assertEqual(context.exception.args[0], "File pre_run.sh does not contain shebang line")
 
     def test_parse_workflow_json(self):
         """Test parsing of workflow with a JSON input job file."""
@@ -145,7 +143,7 @@ TASKS_GOLD_SCRIPT = [
         name='clamr',
         base_command='/CLAMR/clamr_cpuonly',
         hints=[Hint(class_='DockerRequirement', params={'dockerFile': '# Dockerfile.clamr-ffmpeg\n# Developed on Chicoma @lanl\n# Patricia Grubel <pagrubel@lanl.gov>\n\nFROM debian:11\n\n\nRUN apt-get update && \\\n    apt-get install -y wget gnupg git cmake ffmpeg g++ make openmpi-bin libopenmpi-dev libpng-dev libpng16-16 libpng-tools imagemagick libmagickwand-6.q16-6 libmagickwand-6.q16-dev\n\nRUN git clone https://github.com/lanl/CLAMR.git\nRUN cd CLAMR && cmake . && make clamr_cpuonly\n', 'beeflow:containerName': 'clamr-ffmpeg'}), #noqa
-               Hint(class_='beeflow:ScriptRequirement', params={'enabled': True, 'pre_script': 'echo "Before run"\n', 'post_script': 'echo "After run"\n'})], #noqa
+               Hint(class_='beeflow:ScriptRequirement', params={'enabled': True, 'pre_script': '#!/bin/bash\n\necho "Before run"\n', 'post_script': '#!/bin/bash\n\necho "After run"\n'})], #noqa
         requirements=[],
         inputs=[StepInput(id='graphic_steps', type='int', value=None, default=None,
                           source='steps_between_graphics', prefix='-g', position=None,
@@ -204,7 +202,7 @@ TASKS_GOLD_VALIDATE_SCRIPT = [
         name='clamr',
         base_command='/CLAMR/clamr_cpuonly',
         hints=[Hint(class_='DockerRequirement', params={'dockerFile': '# Dockerfile.clamr-ffmpeg\n# Developed on Chicoma @lanl\n# Patricia Grubel <pagrubel@lanl.gov>\n\nFROM debian:11\n\n\nRUN apt-get update && \\\n    apt-get install -y wget gnupg git cmake ffmpeg g++ make openmpi-bin libopenmpi-dev libpng-dev libpng16-16 libpng-tools imagemagick libmagickwand-6.q16-6 libmagickwand-6.q16-dev\n\nRUN git clone https://github.com/lanl/CLAMR.git\nRUN cd CLAMR && cmake . && make clamr_cpuonly\n', 'beeflow:containerName': 'clamr-ffmpeg'}), #noqa
-               Hint(class_='beeflow:ScriptRequirement', params={'enabled': True, 'pre_script': '#!/bin/bash\n\necho "Before run"\n', 'post_script': '#!/bin/bash\n\necho "After run"\n'})], #noqa
+               Hint(class_='beeflow:ScriptRequirement', params={'enabled': True, 'pre_script': 'echo "Before run"\n', 'post_script': 'echo "After run"\n'})], #noqa
         requirements=[],
         inputs=[StepInput(id='graphic_steps', type='int', value=None, default=None,
                           source='steps_between_graphics', prefix='-g', position=None,

--- a/beeflow/tests/test_parser.py
+++ b/beeflow/tests/test_parser.py
@@ -51,7 +51,7 @@ class TestParser(unittest.TestCase):
             self.assertEqual(task.workflow_id, workflow_id)
 
     def test_parse_workflow_validate_script(self):
-        """Test parsing of workflow with a YAML input job file and validate pre/post script files."""
+        """Test parsing of workflow and validate pre/post script files."""
         cwl_wf_file = find("beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/clamr_wf.cwl") #noqa
         cwl_job_yaml = find("beeflow/data/cwl/bee_workflows/clamr-ffmpeg-validate_script/clamr_job.yml") #noqa
 

--- a/ci/test_workflows/pre-post-script/post.sh
+++ b/ci/test_workflows/pre-post-script/post.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 touch post.txt

--- a/ci/test_workflows/pre-post-script/pre.sh
+++ b/ci/test_workflows/pre-post-script/pre.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 touch pre.txt

--- a/docs/sphinx/bee_cwl.rst
+++ b/docs/sphinx/bee_cwl.rst
@@ -180,12 +180,11 @@ beeflow:ScriptRequirement
 Some tasks may require small additional commands for setup or teardown such as
 loading modules, setting up checkpointing files, or cleaning up after a run.
 The script requirement enables this by adding shell scripts that will run before
-and after a task. The script must be within the workflow directory. The shell
-interpreter will be set to  whatever is in the ``$SHELL`` environment variable
-on the system e.g. if ``$SHELL`` is ``/bin/bash``, it will run the script as
-bash. The pre_script is run before a task and the post_script is run after.
-Currently, we only support running scripts outside of a container. We are
-considering adding container support in the future.
+and after a task. The script must be within the workflow directory. The desired
+shell interpreter must be specified in the first line of the file, otherwise, 
+an error will be returned. The pre_script is run before a task and the post_script 
+is run after. Currently, we only support running scripts outside of a container. 
+We are considering adding container support in the future.
 
 ScriptRequirement currently supports the following options:
 


### PR DESCRIPTION
When pre/post script files are enabled, at parse time, it checks the files for a shebang line (first line of file). If no shell environment is defined, it returns an error.