### PR TITLE
Use random pass for neo4j

### DIFF
--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -311,7 +311,7 @@ VALIDATOR.section('graphdb', info='Main graph database configuration section.')
 VALIDATOR.option('graphdb', 'hostname', default='localhost',
                  info='hostname of database')
 
-# Generate random initial password for neo4j 
+# Generate random initial password for neo4j
 random_bytes = os.urandom(32)
 random_pass = base64.b64encode(random_bytes).decode('utf-8')
 

--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -3,6 +3,7 @@
 from configparser import ConfigParser
 import getpass
 import os
+import base64
 import platform
 import random
 import shutil
@@ -309,7 +310,12 @@ VALIDATOR.option('charliecloud', 'setup', default='',
 VALIDATOR.section('graphdb', info='Main graph database configuration section.')
 VALIDATOR.option('graphdb', 'hostname', default='localhost',
                  info='hostname of database')
-VALIDATOR.option('graphdb', 'dbpass', default='password', info='password for database')
+
+# Generate random initial password for neo4j 
+random_bytes = os.urandom(32)
+random_pass = base64.b64encode(random_bytes).decode('utf-8')
+
+VALIDATOR.option('graphdb', 'dbpass', default=random_pass, info='password for database')
 VALIDATOR.option('graphdb', 'bolt_port', default=DEFAULT_BOLT_PORT, validator=int,
                  info='port used for the BOLT API')
 VALIDATOR.option('graphdb', 'http_port', default=DEFAULT_HTTP_PORT, validator=int,


### PR DESCRIPTION
This PR changes the way that we initialize the default password for the neo4j database to be based on a random base64 hash value rather than just the default "password" text, which should hopefully make our database more secure on shared systems. 

The concern is that since the graph database is setup on the shared front-end, automatically setting up a default password of "password" would let other users explore things like the names of steps in another user's workflow, and how their workflow is setup. 

