### PR TITLE
Release 0.1.10

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -65,4 +65,62 @@ Features: Fixes sphinx version to enable publishing documentation, now includes
 - Add separate action for testing docs
 - Fix beeflow config new error
 
+0.1.9
+
+Major features include:
+   Changing graph database to use one instance of Neo4j
+   Initial python api for generating CWL specification
+   Added Rest API for beeflow
+   Add ability to export graph of workflow and task states at any stage
+
+- Updates the Graph Database to use one instance of Neo4j for all workflows for a user vs. using one for each workflow.  - impacts system resources
+- Adds Python API for generating cwl specification of a workflow.
+- Adds coverage metrics for unit tests. - improves reliability
+- Adds resiliency to Task Manager (TM) now updates task states upon automatic restart of TM - improves resilience
+- Enhances pre/post-script capabilities - added flux capability & checks for shell compatibility. - adds flexibility to each task
+- Adds capability to export dag of a workflow before, during and after execution - enhancement verifing workflows prior to submit and visualizing state during run
+- Adds Beeflow connect – A Rest API for BEEflow – capability to start a workflow from Continuous Integration (CI) tests (or on another system by user)
+
+0.1.10
+
+Major features include:
+
+   Adding the capability to limit the number of jobs in active scheduling
+   Improves archiving failed and cancelled workflows
+   Improvements to API for generating CWL specifications
+   Adds SlurmRequirements for qos and reservation
+   Improved configuration
+   Checks if beeflow is running on another front-end
+
+
+ - Implement Archived/Partial-Fail workflow end state
+ - Add --remote flag to beeflow core start (#1015)
+ - Task failure only fails dependent tasks
+ - Prevent multi-failed tasks archiving
+ - Add job_limits to config; limit the number jobs in the job queue (#1010)
+ - Prevent archiving if workflow is already archived
+ - Set up unique remote port number as the default (#1007)
+ - Adds regression test for archive_workflow in wf_update (#997)
+ - Generate CWL Refactor (#1004)
+ - Change SchedulerRequirement to SlurmRequirement; add qos and reservatio
+ - Add CWL requirement beeflow:useContainer support for SquashFS (#990)
+ - Add `pytest` tips to Developer's Guide (#999)
+ - Corrects neo4j cypher queries that trigger warnings (#993)
+ - Issue963/Make beeflow config new non-interactive by default (#983)
+ - Remove extra messages about the openapi_version (#985)
+ - Fix backend issues and reset client db (#981)
+ - Issue979/Remove metadata command (#982)
+ - Correct archives location (#973)
+ - Issue877/Add config option for archive directory (#965)
+ - Fix slurmrestd version function (#953)
+ - Upgrade acceptable versions of python to <= 3.13.0 (#961)
+ - Fix Cancel Workflows (#960)
+ - Issue943/pull deps neo4j (#945)
+ - Update requests-unixsocket to requests-unixsocket2 (#958)
+ - Bump werkzeug from 3.0.4 to 3.0.6 (#952)
+ - remove gdb ports from config (#940)
+ - Archive Cancelled Workflows (#939)
+ - Issue883/add check for different front end (#933)
+ - Fix config issue and revise slurmrestd inference (#950)
+ - Add flag to allow beeflow to run on back end node (#947)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hpc-beeflow"
-version = "0.1.10dev1"
+version = "0.1.10"
 description = "A software package for containerizing HPC applications and managing job workflows"
 
 


### PR DESCRIPTION
   Adds the capability to limit the number of jobs in active scheduling
   Improves archiving failed and cancelled workflows
   Adds improvements to API for generating CWL specifications
   Adds SlurmRequirements for qos and reservation
   Improves configuration
   Checks if beeflow is running on another front-end
