### PR TITLE
Disable builder when no DockerRequirement present

### DIFF
--- a/beeflow/common/build/container_drivers.py
+++ b/beeflow/common/build/container_drivers.py
@@ -82,7 +82,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
                 docker_requirements = docker_requirements.union(hint_docker_requirements)
                 hint_str = f'{set(hint_docker_requirements)}'
                 log.info(f'task {self.task.name} {self.task.id} hint '
-                         'DockerRequirements: {hint_str}')
+                         f'DockerRequirements: {hint_str}')
             except (TypeError, KeyError):
                 log.info(f'task {self.task.name} {self.task.id} hints has no DockerRequirements')
             log.info(f'task {self.task.id} union DockerRequirements : {docker_requirements}')
@@ -90,7 +90,7 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
             self.exec_list = [i for i in exec_superset if i[1] in docker_requirements]
             log_exec_list = [i[1] for i in self.exec_list]
             log.info(f'task {self.task.id} DockerRequirement execution order '
-                     'will be: {log_exec_list}')
+                     f'will be: {log_exec_list}')
             log.info('Execution order pre-empts hint/requirement status.')
 
     def get_docker_req(self, docker_req_param):

--- a/beeflow/common/build/container_drivers.py
+++ b/beeflow/common/build/container_drivers.py
@@ -47,7 +47,8 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         """
         has_container = task.get_full_requirement('DockerRequirement')
         if has_container:  # only try to build if task has a container
-            # Store build container archive pased on config file or relative to bee_workdir if not set.
+            # Store build container archive pased on config file or relative to bee_workdir
+            # if not set.
             container_archive = bc.get('builder', 'container_archive')
             self.container_archive = bc.resolve_path(container_archive)
             os.makedirs(self.container_archive, exist_ok=True)
@@ -69,24 +70,27 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
             self.container_name = None
             docker_requirements = set()
             try:
-                requirement_docker_requirements = self.task.requirements['DockerRequirement'].keys()
-                docker_requirements = docker_requirements.union(requirement_docker_requirements)
-                req_string = f'{set(requirement_docker_requirements)}'
+                req_docker_requirements = self.task.requirements['DockerRequirement'].keys()
+                docker_requirements = docker_requirements.union(req_docker_requirements)
+                req_string = f'{set(req_docker_requirements)}'
                 log.info(f'task {self.task.id} requirement DockerRequirements: {req_string}')
             except (TypeError, KeyError):
-                log.info(f'task {self.task.name} {self.task.id} no DockerRequirements in requirement')
+                log.info(f'task {self.task.name} {self.task.id} '
+                         'no DockerRequirements in requirement')
             try:
                 hint_docker_requirements = self.task.hints['DockerRequirement'].keys()
                 docker_requirements = docker_requirements.union(hint_docker_requirements)
                 hint_str = f'{set(hint_docker_requirements)}'
-                log.info(f'task {self.task.name} {self.task.id} hint DockerRequirements: {hint_str}')
+                log.info(f'task {self.task.name} {self.task.id} hint '
+                         'DockerRequirements: {hint_str}')
             except (TypeError, KeyError):
                 log.info(f'task {self.task.name} {self.task.id} hints has no DockerRequirements')
             log.info(f'task {self.task.id} union DockerRequirements : {docker_requirements}')
             exec_superset = self.resolve_priority()
             self.exec_list = [i for i in exec_superset if i[1] in docker_requirements]
             log_exec_list = [i[1] for i in self.exec_list]
-            log.info(f'task {self.task.id} DockerRequirement execution order will be: {log_exec_list}')
+            log.info(f'task {self.task.id} DockerRequirement execution order '
+                     'will be: {log_exec_list}')
             log.info('Execution order pre-empts hint/requirement status.')
 
     def get_docker_req(self, docker_req_param):

--- a/beeflow/common/build/container_drivers.py
+++ b/beeflow/common/build/container_drivers.py
@@ -45,47 +45,49 @@ class CharliecloudBuildDriver(ContainerBuildDriver):
         :param task: the task to build for
         :type task: Task
         """
