### PR TITLE
Add CheckpointRequirement to Python CWL API

### DIFF
--- a/beeflow/common/cwl/cwl.py
+++ b/beeflow/common/cwl/cwl.py
@@ -359,7 +359,7 @@ class SlurmRequirement:
     """Represents a beeflow custom MPI requirement."""
 
     account: str = None
-    time_limit: int = None
+    time_limit: str = None
     partition: str = None
     qos: str = None
     reservation: str = None

--- a/beeflow/common/cwl/cwl.py
+++ b/beeflow/common/cwl/cwl.py
@@ -72,6 +72,7 @@ class InputBinding:
 
     prefix: str = None
     position: int = None
+    value_from: str = None
 
     def dump(self):
         """Dump returns dictionary that will be used by pyyaml dump."""
@@ -80,6 +81,8 @@ class InputBinding:
             binding_yaml['inputBinding']['position'] = self.position
         if self.prefix:
             binding_yaml['inputBinding']['prefix'] = self.prefix
+        if self.value_from:
+            binding_yaml['inputBinding']['valueFrom'] = self.value_from
         return binding_yaml
 
     def __repr__(self):

--- a/beeflow/common/cwl/examples/clamr_checkpoint.py
+++ b/beeflow/common/cwl/examples/clamr_checkpoint.py
@@ -1,0 +1,66 @@
+"""COMD driver for CWL generator."""
+
+import pathlib
+from beeflow.common.cwl.workflow import (
+    Task,
+    Input,
+    Output,
+    MPI,
+    Charliecloud,
+    Workflow,
+    Slurm,
+    Script,
+    Checkpoint,
+)
+
+
+def main():
+    clamr_task = Task(
+        name="clamr",
+        base_command="/CLAMR/clamr_cpuonly",
+        stdout="clamr.txt",
+        stderr="clamr.err",
+        inputs=[
+            Input("max_levels", "int", 3, prefix="-l"),
+            Input("grid_resolution", "int", 32, prefix="-n"),
+            Input("steps_between_output", "int", 10, prefix="-i"),
+            Input("steps_between_graphics", "int", 25, prefix="-g"),
+            Input("time_steps", "int", 10000, prefix="-t"),
+            Input("graphics_type", "string", "png", prefix="-G"),
+            Input("checkpoint_disk_interval", "int", 50, prefix="-c"),
+        ],
+        outputs=[
+            Output("clamr_stdout", "File", source="clamr/clamr_stdout"),
+            Output("outdir", "Directory", glob="graphics_output/graph%05d.png"),
+            Output(
+                "checkpoint_dir", "Directory", glob="checkpoint_output/backup%05d.crx"
+            ),
+            Output(
+                "clamr_time_log",
+                "File",
+                source="clamr/time_log",
+                glob="total_execution_time.log",
+            ),
+        ],
+        hints=[
+            Checkpoint(
+                enabled=True,
+                file_path="checkpoint_output",
+                container_path="checkpoint_output",
+                file_regex="backup[0-9]*.crx",
+                restart_parameters="-R",
+                num_tries=3,
+            ),
+            Slurm(time_limit="00:00:10"),
+            Charliecloud(
+                docker_file="Dockerfile.clamr-ffmpeg", container_name="clamr-ffmpeg"
+            ),
+        ],
+    )
+    workflow = Workflow("clamr", [clamr_task])
+    workflow.write_wf("clamr")
+    workflow.write_yaml("clamr")
+
+
+if __name__ == "__main__":
+    main()

--- a/beeflow/common/cwl/examples/comd.py
+++ b/beeflow/common/cwl/examples/comd.py
@@ -33,7 +33,7 @@ def main():
                         # Slurm(account="standard", time_limit=60, partition="standard",
                         #      qos="debug", reservation="standard"),
                         Script(pre_script="comd_pre.sh"),
-                        Slurm(time_limit=500),
+                        Slurm(time_limit="500"),
                         Charliecloud(docker_file="Dockerfile.comd-x86_64",
                                      container_name="comd-mpi")
                      ])

