### PR TITLE
Add --remote flag to beeflow core start

### DIFF
--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -259,9 +259,6 @@ VALIDATOR.option('DEFAULT', 'bee_droppoint', info='BEE remote workflow drop poin
                  default=DEFAULT_BEE_DROPPOINT, validator=validation.make_dir,
                  prompt=False)
 
-VALIDATOR.option('DEFAULT', 'remote_api', info='BEE remote REST API activation',
-                 default=False, validator=validation.bool_, prompt=False)
-
 VALIDATOR.option('DEFAULT', 'remote_api_port', info='BEE remote REST API port',
                  default=unique_port(), validator=int, prompt=False)
 

--- a/docs/sphinx/commands.rst
+++ b/docs/sphinx/commands.rst
@@ -15,7 +15,7 @@ To interact with the daemon process you'll need to use the ``beeflow core`` sub-
 Options:
   -F, --foreground  run in the foreground  [default: False]
   -B, --backend  run on a back end node  [default: False]
-
+  -R, --remote  allow remote interactions  [default: False]
 
 ``beeflow core status``: Check the status of beeflow and the components.
 


### PR DESCRIPTION
This will add a flag, ```--remote``` or ```-R```, to ```beeflow core start``` to allow for remote interaction.
All this does is replace the ```remote_api``` variable from the config file. If the ```--remote``` flag is not specified when starting ```beeflow```, then the REST API will not be initiated. This will be convenient for a user trying to interact with a ```beeflow``` instance (remotely) without having to worry if the config file is set up for a remote connection.

This closes issue #992. 