### PR TITLE
Update the GDB Workflow Status on Archive

### DIFF
--- a/beeflow/tests/test_wf_update.py
+++ b/beeflow/tests/test_wf_update.py
@@ -3,6 +3,7 @@
 import os
 import pytest
 from beeflow.wf_manager.resources import wf_update
+from beeflow.tests.mocks import MockWFI
 
 
 @pytest.mark.parametrize(
@@ -20,6 +21,12 @@ def test_archive_workflow(tmpdir, mocker, test_function, expected_state):
     mocker.patch("os.path.expanduser", return_value=str(tmpdir))
     mocker.patch(
         "beeflow.wf_manager.resources.wf_utils.get_workflow_dir", return_value=workdir
+    )
+    mock_wfi = MockWFI()
+    mock_wfi.set_workflow_state = mocker.MagicMock()
+    mocker.patch(
+        "beeflow.wf_manager.resources.wf_utils.get_workflow_interface", 
+        return_value=mock_wfi
     )
     mocker.patch(
         "beeflow.common.config_driver.BeeConfig.get",
@@ -54,6 +61,7 @@ def test_archive_workflow(tmpdir, mocker, test_function, expected_state):
         mock_update_wf_status.assert_called_once_with("wf_id_test", expected_state)
         mock_remove_wf_dir.assert_called_once_with("wf_id_test")
         mock_log.assert_called_once_with("Removing Workflow Directory")
+        mock_wfi.set_workflow_state.assert_called_once_with(expected_state)
 
 
 @pytest.mark.parametrize("wf_state", ["Archived", "Archived/Failed"])

--- a/beeflow/wf_manager/resources/wf_update.py
+++ b/beeflow/wf_manager/resources/wf_update.py
@@ -45,6 +45,8 @@ def archive_workflow(db, wf_id, final_state=None):
     wf_state = f'Archived/{final_state}' if final_state is not None else 'Archived'
     db.workflows.update_workflow_state(wf_id, wf_state)
     wf_utils.update_wf_status(wf_id, wf_state)
+    wfi = wf_utils.get_workflow_interface(wf_id)
+    wfi.set_workflow_state(wf_state)
 
     archive_dir = bc.get('DEFAULT', 'bee_archive_dir')
     os.makedirs(archive_dir, exist_ok=True)


### PR DESCRIPTION
The status in the graph database remains 'running' even when a workflow is archived, causing unintended behavior when users try to interact with the archived workflow. This pull request makes sure to set that state.

Resolves #740 