--- a/beeflow/common/cwl/workflow.py
+++ b/beeflow/common/cwl/workflow.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 from beeflow.common.cwl.cwl import (CWL, CWLInput, CWLInputs, RunInput, Inputs, CWLOutput,
                                     Outputs, Run, RunOutput, Step, Steps, Hints,
                                     InputBinding, MPIRequirement, DockerRequirement,
-                                    ScriptRequirement, SlurmRequirement)
+                                    ScriptRequirement, SlurmRequirement,
+                                    CheckpointRequirement)
 
 
 @dataclass
@@ -118,6 +119,20 @@ class Script:
                                  post_script=self.post_script,
                                  enabled=self.enabled,
                                  shell=self.shell)
+
+
+@dataclass
+class Checkpoint(CheckpointRequirement):
+    """Get Checkpoint Requirements."""
+
+    def requirement(self):
+        """Return a checkpoint requirement object."""
+        return CheckpointRequirement(file_path=self.file_path,
+                                     container_path=self.container_path,
+                                     file_regex=self.file_regex,
+                                     restart_parameters=self.restart_parameters,
+                                     num_tries=self.num_tries,
+                                     enabled=self.enabled)
 
 
 @dataclass

--- a/beeflow/common/cwl/workflow.py
+++ b/beeflow/common/cwl/workflow.py
@@ -15,12 +15,13 @@ class Input:
     name: str
     type_: str
     # This is either a value or a source connection
-    value: str
+    value: str = None
     # The prefix or position of the argument
     # This can either be a prefix such as -f or --file
     # Or a position like 2 if the command is "foo <file>"
     prefix: str = None
     position: int = None
+    value_from: str = None
 
     pattern = re.compile(r"^[^/]+/[^/]+$")
 
@@ -36,7 +37,8 @@ class Input:
 
     def run_input(self):
         """Create a RunInput from generic Input."""
-        bindings = {'prefix': self.prefix, 'position': self.position}
+        bindings = {'prefix': self.prefix, 'position': self.position,
+                    'value_from': self.value_from}
         source = {}
         if self.has_source():
             source.update({"source": self.value})

--- a/beeflow/tests/cwl_files/clamr.cwl
+++ b/beeflow/tests/cwl_files/clamr.cwl
@@ -1,0 +1,94 @@
+cwlVersion: v1.0
+class: Workflow
+
+inputs:
+  max_levels: int
+  grid_resolution: int
+  steps_between_output: int
+  steps_between_graphics: int
+  time_steps: int
+  graphics_type: string
+  checkpoint_disk_interval: int
+
+outputs:
+  clamr_stdout:
+    type: File
+    outputSource: clamr/clamr_stdout
+  clamr_time_log:
+    type: File
+    outputSource: clamr/time_log
+
+steps:
+  clamr:
+    run:
+      class: CommandLineTool
+      baseCommand: /CLAMR/clamr_cpuonly
+      stdout: clamr.txt
+      stderr: clamr.err
+      inputs:
+        max_levels:
+          type: int
+          inputBinding:
+            prefix: -l
+        grid_resolution:
+          type: int
+          inputBinding:
+            prefix: -n
+        steps_between_output:
+          type: int
+          inputBinding:
+            prefix: -i
+        steps_between_graphics:
+          type: int
+          inputBinding:
+            prefix: -g
+        time_steps:
+          type: int
+          inputBinding:
+            prefix: -t
+        graphics_type:
+          type: string
+          inputBinding:
+            prefix: -G
+        checkpoint_disk_interval:
+          type: int
+          inputBinding:
+            prefix: -c
+      outputs:
+        clamr_stdout:
+          type: File
+        outdir:
+          type: Directory
+          outputBinding:
+            glob: graphics_output/graph%05d.png
+        checkpoint_dir:
+          type: Directory
+          outputBinding:
+            glob: checkpoint_output/backup%05d.crx
+        clamr_time_log:
+          type: File
+          outputBinding:
+            glob: total_execution_time.log
+    in:
+      max_levels: max_levels
+      grid_resolution: grid_resolution
+      steps_between_output: steps_between_output
+      steps_between_graphics: steps_between_graphics
+      time_steps: time_steps
+      graphics_type: graphics_type
+      checkpoint_disk_interval: checkpoint_disk_interval
+    out: [clamr_stdout, outdir, checkpoint_dir, clamr_time_log]
+    hints:
+      beeflow:CheckpointRequirement:
+        enabled: true
+        file_path: checkpoint_output
+        container_path: checkpoint_output
+        file_regex: backup[0-9]*.crx
+        restart_parameters: -R
+        num_tries: 3
+      beeflow:SlurmRequirement:
+        timeLimit: 00:00:10
+      DockerRequirement:
+        dockerFile: Dockerfile.clamr-ffmpeg
+        beeflow:containerName: clamr-ffmpeg
+

