### PR TITLE
Add `__init__.py` files for `pytest-cov` discovery

### DIFF
--- a/beeflow/__init__.py
+++ b/beeflow/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow module."""

--- a/beeflow/client/__init__.py
+++ b/beeflow/client/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow client module."""

--- a/beeflow/common/__init__.py
+++ b/beeflow/common/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow common module."""

--- a/beeflow/common/build/__init__.py
+++ b/beeflow/common/build/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow common build module."""

--- a/beeflow/common/crt/__init__.py
+++ b/beeflow/common/crt/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow common crt module."""

--- a/beeflow/common/cwl/__init__.py
+++ b/beeflow/common/cwl/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow common cwl module."""

--- a/beeflow/common/db/__init__.py
+++ b/beeflow/common/db/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow common db module."""

--- a/beeflow/common/deps/__init__.py
+++ b/beeflow/common/deps/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow common deps module."""

--- a/beeflow/common/gdb/__init__.py
+++ b/beeflow/common/gdb/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow common gdb module."""

--- a/beeflow/common/integration/__init__.py
+++ b/beeflow/common/integration/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow common integration module."""

--- a/beeflow/remote/__init__.py
+++ b/beeflow/remote/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow remote module."""

--- a/beeflow/scheduler/__init__.py
+++ b/beeflow/scheduler/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow scheduler module."""

--- a/beeflow/task_manager/__init__.py
+++ b/beeflow/task_manager/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow task_manager module."""

--- a/beeflow/wf_manager/__init__.py
+++ b/beeflow/wf_manager/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow wf_manager module."""

--- a/beeflow/wf_manager/resources/__init__.py
+++ b/beeflow/wf_manager/resources/__init__.py
@@ -1,0 +1,1 @@
+"""beeflow wf_manager resources module."""

--- a/coverage.svg
+++ b/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#dfb317" d="M63 0h36v20H63z"/>
+        <path fill="#fe7d37" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">74%</text>
-        <text x="80" y="14">74%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">54%</text>
+        <text x="80" y="14">54%</text>
     </g>
 </svg>


### PR DESCRIPTION
Noticed when looking at #977 that some files are not being discovered by `pytest-cov` giving an artificially high line coverage. Adding `__init__.py` files to all the module folders forces `pytest-cov` to check files for coverage.

If there is some reason not to add these or if I missed locations that `pytest-cov` should check let me know.