### PR TITLE
Issue963/Make beeflow config new non-interactive by default

### DIFF
--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -241,36 +241,39 @@ VALIDATOR = ConfigValidator('BEE configuration file and validation information.'
 VALIDATOR.section('DEFAULT', info='Default bee.conf configuration section.')
 
 VALIDATOR.option('DEFAULT', 'bee_workdir', info='main BEE workdir',
-                 default=DEFAULT_BEE_WORKDIR, validator=validation.make_dir)
+                 default=DEFAULT_BEE_WORKDIR, validator=validation.make_dir,
+                 prompt=True)
 
 VALIDATOR.option('DEFAULT', 'bee_archive_dir', info='directory to store workflow archives',
-                 default=DEFAULT_BEE_ARCHIVE_DIR, validator=validation.make_dir)
+                 default=DEFAULT_BEE_ARCHIVE_DIR, validator=validation.make_dir,
+                 prompt=True)
 
 VALIDATOR.option('DEFAULT', 'bee_droppoint', info='BEE remote workflow drop point',
-                 default=DEFAULT_BEE_DROPPOINT, validator=validation.make_dir)
+                 default=DEFAULT_BEE_DROPPOINT, validator=validation.make_dir,
+                 prompt=False)
 
 VALIDATOR.option('DEFAULT', 'remote_api', info='BEE remote REST API activation',
-                 default=False, validator=validation.bool_)
+                 default=False, validator=validation.bool_, prompt=False)
 
 VALIDATOR.option('DEFAULT', 'remote_api_port', info='BEE remote REST API port',
-                 default=7777, validator=int)
+                 default=7777, validator=int, prompt=False)
 
 VALIDATOR.option('DEFAULT', 'workload_scheduler', choices=('Slurm', 'LSF', 'Flux', 'Simple'),
-                 default='Slurm', info='backend workload scheduler to interact with ')
+                 default='Slurm', info='backend workload scheduler to interact with ',
+                 prompt=True)
 
 VALIDATOR.option('DEFAULT', 'delete_completed_workflow_dirs', validator=validation.bool_,
-                 default=True, info='delete workflow directory for completed jobs')
+                 default=True, info='delete workflow directory for completed jobs', prompt=False)
 
 VALIDATOR.option('DEFAULT', 'neo4j_image', validator=validation.file_,
                  default=NEO4J_IMAGE, info='neo4j container image',
-                 input_fn=filepath_completion_input)
+                 input_fn=filepath_completion_input, prompt=True)
 
 VALIDATOR.option('DEFAULT', 'redis_image', validator=validation.file_,
                  default=REDIS_IMAGE, info='redis container image',
-                 input_fn=filepath_completion_input)
+                 input_fn=filepath_completion_input, prompt=True)
 
