### PR TITLE
Allow beeflow to run on back end node

### DIFF
--- a/beeflow/client/core.py
+++ b/beeflow/client/core.py
@@ -303,7 +303,6 @@ def check_dependencies(backend=False):
         warn('Slurm job node detected! Beeflow should not be run on a compute node.')
         warn(f'SLURM_JOB_NODELIST = {os.environ.get("SLURM_JOB_NODELIST")}')
         sys.exit(1)
-        
     print('Checking dependencies...')
     # Check for Charliecloud and its version
     load_check_charliecloud()
@@ -386,7 +385,7 @@ app = typer.Typer(no_args_is_help=True)
 
 @app.command()
 def start(foreground: bool = typer.Option(False, '--foreground', '-F',
-          help='run in the foreground'), backend: bool = typer.Option(False, '--backend', 
+          help='run in the foreground'), backend: bool = typer.Option(False, '--backend',
           '-B', help='allow to run on a backend node')):
     """Start all BEE components."""
     if backend:  # allow beeflow to run on backend node

--- a/beeflow/client/core.py
+++ b/beeflow/client/core.py
@@ -296,14 +296,15 @@ def load_check_charliecloud():
         sys.exit(1)
 
 
-def check_dependencies():
+def check_dependencies(backend=False):
     """Check for various dependencies in the environment."""
-    print('Checking dependencies...')
     # Check if running on compute node under Slurm scheduler
-    if os.environ.get('SLURM_JOB_NODELIST') is not None:
+    if not backend and os.environ.get('SLURM_JOB_NODELIST') is not None:
         warn('Slurm job node detected! Beeflow should not be run on a compute node.')
         warn(f'SLURM_JOB_NODELIST = {os.environ.get("SLURM_JOB_NODELIST")}')
         sys.exit(1)
+        
+    print('Checking dependencies...')
     # Check for Charliecloud and its version
     load_check_charliecloud()
     # Check for the flux API
@@ -385,9 +386,13 @@ app = typer.Typer(no_args_is_help=True)
 
 @app.command()
 def start(foreground: bool = typer.Option(False, '--foreground', '-F',
-          help='run in the foreground')):
+          help='run in the foreground'), backend: bool = typer.Option(False, '--backend', 
+          '-B', help='allow to run on a backend node')):
     """Start all BEE components."""
-    check_dependencies()
+    if backend:  # allow beeflow to run on backend node
+        check_dependencies(backend=True)
+    else:
+        check_dependencies()
     mgr = init_components()
     beeflow_log = paths.log_fname('beeflow')
     sock_path = paths.beeflow_socket()

--- a/docs/sphinx/commands.rst
+++ b/docs/sphinx/commands.rst
@@ -14,6 +14,7 @@ To interact with the daemon process you'll need to use the ``beeflow core`` sub-
 
 Options:
   -F, --foreground  run in the foreground  [default: False]
+  -B, --backend  run on a back end node  [default: False]
 
 
 ``beeflow core status``: Check the status of beeflow and the components.


### PR DESCRIPTION
Adding a flag to ```beeflow core start``` to allow ```beeflow``` to run on a back end node for testing purposes.

We can now run with the following flag: ```-B, --backend [default: False]```.

Documentation has also been updated.