### PR TITLE
Fix restarts script file names surrounded by quotes

### DIFF
--- a/beeflow/common/wf_interface.py
+++ b/beeflow/common/wf_interface.py
@@ -121,12 +121,12 @@ class WorkflowInterface:
         # Pattern match on task name
         # Append (1) if not in name already
         # Increment number on each restart
-        match = re.match(r".+\(([0-9]+)\)$", new_task.name)
+        match = re.search(r"-(\d+)$", new_task.name)
         if not match:
-            new_task.name += "(1)"
+            new_task.name += "-1"
         else:
             i = int(match.group(1))
-            new_task.name = re.sub(r"\([0-9]+\)", f"({i + 1})", new_task.name)
+            new_task.name = re.sub(r"-(\d+)$", f"-{i + 1}", new_task.name)
         metadata = self.get_task_metadata(task)
         self._gdb_driver.restart_task(task, new_task)
         self.set_task_metadata(new_task, metadata)

--- a/beeflow/tests/test_wf_interface.py
+++ b/beeflow/tests/test_wf_interface.py
@@ -239,7 +239,7 @@ class TestWorkflowInterface(unittest.TestCase):
 
         # Assert inequality of Task objects
         self.assertNotEqual(task.id, new_task.id)
-        self.assertEqual("test_task(1)", new_task.name)
+        self.assertEqual("test_task-1", new_task.name)
 
         # Assert equality of graph database objects
         self.assertEqual(new_task, self.wfi.get_task_by_id(new_task.id))
@@ -258,7 +258,7 @@ class TestWorkflowInterface(unittest.TestCase):
 
         # Assert inequality of Task objects
         self.assertNotEqual(new_task.id, newer_task.id)
-        self.assertEqual("test_task(2)", newer_task.name)
+        self.assertEqual("test_task-2", newer_task.name)
 
         # Assert equality of graph database objects
         self.assertEqual(newer_task, self.wfi.get_task_by_id(newer_task.id))


### PR DESCRIPTION
Closes #1067 

This PR implements the suggestion in #1067 to change restart name convention to `file_name-1.sh`, `file_name-2.sh`, etc from the original `file_name(1).sh` which resulted in files having quotes (`'file_name(1).sh'`) when examining via `ls` or similar.

This change was already covered by a test, so I just updated it to match the new convention.