-VALIDATOR.option('DEFAULT', 'max_restarts', validator=int,
-                 default=3,
+VALIDATOR.option('DEFAULT', 'max_restarts', validator=int, default=3, prompt=False,
                  info='max number of times beeflow will restart a component on failure')
 
 # Workflow Manager
@@ -279,26 +282,26 @@ VALIDATOR.section('workflow_manager', info='Workflow manager section.')
 VALIDATOR.section('task_manager',
                   info='Task manager configuration and config of container to use.')
 VALIDATOR.option('task_manager', 'container_runtime', default='Charliecloud',
-                 choices=('Charliecloud', 'Singularity'),
+                 choices=('Charliecloud', 'Singularity'), prompt=False,
                  info='container runtime to use for configuration')
-VALIDATOR.option('task_manager', 'runner_opts', default='',
+VALIDATOR.option('task_manager', 'runner_opts', default='', prompt=False,
                  info='special runner options to pass to the runner opts')
 VALIDATOR.option('task_manager', 'background_interval', default=5,
-                 validator=int,
+                 validator=int, prompt=False,
                  info='interval at which the task manager processes queues and updates states')
 
 # Charliecloud (depends on task_manager::container_runtime == Charliecloud)
 VALIDATOR.section('charliecloud', info='Charliecloud configuration section.',
                   depends_on=('task_manager', 'container_runtime', 'Charliecloud'))
-VALIDATOR.option('charliecloud', 'image_mntdir', default=join_path('/tmp', USER),
+VALIDATOR.option('charliecloud', 'image_mntdir', default=join_path('/tmp', USER), prompt=False,
                  info='Charliecloud mount directory', validator=validation.make_dir)
 # General job requirements
 VALIDATOR.section('job', info='General job requirements.')
-VALIDATOR.option('job', 'default_account', validator=lambda val: val.strip(),
+VALIDATOR.option('job', 'default_account', validator=lambda val: val.strip(), prompt=True,
                  default='', info='default account to launch jobs with (leave blank if none)')
-VALIDATOR.option('job', 'default_time_limit', validator=validation.time_limit,
+VALIDATOR.option('job', 'default_time_limit', validator=validation.time_limit, prompt=True,
                  default='', info='default account time limit (leave blank if none)')
-VALIDATOR.option('job', 'default_partition', validator=lambda val: val.strip(),
+VALIDATOR.option('job', 'default_partition', validator=lambda val: val.strip(), prompt=True,
                  default='', info='default partition to run jobs on (leave blank if none)')
 
 
@@ -313,38 +316,39 @@ def validate_chrun_opts(opts):
 
 
 VALIDATOR.option('charliecloud', 'chrun_opts', default='--home',
-                 validator=validate_chrun_opts,
+                 validator=validate_chrun_opts, prompt=False,
                  info='extra options to pass to ch-run')
-VALIDATOR.option('charliecloud', 'setup', default='',
+VALIDATOR.option('charliecloud', 'setup', default='', prompt=False,
                  info='extra Charliecloud setup to put in a job script')
 # Graph Database
 VALIDATOR.section('graphdb', info='Main graph database configuration section.')
-VALIDATOR.option('graphdb', 'hostname', default='localhost',
+VALIDATOR.option('graphdb', 'hostname', default='localhost', prompt=False,
                  info='hostname of database')
 
-VALIDATOR.option('graphdb', 'dbpass', default='password', info='password for database')
+VALIDATOR.option('graphdb', 'dbpass', default='password', info='password for database',
+                 prompt=False)
 
-VALIDATOR.option('graphdb', 'gdb_image_mntdir', default=join_path('/tmp', USER),
+VALIDATOR.option('graphdb', 'gdb_image_mntdir', default=join_path('/tmp', USER), prompt=False,
                  info='graph database image mount directory', validator=validation.make_dir)
-VALIDATOR.option('graphdb', 'sleep_time', validator=int, default=1,
+VALIDATOR.option('graphdb', 'sleep_time', validator=int, default=1, prompt=False,
                  info='how long to wait for the graph database to come up (this can take a while, '
                       'depending on the system)')
 # Builder
 VALIDATOR.section('builder', info='General builder configuration section.')
-VALIDATOR.option('builder', 'deployed_image_root', default='/tmp',
+VALIDATOR.option('builder', 'deployed_image_root', default='/tmp', prompt=False,
                  info='where to deploy container images', validator=validation.make_dir)
-VALIDATOR.option('builder', 'container_output_path', default='/tmp',
+VALIDATOR.option('builder', 'container_output_path', default='/tmp', prompt=False,
                  info='container output path', validator=validation.make_dir)
-VALIDATOR.option('builder', 'container_archive',
+VALIDATOR.option('builder', 'container_archive', prompt=True,
                  default=join_path(DEFAULT_BEE_WORKDIR, 'container_archive'),
                  info='container archive location')
 VALIDATOR.option('builder', 'container_type', default='charliecloud',
-                 info='container type to use')
+                 info='container type to use', prompt=False)
 # Slurmrestd (depends on DEFAULT:workload_scheduler == Slurm)
 VALIDATOR.section('slurm', info='Configuration section for Slurm.',
                   depends_on=('DEFAULT', 'workload_scheduler', 'Slurm'))
 VALIDATOR.option('slurm', 'use_commands', validator=validation.bool_,
-                 default=(shutil.which('slurmrestd') is None),
+                 default=(shutil.which('slurmrestd') is None), prompt=False,
                  info='if set, use slurm cli commands instead of slurmrestd')
 DEFAULT_SLURMRESTD_SOCK = join_path('/tmp', f'slurm_{USER}_{random.randint(1, 10000)}.sock')
 
@@ -352,9 +356,9 @@ DEFAULT_SLURMRESTD_SOCK = join_path('/tmp', f'slurm_{USER}_{random.randint(1, 10
 VALIDATOR.section('scheduler', info='Scheduler configuration section.')
 SCHEDULER_ALGORITHMS = ('fcfs', 'backfill', 'sjf')
 VALIDATOR.option('scheduler', 'algorithm', default='fcfs', choices=SCHEDULER_ALGORITHMS,
-                 info='scheduling algorithm to use')
+                 info='scheduling algorithm to use', prompt=False)
 VALIDATOR.option('scheduler', 'default_algorithm', default='fcfs',
-                 choices=SCHEDULER_ALGORITHMS,
+                 choices=SCHEDULER_ALGORITHMS, prompt=False,
                  info=('default algorithm to use'))
 
 
@@ -405,8 +409,9 @@ class ConfigGenerator:
                 this_default = option.default
                 if flux is True and opt_name == 'workload_scheduler':
                     this_default = "Flux"
+                    option.prompt = False
                 # Check for a default value
-                if not interactive and this_default is not None:
+                if (not interactive or option.prompt is False) and this_default is not None:
                     value = option.validate(this_default)
                     print(f'Setting option "{opt_name}" to default value "{value}".')
                     print()

--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -380,12 +380,13 @@ class ConfigGenerator:
             os.makedirs(dirname, exist_ok=True)
         print(f'Creating a new config: "{self.fname}".')
         print()
-        print_wrap('This will walk you through creating a new configuration for BEE. '
-                   'Note that you will only be required to enter values for options '
-                   'without defaults. Please take a look at the other options and '
-                   'their defaults before running BEE.')
-        print()
-        print('Please enter values for the following sections and options:')
+        if interactive:
+            print_wrap('This will walk you through creating a new configuration for BEE. '
+                       'Note that you will only be required to enter values for options '
+                       'without defaults. Please take a look at the other options and '
+                       'their defaults before running BEE.')
+            print()
+            print('Please enter values for the following sections and options:')
         # Let the user choose values for each required attribute
         for sec_name, section in self.validator.sections:
             # Determine if this section is valid under the current configuration

--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -386,9 +386,9 @@ class ConfigGenerator:
         print()
         if interactive:
             print_wrap('This will walk you through creating a new configuration for BEE. '
-                       'Note that you will only be required to enter values for options '
-                       'without defaults. Please take a look at the other options and '
-                       'their defaults before running BEE.')
+                       'Note that you will only be required to enter values for some '
+                       'options. Please take a look at the other options and their '
+                       'values before running BEE.')
             print()
             print('Please enter values for the following sections and options:')
         # Let the user choose values for each required attribute

--- a/beeflow/common/config_validator.py
+++ b/beeflow/common/config_validator.py
@@ -160,7 +160,8 @@ class ConfigSection:
 class ConfigOption:
     """Config option/validation class."""
 
-    def __init__(self, info, validator=str, choices=None, default=None, input_fn=None):
+    def __init__(self, info, validator=str, choices=None, default=None, input_fn=None,
+                 prompt=False):
         """Construct the config option class."""
         self.info = info
         self.choices = choices
@@ -169,6 +170,7 @@ class ConfigOption:
         # Function used to set the option from user input at config generation time
         self.input_fn = input_fn
         self._validator = validator
+        self.prompt = prompt
 
     def validate(self, value):
         """Validate the value and return it."""

--- a/beeflow/tests/test_config_driver.py
+++ b/beeflow/tests/test_config_driver.py
@@ -107,20 +107,22 @@ def test_change_value_multiple_times(mocker):
     assert alter_config.changes == {"DEFAULT": {"bee_workdir": "/path/two"}}
 
 
-@pytest.mark.parametrize("interactive, flux, expected",
+@pytest.mark.parametrize("interactive, flux, prompt, expected",
                          [
-                             (True, True, 'input'),
-                             (True, False, 'input'),
-                             (False, True, 'Flux'),
-                             (False, False, 'default'),
+                             (True, True, False, 'Flux'),
+                             (True, False, False, 'default'),
+                             (True, True, True, 'Flux'),
+                             (True, False, True, 'input'),
+                             (False, True, False, 'Flux'),
+                             (False, False, False, 'default'),
                          ],
                          )
-def test_choose_values(interactive, flux, expected):
+def test_choose_values(interactive, flux, prompt, expected):
     """Test running choose_values with different flags."""
     validator = ConfigValidator('')
     validator.section('sec', info='')
     validator.option('sec', 'workload_scheduler', info='', default='default',
-                     validator=lambda _: _, input_fn=lambda _: 'input')
+                     validator=lambda _: _, input_fn=lambda _: 'input', prompt=prompt)
     config_generator = ConfigGenerator('', validator)
     config = config_generator.choose_values(interactive=interactive,
                                             flux=flux).sections

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
-        <text x="80" y="14">71%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">72%</text>
+        <text x="80" y="14">72%</text>
     </g>
 </svg>

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -53,7 +53,7 @@ You will need to setup the bee configuration file that will be located in:
 
     macOS:  ``~/Library/Application Support/beeflow/bee.conf``
 
-Using ``beeflow config new`` will create the configuration file using the default values or you can use the ``--interactive`` flag to be prompted for each setting.
+Using ``beeflow config new`` will create the configuration file using the default values or you can use the ``--interactive`` flag to be prompted for the most important settings.
 
 Following generation of the bee.conf configuration file you can edit the settings using a text editor.
 

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -53,16 +53,19 @@ You will need to setup the bee configuration file that will be located in:
 
     macOS:  ``~/Library/Application Support/beeflow/bee.conf``
 
-Before creating a bee.conf file you will need to know the path to the two required Charliecloud containers, one for Neo4j (``neo4j_image``) and Redis (``redis_image``). See `Requirements:`_ above for pulling these containers. Depending on the system, you may also need to know system-specific information, such as account information. You can leave some options blank if these are unnecessary.
+Using ``beeflow config new`` will create the configuration file using the default values or you can use the ``--interactive`` flag to be prompted for each setting.
 
-Once you are ready type ``beeflow config new``.
-
-The bee.conf configuration file is a text file and you can edit it for your
-needs.
+Following generation of the bee.conf configuration file you can edit the settings using a text editor.
 
 **Caution: The default for container_archive is in the home directory. Some
 systems have small quotas for home directories and containers can be large
 files.**
+
+It is important to ensure the path to the two required Charliecloud containers is correct. There is a setting for the Neo4j container (``neo4j_image``) and the Redis container (``redis_image``). See `Requirements:`_ above for pulling these containers.
+
+Depending on the system, you may also need to enter the system-specific information, such as account information.
+
+Options can be left blank if they are unnecessary.
 
 **beeflow config** has other options including a configuration validator. For more
 information or help run: ``beeflow config info`` or ``beeflow config --help``.


### PR DESCRIPTION
Closes #963 

This PR makes `beeflow config new` and automatic incantations non-interactive by default. All config options now have a default value which is used for the non-interactive mode. `beeflow config new --flux` overrides `workflow_scheduler` default of "Slurm" to be "Flux".

`beeflow config new --interactive` will prompt the user for every config option, but entering nothing will now use the stored default.