### PR TITLE
Fail dependent tasks for TIMEOUT

### DIFF
--- a/beeflow/common/gdb/neo4j_cypher.py
+++ b/beeflow/common/gdb/neo4j_cypher.py
@@ -4,7 +4,8 @@ from re import fullmatch
 from beeflow.common import log as bee_logging
 
 log = bee_logging.setup(__name__)
-
+failed_task_states = ['FAILED', 'SUBMIT_FAIL', 'BUILD_FAIL', 'DEP_FAIL', 'TIMEOUT', 'TIMELIMIT']
+final_task_states = ['COMPLETED'] + failed_task_states
 
 def create_bee_node(tx):
     """Create a BEE node in the Neo4j database.
@@ -718,8 +719,6 @@ def reset_workflow_id(tx, old_id, new_id):
 def final_tasks_completed(tx, wf_id):
     """Return true if each of a workflow's final Task nodes is in a finished state.
 
-    Finished states: 'COMPLETED', 'FAILED', 'SUBMIT_FAIL', 'BUILD_FAIL', or 'DEP_FAIL'.
-
     :param wf_id: the workflow's id
     :type wf_id: str
     :rtype: bool
@@ -727,8 +726,7 @@ def final_tasks_completed(tx, wf_id):
     restart = "|RESTARTED_FROM" if get_workflow_by_id(tx, wf_id)['restart'] else ""
     not_completed_query = ("MATCH (m:Metadata)-[:DESCRIBES]->(t:Task {workflow_id: $wf_id}) "
                            f"WHERE NOT (t)<-[:DEPENDS_ON{restart}]-(:Task) "
-                           "AND NOT m.state IN "
-                           "['COMPLETED', 'FAILED', 'SUBMIT_FAIL', 'BUILD_FAIL', 'DEP_FAIL'] "
+                           f"AND NOT m.state IN {final_task_states} "
                            "RETURN t IS NOT NULL LIMIT 1")
 
     # False if at least one task is not finished
@@ -755,8 +753,6 @@ def final_tasks_succeeded(tx, wf_id):
 def final_tasks_failed(tx, wf_id):
     """Return true if each of a workflow's final Task nodes is in a failed state.
 
-    Finished states: 'FAILED', 'SUBMIT_FAIL', 'BUILD_FAIL', or 'DEP_FAIL'.
-
     :param wf_id: the workflow's id
     :type wf_id: str
     :rtype: bool
@@ -764,8 +760,7 @@ def final_tasks_failed(tx, wf_id):
     restart = "|RESTARTED_FROM" if get_workflow_by_id(tx, wf_id)['restart'] else ""
     not_failed_query = ("MATCH (m:Metadata)-[:DESCRIBES]->(t:Task {workflow_id: $wf_id}) "
                         f"WHERE NOT (t)<-[:DEPENDS_ON{restart}]-(:Task) "
-                        "AND NOT m.state IN "
-                        "['FAILED', 'SUBMIT_FAIL', 'BUILD_FAIL', 'DEP_FAIL'] "
+                        f"AND NOT m.state IN {failed_task_states} "
                         "RETURN t IS NOT NULL LIMIT 1")
 
     # False if at least one task is not failed

--- a/beeflow/common/gdb/neo4j_cypher.py
+++ b/beeflow/common/gdb/neo4j_cypher.py
@@ -4,7 +4,7 @@ from re import fullmatch
 from beeflow.common import log as bee_logging
 
 log = bee_logging.setup(__name__)
-failed_task_states = ['FAILED', 'SUBMIT_FAIL', 'BUILD_FAIL', 'DEP_FAIL', 'TIMEOUT', 'TIMELIMIT']
+failed_task_states = ['FAILED', 'SUBMIT_FAIL', 'BUILD_FAIL', 'DEP_FAIL', 'TIMEOUT']
 final_task_states = ['COMPLETED'] + failed_task_states
 
 def create_bee_node(tx):

--- a/beeflow/common/worker/flux_worker.py
+++ b/beeflow/common/worker/flux_worker.py
@@ -140,7 +140,7 @@ class FluxWorker(Worker):
 
     def query_task(self, job_id):
         """Query job state for the task."""
-        # TODO: How does Flux handle TIMEOUT/TIMELIMIT? They don't seem to have
+        # TODO: How does Flux handle TIMEOUT? They don't seem to have
         # a state for this
         log.info(f'Querying task with job_id: {job_id}')
         flux = self.flux.Flux()

--- a/beeflow/task_manager/background.py
+++ b/beeflow/task_manager/background.py
@@ -26,7 +26,7 @@ else:
 log.info(f'The number of jobs queued will be limited to {jobs_limit}.')
 
 # States are based on https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES
-COMPLETED_STATES = {'UNKNOWN', 'COMPLETED', 'CANCELLED', 'FAILED', 'TIMEOUT', 'TIMELIMIT'}
+COMPLETED_STATES = {'UNKNOWN', 'COMPLETED', 'CANCELLED', 'FAILED', 'TIMEOUT'}
 
 def resolve_environment(task):
     """Use build interface to create a valid environment.
