### PR TITLE
Check for default dependency containers for new configuration

### DIFF
--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -224,9 +224,24 @@ DEFAULT_WFM_PORT = 5000 + OFFSET
 DEFAULT_TM_PORT = 5050 + OFFSET
 DEFAULT_SCHED_PORT = 5100 + OFFSET
 
+DEFAULT_NEO4J_IMAGE = join_path('/usr/projects/BEE/neo4j.tar.gz')
+DEFAULT_REDIS_IMAGE = join_path('/usr/projects/BEE/redis.tar.gz')
+
 DEFAULT_BEE_WORKDIR = join_path(HOME_DIR, '.beeflow')
 DEFAULT_BEE_DROPPOINT = join_path(HOME_DIR, '.beeflow/droppoint')
 USER = getpass.getuser()
+
+# Check for default containers; setting to None value results in querying user for path
+if os.path.isfile(DEFAULT_NEO4J_IMAGE):
+    print(DEFAULT_NEO4J_IMAGE)
+    neo4j_img = DEFAULT_NEO4J_IMAGE
+else:
+    neo4j_img = None
+if os.path.isfile(DEFAULT_REDIS_IMAGE):
+    redis_img = DEFAULT_REDIS_IMAGE
+else:
+    redis_img = None
+
 # Create the validator
 VALIDATOR = ConfigValidator('BEE configuration file and validation information.')
 VALIDATOR.section('DEFAULT', info='Default bee.conf configuration section.')
@@ -250,11 +265,11 @@ VALIDATOR.option('DEFAULT', 'delete_completed_workflow_dirs', validator=validati
                  default=True, info='delete workflow directory for completed jobs')
 
 VALIDATOR.option('DEFAULT', 'neo4j_image', validator=validation.file_,
-                 info='neo4j container image',
+                 default=neo4j_img, info='neo4j container image',
                  input_fn=filepath_completion_input)
 
 VALIDATOR.option('DEFAULT', 'redis_image', validator=validation.file_,
-                 info='redis container image',
+                 default=redis_img, info='redis container image',
                  input_fn=filepath_completion_input)
 
 VALIDATOR.option('DEFAULT', 'max_restarts', validator=int,
@@ -389,9 +404,7 @@ class ConfigGenerator:
             for opt_name, option in self.validator.options(sec_name):
                 # Print the section name if it hasn't already been printed.
                 if not printed:
-                    print()
-                    print(f'## {sec_name}')
-                    print()
+                    print(f'\n## {sec_name}\n')
                     print_wrap(section.info)
                     print()
                     printed = True

--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -234,13 +234,13 @@ USER = getpass.getuser()
 # Check for default containers; setting to None value results in querying user for path
 if os.path.isfile(DEFAULT_NEO4J_IMAGE):
     print(DEFAULT_NEO4J_IMAGE)
-    neo4j_img = DEFAULT_NEO4J_IMAGE
+    NEO4J_IMAGE = DEFAULT_NEO4J_IMAGE
 else:
-    neo4j_img = None
+    NEO4J_IMAGE = None
 if os.path.isfile(DEFAULT_REDIS_IMAGE):
-    redis_img = DEFAULT_REDIS_IMAGE
+    REDIS_IMAGE = DEFAULT_REDIS_IMAGE
 else:
-    redis_img = None
+    REDIS_IMAGE = None
 
 # Create the validator
 VALIDATOR = ConfigValidator('BEE configuration file and validation information.')
@@ -265,11 +265,11 @@ VALIDATOR.option('DEFAULT', 'delete_completed_workflow_dirs', validator=validati
                  default=True, info='delete workflow directory for completed jobs')
 
 VALIDATOR.option('DEFAULT', 'neo4j_image', validator=validation.file_,
-                 default=neo4j_img, info='neo4j container image',
+                 default=NEO4J_IMAGE, info='neo4j container image',
                  input_fn=filepath_completion_input)
 
 VALIDATOR.option('DEFAULT', 'redis_image', validator=validation.file_,
-                 default=redis_img, info='redis container image',
+                 default=REDIS_IMAGE, info='redis container image',
                  input_fn=filepath_completion_input)
 
 VALIDATOR.option('DEFAULT', 'max_restarts', validator=int,

--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -233,7 +233,6 @@ USER = getpass.getuser()
 
 # Check for default containers; setting to None value results in querying user for path
 if os.path.isfile(DEFAULT_NEO4J_IMAGE):
-    print(DEFAULT_NEO4J_IMAGE)
     NEO4J_IMAGE = DEFAULT_NEO4J_IMAGE
 else:
     NEO4J_IMAGE = None

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -17,7 +17,7 @@ Requirements:
 * **Containers**:
     Two Charliecloud dependency containers are currently required for BEE: one for the Neo4j graph database and another for Redis. The paths to these containers will need to be set in the BEE configuration later, using the ``neo4j_image`` and the ``redis_image`` options respectively. BEE only supports Neo4j 5.x. We are currently using the latest version of Redis supplied on Docker Hub (as of 2023).
 
-    For LANL systems, please use the containers supplied by the BEE team: **/usr/projects/BEE/neo4j.tar.gz**, **/usr/projects/BEE/redis.tar.gz**.
+    For LANL systems: the default locations are checked used and you will not be asked for them. 
 
     For other users, these containers can be pulled from Docker Hub (after following `Installation:`_ below) using ``beeflow core pull-deps``, which will download and report the container paths to be set in the config later.
 

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -17,7 +17,7 @@ Requirements:
 * **Containers**:
     Two Charliecloud dependency containers are currently required for BEE: one for the Neo4j graph database and another for Redis. The paths to these containers will need to be set in the BEE configuration later, using the ``neo4j_image`` and the ``redis_image`` options respectively. BEE only supports Neo4j 5.x. We are currently using the latest version of Redis supplied on Docker Hub (as of 2023).
 
-    For LANL systems: the default locations are checked used and you will not be asked for them. 
+    For LANL systems, default locations are used and you will not be asked for them.
 
     For other users, these containers can be pulled from Docker Hub (after following `Installation:`_ below) using ``beeflow core pull-deps``, which will download and report the container paths to be set in the config later.
 


### PR DESCRIPTION
Checks if default dependency containers exist and will automatically put their paths in bee.conf if they exist.

If a different container is desired the user will have to edit the bee.conf file manually.