--- a/beeflow/tests/cwl_files/clamr.yml
+++ b/beeflow/tests/cwl_files/clamr.yml
@@ -1,0 +1,8 @@
+max_levels: 3
+grid_resolution: 32
+steps_between_output: 10
+steps_between_graphics: 25
+time_steps: 10000
+graphics_type: png
+checkpoint_disk_interval: 50
+

--- a/beeflow/tests/test_cwl.py
+++ b/beeflow/tests/test_cwl.py
@@ -19,9 +19,15 @@ import pytest
         ),
         (
             cwl.InputBinding,
-            {"prefix": "-f", "position": 1},
-            "inputBinding:\n  position: 1\n  prefix: -f\n",
-            {"inputBinding": {"position": 1, "prefix": "-f"}},
+            {"prefix": "-f", "position": 1, "value_from": '$("/graph%05d.png")'},
+            'inputBinding:\n  position: 1\n  prefix: -f\n  valueFrom: $("/graph%05d.png")\n',
+            {
+                "inputBinding": {
+                    "position": 1,
+                    "prefix": "-f",
+                    "valueFrom": '$("/graph%05d.png")',
+                }
+            },
         ),
         (
             cwl.RunInput,

--- a/beeflow/tests/test_cwl_workflow.py
+++ b/beeflow/tests/test_cwl_workflow.py
@@ -7,6 +7,7 @@ from beeflow.common.cwl.workflow import (
     Charliecloud,
     Slurm,
     Script,
+    Checkpoint,
 )
 from importlib.resources import files
 
@@ -133,6 +134,66 @@ def test_workflow_comd(tmpdir):
             expected = f2.read()
             assert actual == expected
         with open("comd.yml", "r") as f1, open(expected_yaml, "r") as f2:
+            actual = f1.read()
+            expected = f2.read()
+            assert actual == expected
+
+
+def test_workflow_checkpoint(tmpdir):
+    """Regression test simple workflow with checkpointing."""
+    expected_wf = expected_folder / "clamr.cwl"
+    expected_yaml = expected_folder / "clamr.yml"
+    clamr_task = Task(
+        name="clamr",
+        base_command="/CLAMR/clamr_cpuonly",
+        stdout="clamr.txt",
+        stderr="clamr.err",
+        inputs=[
+            Input("max_levels", "int", 3, prefix="-l"),
+            Input("grid_resolution", "int", 32, prefix="-n"),
+            Input("steps_between_output", "int", 10, prefix="-i"),
+            Input("steps_between_graphics", "int", 25, prefix="-g"),
+            Input("time_steps", "int", 10000, prefix="-t"),
+            Input("graphics_type", "string", "png", prefix="-G"),
+            Input("checkpoint_disk_interval", "int", 50, prefix="-c"),
+        ],
+        outputs=[
+            Output("clamr_stdout", "File", source="clamr/clamr_stdout"),
+            Output("outdir", "Directory", glob="graphics_output/graph%05d.png"),
+            Output(
+                "checkpoint_dir", "Directory", glob="checkpoint_output/backup%05d.crx"
+            ),
+            Output(
+                "clamr_time_log",
+                "File",
+                source="clamr/time_log",
+                glob="total_execution_time.log",
+            ),
+        ],
+        hints=[
+            Checkpoint(
+                enabled=True,
+                file_path="checkpoint_output",
+                container_path="checkpoint_output",
+                file_regex="backup[0-9]*.crx",
+                restart_parameters="-R",
+                num_tries=3,
+            ),
+            Slurm(time_limit="00:00:10"),
+            Charliecloud(
+                docker_file="Dockerfile.clamr-ffmpeg", container_name="clamr-ffmpeg"
+            ),
+        ],
+    )
+    workflow = Workflow("clamr", [clamr_task])
+    with tmpdir.as_cwd():
+        workflow.write_wf(".")
+        workflow.write_yaml(".")
+        with open("clamr.cwl", "r") as f1, open(expected_wf, "r") as f2:
+            actual = f1.read()
+            expected = f2.read()
+            assert actual == expected
+        with open("clamr.yml", "r") as f1, open(expected_yaml, "r") as f2:
             actual = f1.read()
             expected = f2.read()
             assert actual == expected

--- a/examples/clamr-checkpoint-cwl/Dockerfile.clamr-ffmpeg
+++ b/examples/clamr-checkpoint-cwl/Dockerfile.clamr-ffmpeg
@@ -1,0 +1,12 @@
+# Dockerfile.clamr-ffmpeg
+# Developed on Chicoma @lanl
+# Patricia Grubel <pagrubel@lanl.gov>
+
+FROM debian:11
+
+
+RUN apt-get update && \
+    apt-get install -y wget gnupg git cmake ffmpeg g++ make openmpi-bin libopenmpi-dev libpng-dev libpng16-16 libpng-tools imagemagick libmagickwand-6.q16-6 libmagickwand-6.q16-dev
+
+RUN git clone https://github.com/lanl/CLAMR.git
+RUN cd CLAMR && cmake . && make clamr_cpuonly

--- a/examples/clamr-checkpoint-cwl/clamr_checkpoint.py
+++ b/examples/clamr-checkpoint-cwl/clamr_checkpoint.py
@@ -1,4 +1,4 @@
-"""COMD driver for CWL generator."""
+"""Clamr driver for CWL generator."""
 
 import pathlib
 from beeflow.common.cwl.workflow import (
@@ -57,9 +57,44 @@ def main():
             ),
         ],
     )
