### PR TITLE
Change default test target for Slurm to be slurm commands

### DIFF
--- a/ci/bee_config.sh
+++ b/ci/bee_config.sh
@@ -61,7 +61,7 @@ case $BEE_WORKER in
 Slurmrestd)
     cat >> $BEE_CONFIG <<EOF
 [slurm]
-use_commands = False
+use_commands = True
 openapi_version = $OPENAPI_VERSION
 EOF
     ;;


### PR DESCRIPTION
Trying to change the default internal test target to use slurm commands rather than slurmrestd to aid in testing. 