### PR TITLE
Change default test-target back to Slurmrestd

### DIFF
--- a/ci/bee_config.sh
+++ b/ci/bee_config.sh
@@ -61,7 +61,7 @@ case $BEE_WORKER in
 Slurmrestd)
     cat >> $BEE_CONFIG <<EOF
 [slurm]
-use_commands = True
+use_commands = False
 openapi_version = $OPENAPI_VERSION
 EOF
     ;;


### PR DESCRIPTION
I am backing out a change that Rusty and I had made during our debugging session to set the default test target for the internal CI to be using Slurm commands. 

This change reverts it back to the original setting which is to attempt using Slurmrestd