@@ -100,10 +100,10 @@ def update_jobs(db):
         if job_state != new_job_state:
             db.job_queue.update_job_state(id_, new_job_state)
             log.info(f"Job Updated '{task.name}' job_id: {job_id} job_state: {new_job_state}")
-            if new_job_state in ('FAILED', 'TIMELIMIT', 'TIMEOUT'):
+            if new_job_state in ('FAILED', 'TIMEOUT'):
                 # Harvest lastest checkpoint file.
                 task_checkpoint = task.get_full_requirement('beeflow:CheckpointRequirement')
-                log.info(f'TIMELIMIT/TIMEOUT task_checkpoint: {task_checkpoint}')
+                log.info(f'TIMEOUT task_checkpoint: {task_checkpoint}')
                 if task_checkpoint:
                     try:
                         checkpoint_file = utils.get_restart_file(task_checkpoint, task.workdir)

--- a/beeflow/wf_manager/resources/wf_update.py
+++ b/beeflow/wf_manager/resources/wf_update.py
@@ -146,7 +146,10 @@ class WFUpdate(Resource):
                 wf_utils.schedule_submit_tasks(state_update.wf_id, tasks)
 
         # If the job failed, fail the dependent tasks
-        if state_update.job_state in ['FAILED', 'SUBMIT_FAIL', 'BUILD_FAIL']:
+        # TIMEOUT, TIMELIMIT states should only be seen here if they can't restart
+        if state_update.job_state in [
+            'FAILED', 'SUBMIT_FAIL', 'BUILD_FAIL', 'TIMEOUT', 'TIMELIMIT'
+        ]:
             set_dependent_tasks_dep_fail(db, wfi, state_update.wf_id, task)
             log.info(f"Task {task.name} failed")
 

--- a/beeflow/wf_manager/resources/wf_update.py
+++ b/beeflow/wf_manager/resources/wf_update.py
@@ -146,9 +146,9 @@ class WFUpdate(Resource):
                 wf_utils.schedule_submit_tasks(state_update.wf_id, tasks)
 
         # If the job failed, fail the dependent tasks
-        # TIMEOUT, TIMELIMIT states should only be seen here if they can't restart
+        # TIMEOUT states should only be seen here if they can't restart
         if state_update.job_state in [
-            'FAILED', 'SUBMIT_FAIL', 'BUILD_FAIL', 'TIMEOUT', 'TIMELIMIT'
+            'FAILED', 'SUBMIT_FAIL', 'BUILD_FAIL', 'TIMEOUT'
         ]:
             set_dependent_tasks_dep_fail(db, wfi, state_update.wf_id, task)
             log.info(f"Task {task.name} failed")


### PR DESCRIPTION
Closes #1034 

This corrects the issue for the case described in #1034:

>To reproduce you can set the default_time_limit in bee.conf to something short. I did 30 seconds. And then run the clamr workflow.

From my read of the code, it seems like this should not affect restarts; but I still need to verify this. ~~I should also check a case for `TIMELIMIT`.~~