### PR TITLE
Correct archives location

### DIFF
--- a/beeflow/client/core.py
+++ b/beeflow/client/core.py
@@ -559,6 +559,7 @@ def reset(archive: bool = typer.Option(False, '--archive', '-a',
         Shutdown beeflow and all BEE components.
         Delete the bee_workdir directory which results in:
             Removing the archive of all workflows.
+                (unless archives is configured elsewhere).
             Removing the archive of workflow containers
                 (unless container_archive is configured elsewhere).
             Reset all databases associated with the beeflow app.

--- a/beeflow/wf_manager/resources/wf_actions.py
+++ b/beeflow/wf_manager/resources/wf_actions.py
@@ -10,6 +10,7 @@ from beeflow.wf_manager.resources.wf_update import archive_workflow
 
 from beeflow.common.db import wfm_db
 from beeflow.common.db.bdb import connect_db
+from beeflow.common.config_driver import BeeConfig as bc
 
 log = bee_logging.setup(__name__)
 db_path = wf_utils.get_db_path()
@@ -77,7 +78,8 @@ class WFActions(Resource):
             bee_workdir = wf_utils.get_bee_workdir()
             workflow_dir = f"{bee_workdir}/workflows/{wf_id}"
             shutil.rmtree(workflow_dir, ignore_errors=True)
-            archive_path = f"{bee_workdir}/archives/{wf_id}.tgz"
+            archive_dir = bc.get('DEFAULT', 'bee_archive_dir')
+            archive_path = f"{archive_dir}/{wf_id}.tgz"
             if os.path.exists(archive_path):
                 os.remove(archive_path)
         return resp

--- a/beeflow/wf_manager/resources/wf_list.py
+++ b/beeflow/wf_manager/resources/wf_list.py
@@ -20,6 +20,7 @@ from beeflow.common import wf_data
 
 from beeflow.common.db import wfm_db
 from beeflow.common.db.bdb import connect_db
+from beeflow.common.config_driver import BeeConfig as bc
 
 log = bee_logging.setup(__name__)
 
@@ -150,9 +151,9 @@ class WFList(Resource):
         """Copy workflow archive."""
         reqparser = reqparse.RequestParser()
         data = reqparser.parse_args()
-        bee_workdir = wf_utils.get_bee_workdir()
         wf_id = data['wf_id']
-        archive_path = os.path.join(bee_workdir, 'archives', wf_id + '.tgz')
+        archive_dir = bc.get('DEFAULT', 'bee_archive_dir')
+        archive_path = os.path.join(archive_dir, wf_id + '.tgz')
         with open(archive_path, 'rb') as archive:
             archive_file = jsonpickle.encode(archive.read())
         archive_filename = os.path.basename(archive_path)


### PR DESCRIPTION
Follow-up related to issue #877. 

I checked `git grep archives` on `develop` and noticed some mention of the archives folder that should be updated to use the location defined in the config:

```shell
beeflow/client/core.py:    archive_dirs = ['logs', 'container_archive', 'archives', 'workflows']
beeflow/wf_manager/resources/wf_actions.py:            archive_path = f"{bee_workdir}/archives/{wf_id}.tgz"
beeflow/wf_manager/resources/wf_list.py:        archive_path = os.path.join(bee_workdir, 'archives', wf_id + '.tgz')
```