### PR TITLE
Fix blank restart_parameters shows None

### DIFF
--- a/beeflow/common/parser/parser.py
+++ b/beeflow/common/parser/parser.py
@@ -339,7 +339,7 @@ class CwlParser:
             for req in requirements:
                 items = {}
                 for k, v in req.items():
-                    if k != 'class':
+                    if k != 'class' and v is not None:
                         if isinstance(v, (int, float)):
                             items[k] = v
                         else:

--- a/beeflow/tests/test_parser.py
+++ b/beeflow/tests/test_parser.py
@@ -6,6 +6,8 @@ import unittest
 from beeflow.common.parser import CwlParser, CwlParseError
 from beeflow.common.wf_data import (generate_workflow_id, Workflow, Task, Hint,
                                     StepInput, StepOutput, InputParameter, OutputParameter)
+import pytest
+from collections import OrderedDict
 
 
 REPO_PATH = Path(*Path(__file__).parts[:-3])
@@ -373,6 +375,53 @@ TASKS_NOJOB_GOLD = [
         stderr=None,
         workflow_id=WORKFLOW_NOJOB_GOLD.id)
 ]
+
+
+@pytest.mark.parametrize(
+    "requirements, exp_reqs",
+    [
+        (
+            [
+                OrderedDict(
+                    [("timeLimit", "00:00:10"), ("class", "beeflow:SlurmRequirement")]
+                )
+            ],
+            [Hint(class_="beeflow:SlurmRequirement", params={"timeLimit": "00:00:10"})],
+        ),
+        (
+            [
+                OrderedDict(
+                    [
+                        ("enabled", True),
+                        ("file_path", "checkpoint_output"),
+                        ("container_path", "checkpoint_output"),
+                        ("file_regex", "backup[0-9]*.crx"),
+                        ("restart_parameters", None),
+                        ("num_tries", 3),
+                        ("class", "beeflow:CheckpointRequirement"),
+                    ]
+                )
+            ],
+            [
+                Hint(
+                    class_="beeflow:CheckpointRequirement",
+                    params={
+                        "enabled": True,
+                        "file_path": "checkpoint_output",
+                        "container_path": "checkpoint_output",
+                        "file_regex": "backup[0-9]*.crx",
+                        "num_tries": 3,
+                    },
+                )
+            ],
+        ),
+    ],
+)
+def test_parse_requirements_hints(requirements, exp_reqs):
+    """Regression test parse_requirements when as_hints=True."""
+    parser = CwlParser()
+    reqs = parser.parse_requirements(requirements, as_hints=True)
+    assert reqs == exp_reqs
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #1066 

This adds a None check on parsing of hint parameters which prevents the 'None' from showing up downstream when `restart_parameters` is blank. 

I added a simple regression test which should fail prior to this patch.

Additionally, I checked the `*.sh` files created when running `ci/test_workflows/clamr-wf-checkpoint` after setting `restart_parameters` to nothing. Prior to the patch 'None' showed up in the command, but after the patch it does not. The workflow errors because the command is incorrect without the `-R`, but that is expected.