### PR TITLE
BUILD_FAIL should cause DEP_FAIL for dependent tasks

### DIFF
--- a/beeflow/tests/test_wf_update.py
+++ b/beeflow/tests/test_wf_update.py
@@ -71,7 +71,7 @@ def test_archive_archived_wf(mocker, wf_state):
     )
 
 
-@pytest.mark.parametrize("job_state", ["FAILED", "SUBMIT_FAIL"])
+@pytest.mark.parametrize("job_state", ["FAILED", "SUBMIT_FAIL", 'BUILD_FAIL'])
 def test_handle_state_change_failed_task(mocker, job_state):
     """Regression test task failure."""
     state_update = mocker.MagicMock()

--- a/beeflow/wf_manager/resources/wf_update.py
+++ b/beeflow/wf_manager/resources/wf_update.py
@@ -146,13 +146,9 @@ class WFUpdate(Resource):
                 wf_utils.schedule_submit_tasks(state_update.wf_id, tasks)
 
         # If the job failed, fail the dependent tasks
-        if state_update.job_state in ['FAILED', 'SUBMIT_FAIL']:
+        if state_update.job_state in ['FAILED', 'SUBMIT_FAIL', 'BUILD_FAIL']:
             set_dependent_tasks_dep_fail(db, wfi, state_update.wf_id, task)
             log.info(f"Task {task.name} failed")
-
-        if state_update.job_state == 'BUILD_FAIL':
-            log.error(f'Workflow failed due to failed container build for task {task.name}')
-            archive_fail_workflow(db, state_update.wf_id)
 
         if wfi.workflow_completed():
             wf_id = wfi.workflow_id


### PR DESCRIPTION
Closes #1017 

After discussion we decided that for now BUILD_FAIL should just fail dependent tasks. This PR adjusts the behavior of BUILD_FAIL to be similar to any other task failure. Dependent tasks will fail with DEP_FAIL, but the non-dependent tasks will continue as usual.

I tested this by making a variation of the `build-failure` ci workflow that has two branches. It uses the Dockerfile and `input.yml` from that workflow.

<details><summary>modified workflow.cwl</summary>

```shell
class: Workflow
cwlVersion: v1.2

inputs:
  fname: string

outputs:
  outA:
    type: File
    outputSource: step1A/stdout
  outB:
    type: File
    outputSource: step1B/stdout

steps:
  step0A:
    run:
      class: CommandLineTool
      baseCommand: ls
      stdout: step0A_stdout.txt
      inputs:
        fname:
          type: string
          inputBinding: {}
      outputs:
        stdout:
          type: stdout
    in:
      fname: fname
    out: [stdout]
    hints:
      DockerRequirement:
        dockerFile: "Dockerfile.build-failure"
        beeflow:containerName: "build-failure"
  step1A:
    run:
      class: CommandLineTool
      baseCommand: cat
      stdout: step1A_stdout.txt
      inputs:
        infile:
          type: File
          inputBinding: {}
      outputs:
        stdout:
          type: stdout
    in:
      infile: step0A/stdout
    out: [stdout]
  step0B:
    run:
      class: CommandLineTool
      baseCommand: printf
      stdout: step0B_stdout.txt
      inputs:
        fname:
          type: string
          inputBinding: {}
      outputs:
        stdout:
          type: stdout
    in:
      fname: fname
    out: [stdout]
  step1B:
    run:
      class: CommandLineTool
      baseCommand: cat
      stdout: step1B_stdout.txt
      inputs:
        infile:
          type: File
          inputBinding: {}
      outputs:
        stdout:
          type: stdout
    in:
      infile: step0B/stdout
    out: [stdout]
```

</details>

The workflow should end as follows:

```shell
Archived/Partial-Fail
step0A--BUILD_FAIL
step0B--COMPLETED
step1A--DEP_FAIL
step1B--COMPLETED
```