### PR TITLE
Reverse fix for random password

### DIFF
--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -3,7 +3,6 @@
 from configparser import ConfigParser
 import getpass
 import os
-import base64
 import platform
 import random
 import shutil
@@ -323,12 +322,7 @@ VALIDATOR.section('graphdb', info='Main graph database configuration section.')
 VALIDATOR.option('graphdb', 'hostname', default='localhost',
                  info='hostname of database')
 
-
-# Generate random initial password for neo4j
-random_bytes = os.urandom(32)
-random_pass = base64.b64encode(random_bytes).decode('utf-8')
-
-VALIDATOR.option('graphdb', 'dbpass', default=random_pass, info='password for database')
+VALIDATOR.option('graphdb', 'dbpass', default='password', info='password for database')
 
 VALIDATOR.option('graphdb', 'gdb_image_mntdir', default=join_path('/tmp', USER),
                  info='graph database image mount directory', validator=validation.make_dir)


### PR DESCRIPTION
This PR reverses fix in PR#948 since workflows are always initializing with that fix. 
We need to have our integration tests   generate a config file before attempting to implement the random password again.