### PR TITLE
Support additional parameters when restarting

### DIFF
--- a/beeflow/common/cwl/cwl.py
+++ b/beeflow/common/cwl/cwl.py
@@ -1,6 +1,7 @@
 """Create and manage CWL files."""
 from dataclasses import dataclass
 from io import StringIO
+from typing import Optional
 import ruamel.yaml
 
 # Create the global object for ruamel.ymal
@@ -399,6 +400,7 @@ class CheckpointRequirement:
     restart_parameters: str
     num_tries: int
     enabled: bool = True
+    add_parameters: Optional[str] = None
 
     def dump(self):
         """Dump beeflow requirement to a dictionary."""
@@ -409,6 +411,7 @@ class CheckpointRequirement:
         checkpoint_dump[req_name]['container_path'] = self.container_path
         checkpoint_dump[req_name]['file_regex'] = self.file_regex
         checkpoint_dump[req_name]['restart_parameters'] = self.restart_parameters
+        checkpoint_dump[req_name]['add_parameters'] = self.add_parameters
         checkpoint_dump[req_name]['num_tries'] = self.num_tries
         return checkpoint_dump
 

--- a/beeflow/common/cwl/workflow.py
+++ b/beeflow/common/cwl/workflow.py
@@ -133,6 +133,7 @@ class Checkpoint(CheckpointRequirement):
                                      container_path=self.container_path,
                                      file_regex=self.file_regex,
                                      restart_parameters=self.restart_parameters,
+                                     add_parameters=self.add_parameters,
                                      num_tries=self.num_tries,
                                      enabled=self.enabled)
 

--- a/beeflow/common/wf_data.py
+++ b/beeflow/common/wf_data.py
@@ -330,6 +330,8 @@ class Task:
                         os.getenv('HOME'): os.path.join('/home', os.getenv('USER')),
                     }
                     command.append(convert_path(checkpoint_file, bind_mounts))
+                    if "add_parameters" in hint.params:
+                        command.append(hint.params["add_parameters"])
                 break
 
         return command

--- a/beeflow/tests/cwl_files/clamr.cwl
+++ b/beeflow/tests/cwl_files/clamr.cwl
@@ -85,6 +85,7 @@ steps:
         container_path: checkpoint_output
         file_regex: backup[0-9]*.crx
         restart_parameters: -R
+        add_parameters:
         num_tries: 3
       beeflow:SlurmRequirement:
         timeLimit: 00:00:10

--- a/beeflow/tests/test_cwl.py
+++ b/beeflow/tests/test_cwl.py
@@ -169,9 +169,10 @@ import pytest
                 "restart_parameters": "-R",
                 "num_tries": 2,
             },
-            "beeflow:CheckpointRequirement:\n  enabled: true\n  file_path: checkpoint_output\n  container_path: checkpoint_output\n  file_regex: backup[0-9]*.crx\n  restart_parameters: -R\n  num_tries: 2\n",
+            "beeflow:CheckpointRequirement:\n  enabled: true\n  file_path: checkpoint_output\n  container_path: checkpoint_output\n  file_regex: backup[0-9]*.crx\n  restart_parameters: -R\n  add_parameters:\n  num_tries: 2\n",
             {
                 "beeflow:CheckpointRequirement": {
+                    "add_parameters": None,
                     "enabled": True,
                     "file_path": "checkpoint_output",
                     "container_path": "checkpoint_output",

--- a/docs/sphinx/bee_cwl.rst
+++ b/docs/sphinx/bee_cwl.rst
@@ -146,12 +146,15 @@ An example ``beeflow:CheckpointRequirement`` in BEE is shown below::
             container_path: checkpoint_output
             file_regex: backup[0-9]*.crx
             restart_parameters: -R
+            add_parameters: --additional-options True
             num_tries: 3
 
 For the above example ``file_path`` is the location of the checkpoint_file. The
 ``file_regex`` specifies the regular expression for the possible checkpoint
 filenames, the ``restart parameter`` will be added to the run command followed
-by the path to the latest checkpoint file, and ``num_tries`` specifies the maximum
+by the path to the latest checkpoint file. ``add_parameters`` allows for
+additional parameters that need to be specified; these will be appended to the
+run command after the checkpoint file. ``num_tries`` specifies the maximum
 number of times the task will be restarted.
 
 beeflow:SlurmRequirement


### PR DESCRIPTION
Closes #1068

This adds a new option to `beeflow:CheckpointRequirement` called `add_parameters`. Anything specified will be appended to the end of the run command on restart. The CWL API has been updated to implement this.