-    workflow = Workflow("clamr", [clamr_task])
-    workflow.write_wf("clamr")
-    workflow.write_yaml("clamr")
+    ffmpeg_task = Task(
+        name="ffmpeg",
+        base_command="ffmpeg -y",
+        stdout="ffmpeg.txt",
+        stderr="ffmpeg.err",
+        inputs=[
+            Input("input_format", "string", "image2", prefix="-f", position=1),
+            Input(
+                "ffmpeg_input",
+                "Directory",
+                value="clamr/outdir",
+                prefix="-i",
+                position=2,
+                value_from='$("/graph%05d.png")',
+            ),
+            Input("frame_rate", "int", 12, prefix="-r", position=3),
+            Input("frame_size", "string", "800x800", prefix="-s", position=4),
+            Input("pixel_format", "string", "yuv420p", prefix="-pix_fmt", position=5),
+            Input("output_filename", "string", "CLAMR_movie.mp4", position=6),
+        ],
+        outputs=[
+            Output(
+                "clamr_movie",
+                "File",
+                source="ffmpeg/movie",
+                glob="$(inputs.output_file)",
+            ),
+            Output("ffmpeg_stderr", "stderr", source="ffmpeg/ffmpeg_stderr"),
+        ],
+        hints=[
+            Charliecloud(
+                docker_file="Dockerfile.clamr-ffmpeg", container_name="clamr-ffmpeg"
+            )
+        ],
+    )
+    workflow = Workflow("clamr", [clamr_task, ffmpeg_task])
+    workflow.write_wf(".")
+    workflow.write_yaml(".")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds support for `CheckpointRequirement` to the CWL generation. Aspects of this were already written.

I added a test and an example using a simple `clamr` workflow based on `ci/clamr-wf-checkpoint`; but I removed the `ffmpeg` step for simplicity.

If you want to test the workflow that is generated:

```shell
cd beeflow/common/cwl/examples
mkdir clamr
python3 clamr_checkpoint.py
cp ../../../../ci/test_workflows/clamr-wf-checkpoint/Dockerfile.clamr-ffmpeg .
beeflow submit test clamr clamr/clamr.cwl clamr/clamr.yml .
```

Side note: this workflow uses SlurmRequirement to set a time limit of 10 seconds, but this may be smaller than what is allowed. For example, it can get rounded to the nearest minute depending on the slurm configuration where its run.