### PR TITLE
beeflow core info

### DIFF
--- a/beeflow/client/core.py
+++ b/beeflow/client/core.py
@@ -425,6 +425,13 @@ def status():
     for comp, stat in resp['components'].items():
         print(f'{comp} ... {stat}')
 
+@app.command()
+def info():
+    """Get information about beeflow's installation."""
+    version = importlib.metadata.version("hpc-beeflow")
+    print(f"Beeflow version: {version}")
+    print(f".beeflow directory: {paths.workdir()}") 
+    print(f"Log path: {paths.log_path()}")
 
 @app.command()
 def stop(query='yes'):

--- a/beeflow/client/core.py
+++ b/beeflow/client/core.py
@@ -431,7 +431,7 @@ def info():
     """Get information about beeflow's installation."""
     version = importlib.metadata.version("hpc-beeflow")
     print(f"Beeflow version: {version}")
-    print(f".beeflow directory: {paths.workdir()}")
+    print(f"bee_workflow directory: {paths.workdir()}")
     print(f"Log path: {paths.log_path()}")
 
 

--- a/beeflow/client/core.py
+++ b/beeflow/client/core.py
@@ -425,13 +425,15 @@ def status():
     for comp, stat in resp['components'].items():
         print(f'{comp} ... {stat}')
 
+
 @app.command()
 def info():
     """Get information about beeflow's installation."""
     version = importlib.metadata.version("hpc-beeflow")
     print(f"Beeflow version: {version}")
-    print(f".beeflow directory: {paths.workdir()}") 
+    print(f".beeflow directory: {paths.workdir()}")
     print(f"Log path: {paths.log_path()}")
+
 
 @app.command()
 def stop(query='yes'):

--- a/docs/sphinx/commands.rst
+++ b/docs/sphinx/commands.rst
@@ -18,6 +18,8 @@ Options:
 
 ``beeflow core status``: Check the status of beeflow and the components.
 
+``beeflow core info``: Get information about beeflow, including .beeflow directory location, log location, and version number.
+
 ``beeflow core stop``: Stop running beeflow components. Active workflows will be paused. You may continue running paused workflows with the ``beeflow resume <wf_id>`` command. Once you start beeflow components after a stop, you should check the status of workflows, query any running workflows. If they were intializing when a ``beeflow core stop`` was issued, the workflow may be running with tasks stuck in the waiting state. If this occurs and you want the workflow to continue pause and resume the workflow (``beeflow pause <wf_id>``, ``beeflow resume <wf_id>``) or to start over cancel the workflow (``beeflow cancel <wf_id>``) and resubmit it.
 
 ``beeflow core --version``: Display the version number of BEE.


### PR DESCRIPTION
This PR adds a way to get information about the current instance, which should be useful for debugging various issues:

Usage:
```
(poetry-ci) [aquan@darwin-fe1 .beeflow]$ beeflow core info
Beeflow version: 0.1.9.dev3
.beeflow directory: /vast/home/aquan/.beeflow
Log path: /vast/home/aquan/.beeflow/logs
```


