### PR TITLE
Issue971/Corrects neo4j cypher queries that trigger warnings

### DIFF
--- a/beeflow/tests/test_neo4j_cypher.py
+++ b/beeflow/tests/test_neo4j_cypher.py
@@ -1,0 +1,56 @@
+"""Tests for neo4j_cypher module."""
+
+import pytest
+from beeflow.common.gdb import neo4j_cypher
+
+
+@pytest.mark.parametrize("reqs, expected", [(True, ["dummy"] * 3), (False, [])])
+def test_get_workflow_requirements(mocker, reqs, expected):
+    """Regression test get_workflow_requirements."""
+    tx = mocker.MagicMock()
+    tx.run.return_value = [{"r": e} for e in expected]
+    mocker.patch(
+        "beeflow.common.gdb.neo4j_cypher.get_workflow_by_id",
+        return_value={"reqs": reqs},
+    )
+    result = neo4j_cypher.get_workflow_requirements(tx, "")
+    assert result == expected
+
+
+@pytest.mark.parametrize("hints, expected", [(True, ["dummy"] * 3), (False, [])])
+def test_get_workflow_hints(mocker, hints, expected):
+    """Regression test get_workflow_hints."""
+    tx = mocker.MagicMock()
+    tx.run.return_value = [{"h": e} for e in expected]
+    mocker.patch(
+        "beeflow.common.gdb.neo4j_cypher.get_workflow_by_id",
+        return_value={"hints": hints},
+    )
+    result = neo4j_cypher.get_workflow_hints(tx, "")
+    assert result == expected
+
+
+@pytest.mark.parametrize("reqs, expected", [(True, ["dummy"] * 3), (False, [])])
+def test_get_task_requirements(mocker, reqs, expected):
+    """Regression test get_task_requirements."""
+    tx = mocker.MagicMock()
+    tx.run.return_value = [{"r": e} for e in expected]
+    mocker.patch(
+        "beeflow.common.gdb.neo4j_cypher.get_task_by_id",
+        return_value={"reqs": reqs},
+    )
+    result = neo4j_cypher.get_task_requirements(tx, "")
+    assert result == expected
+
+
+@pytest.mark.parametrize("hints, expected", [(True, ["dummy"] * 3), (False, [])])
+def test_get_task_hints(mocker, hints, expected):
+    """Regression test get_task_hints."""
+    tx = mocker.MagicMock()
+    tx.run.return_value = [{"h": e} for e in expected]
+    mocker.patch(
+        "beeflow.common.gdb.neo4j_cypher.get_task_by_id",
+        return_value={"hints": hints},
+    )
+    result = neo4j_cypher.get_task_hints(tx, "")
+    assert result == expected


### PR DESCRIPTION
Closes #971 

This stops the `neo4j` warnings cluttering the logs such as:

```shell
Received notification from DBMS server: {severity: WARNING} {code: Neo.ClientNotification.Statement.UnknownLabelWarning} {category: UNRECOGNIZED} {title: The provided label is not in the database.} {description: One of the labels in your query is not available in the database, make sure you didn't misspell it or that the label is available when you run this statement in your application (the missing label name is: Hint)} {position: line: 1, column: 45, offset: 44} for query: 'MATCH (:Task {id: $task_id})<-[:HINT_OF]-(h:Hint) RETURN h'
```

Many of these are due to workflows/tasks that do not have hints or requirements. `neo4j` returns warnings when relationships or labels are used in queries when they don't exist. These were corrected by storing on the workflow node or task node whether hints or requirements exist at creation. This allows the queries to only be performed if hints or queries exist.

There is a similar issue for restarts. This query operates on all tasks, so whether or not there could be a restart is stored on the workflow node.

There was a deprecation warning to use the syntax `[:DEPENDS_ON|RESTARTED_FROM]` over `[:DEPENDS_ON|:RESTARTED_FROM]`. This was corrected where it existed.

Finally I added a couple of very basic regression tests on some of the relevant methods in `neo4j_cypher.py`

EDIT: 
So far I have verified that warnings are not received on the `cat-grep-tar` and `clamr-ffmpeg-build` example workflows and these finish to completion without error.

`cat-grep-tar` has no hints or requirements and `clamr-ffmpeg-build` has hints. So it would be best to run a workflow with requirements and that was restarted to verify they have no issues.