### PR TITLE
Set up unique remote port number as the default

### DIFF
--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -203,6 +203,13 @@ def filepath_completion_input(*pargs, **kwargs):
         return input(*pargs, **kwargs)
 
 
+def unique_port():
+    """Assign unique port for remote user."""
+    uid = os.getuid()
+    port = ((uid%(16000-7777))+7777)
+    return port
+
+
 # Below is the definition of all bee config options, defaults and requirements.
 # This will be used to validate config files on loading them in the BeeConfig
 # singleton class above.
@@ -256,7 +263,7 @@ VALIDATOR.option('DEFAULT', 'remote_api', info='BEE remote REST API activation',
                  default=False, validator=validation.bool_, prompt=False)
 
 VALIDATOR.option('DEFAULT', 'remote_api_port', info='BEE remote REST API port',
-                 default=7777, validator=int, prompt=False)
+                 default=unique_port(), validator=int, prompt=False)
 
 VALIDATOR.option('DEFAULT', 'workload_scheduler', choices=('Slurm', 'LSF', 'Flux', 'Simple'),
                  default='Slurm', info='backend workload scheduler to interact with ',

--- a/beeflow/remote/remote.py
+++ b/beeflow/remote/remote.py
@@ -137,7 +137,6 @@ def find_free_port(start_port=1024, end_port=65535, host='127.0.0.1'):
 
 def create_app():
     """Start the web-server for the API with uvicorn."""
-    # decide what port we're using for the long term. I set it to port 7777 temporarily
 
     port_number = bc.get('DEFAULT', 'remote_api_port')
     if is_port_taken(port_number) is True:

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">73%</text>
-        <text x="80" y="14">73%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">74%</text>
+        <text x="80" y="14">74%</text>
     </g>
 </svg>


### PR DESCRIPTION
Changing default remote port number of '7777' to a unique number in the range of (7777, 16000) using the user's $UID number.

Note: This new _unique_ port number still goes through the ```is_port_taken()``` and ```find_free_port()``` functions in ```beeflow/remote.py``` in case it happens to be taken.