-        # Store build container archive pased on config file or relative to bee_workdir if not set.
-        container_archive = bc.get('builder', 'container_archive')
-        self.container_archive = bc.resolve_path(container_archive)
-        os.makedirs(self.container_archive, exist_ok=True)
-        # Deploy build tarballs relative to /var/tmp/username/beeflow by default
-        deployed_image_root = bc.get('builder', 'deployed_image_root')
-        # Make sure conf_file path exists
-        os.makedirs(deployed_image_root, exist_ok=True)
-        # Make sure path is absolute
-        deployed_image_root = bc.resolve_path(deployed_image_root)
-        self.deployed_image_root = deployed_image_root
-        os.makedirs(self.deployed_image_root, exist_ok=True)
-        # Set container-relative output directory based on BeeConfig, or use '/'
-        container_output_path = bc.get('builder', 'container_output_path')
-        self.container_output_path = container_output_path
-        # record that a Charliecloud builder was used
-        # bc.modify_section('user', 'builder', {'container_type': 'charliecloud'})
-        self.task = task
-        self.docker_image_id = None
-        self.container_name = None
-        docker_requirements = set()
-        try:
-            requirement_docker_requirements = self.task.requirements['DockerRequirement'].keys()
-            docker_requirements = docker_requirements.union(requirement_docker_requirements)
-            req_string = f'{set(requirement_docker_requirements)}'
-            log.info(f'task {self.task.id} requirement DockerRequirements: {req_string}')
-        except (TypeError, KeyError):
-            log.info(f'task {self.task.name} {self.task.id} no DockerRequirements in requirement')
-        try:
-            hint_docker_requirements = self.task.hints['DockerRequirement'].keys()
-            docker_requirements = docker_requirements.union(hint_docker_requirements)
-            hint_str = f'{set(hint_docker_requirements)}'
-            log.info(f'task {self.task.name} {self.task.id} hint DockerRequirements: {hint_str}')
-        except (TypeError, KeyError):
-            log.info(f'task {self.task.name} {self.task.id} hints has no DockerRequirements')
-        log.info(f'task {self.task.id} union DockerRequirements : {docker_requirements}')
-        exec_superset = self.resolve_priority()
-        self.exec_list = [i for i in exec_superset if i[1] in docker_requirements]
-        log_exec_list = [i[1] for i in self.exec_list]
-        log.info(f'task {self.task.id} DockerRequirement execution order will be: {log_exec_list}')
-        log.info('Execution order pre-empts hint/requirement status.')
+        has_container = task.get_full_requirement('DockerRequirement')
+        if has_container:  # only try to build if task has a container
+            # Store build container archive pased on config file or relative to bee_workdir if not set.
+            container_archive = bc.get('builder', 'container_archive')
+            self.container_archive = bc.resolve_path(container_archive)
+            os.makedirs(self.container_archive, exist_ok=True)
+            # Deploy build tarballs relative to /var/tmp/username/beeflow by default
+            deployed_image_root = bc.get('builder', 'deployed_image_root')
+            # Make sure conf_file path exists
+            os.makedirs(deployed_image_root, exist_ok=True)
+            # Make sure path is absolute
+            deployed_image_root = bc.resolve_path(deployed_image_root)
+            self.deployed_image_root = deployed_image_root
+            os.makedirs(self.deployed_image_root, exist_ok=True)
+            # Set container-relative output directory based on BeeConfig, or use '/'
+            container_output_path = bc.get('builder', 'container_output_path')
+            self.container_output_path = container_output_path
+            # record that a Charliecloud builder was used
+            # bc.modify_section('user', 'builder', {'container_type': 'charliecloud'})
+            self.task = task
+            self.docker_image_id = None
+            self.container_name = None
+            docker_requirements = set()
+            try:
+                requirement_docker_requirements = self.task.requirements['DockerRequirement'].keys()
+                docker_requirements = docker_requirements.union(requirement_docker_requirements)
+                req_string = f'{set(requirement_docker_requirements)}'
+                log.info(f'task {self.task.id} requirement DockerRequirements: {req_string}')
+            except (TypeError, KeyError):
+                log.info(f'task {self.task.name} {self.task.id} no DockerRequirements in requirement')
+            try:
+                hint_docker_requirements = self.task.hints['DockerRequirement'].keys()
+                docker_requirements = docker_requirements.union(hint_docker_requirements)
+                hint_str = f'{set(hint_docker_requirements)}'
+                log.info(f'task {self.task.name} {self.task.id} hint DockerRequirements: {hint_str}')
+            except (TypeError, KeyError):
+                log.info(f'task {self.task.name} {self.task.id} hints has no DockerRequirements')
+            log.info(f'task {self.task.id} union DockerRequirements : {docker_requirements}')
+            exec_superset = self.resolve_priority()
+            self.exec_list = [i for i in exec_superset if i[1] in docker_requirements]
+            log_exec_list = [i[1] for i in self.exec_list]
+            log.info(f'task {self.task.id} DockerRequirement execution order will be: {log_exec_list}')
+            log.info('Execution order pre-empts hint/requirement status.')
 
     def get_docker_req(self, docker_req_param):
         """Get dockerRequirement, prioritizing requirements over hints.

--- a/beeflow/task_manager/background.py
+++ b/beeflow/task_manager/background.py
@@ -40,9 +40,11 @@ def resolve_environment(task):
 def submit_task(db, worker, task):
     """Submit (or resubmit) a task."""
     try:
-        log.info(f'Resolving environment for task {task.name}')
-        resolve_environment(task)
-        log.info(f'Environment preparation complete for task {task.name}')
+        has_container = task.get_full_requirement('DockerRequirement')
+        if has_container:
+            log.info(f'Resolving environment for task {task.name}')
+            resolve_environment(task)
+            log.info(f'Environment preparation complete for task {task.name}')
         job_id, job_state = worker.submit_task(task)
         log.info(f"Job Submitted '{task.name}' job_id: {job_id} job_state: {job_state}")
         # place job in queue to monitor

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">72%</text>
-        <text x="80" y="14">72%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
+        <text x="80" y="14">71%</text>
     </g>
 </svg>

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,9 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">74%</text>
-        <text x="80" y="14">74%</text>
-
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">73%</text>
+        <text x="80" y="14">73%</text>
     </g>
 </svg>


### PR DESCRIPTION
The builder only runs if there is a DockerRequirement in the CWL, but the worker (in ```worker.py```) calls the ```ContainerRuntimeInterface``` to load the container runtime drivers even if a container is not required. Because of this, the crt logs are still appearing in the ```task_manager.log``` file. We could probably make this a separate issue.