### PR TITLE
Add Proper Wait Monitoring for Neo4j Being Up

### DIFF
--- a/beeflow/common/deps/neo4j_manager.py
+++ b/beeflow/common/deps/neo4j_manager.py
@@ -5,6 +5,13 @@ import shutil
 import re
 import subprocess
 import time
+import logging
+
+from neo4j import GraphDatabase
+from neo4j import exceptions as neo4j_exc
+
+from beeflow.common.gdb.neo4j_driver import (DEFAULT_USER, DEFAULT_PASSWORD, DEFAULT_HOSTNAME,
+                                             DEFAULT_BOLT_PORT, MAX_WAIT_SECS, RETRY_DELAY_SECS)
 
 from beeflow.wf_manager.resources import wf_utils
 from beeflow.common.db import wfm_db
@@ -15,6 +22,7 @@ from beeflow.common.deps import container_manager
 from beeflow.common.config_driver import BeeConfig as bc
 from beeflow.common import log as bee_logging
 
+
 BEE_WORKDIR = None
 MOUNT_DIR = None
 DATA_DIR = None
@@ -23,9 +31,9 @@ RUN_DIR = None
 CERTS_DIR = None
 CONFS_DIR = None
 GRAPHMLS_DIR = None
-CONTAINER_PATH = Nonelog = bee_logging.setup('neo4j')
-log = bee_logging.setup('neo4j')
+CONTAINER_PATH = None
 
+log = None  # pylint: disable=C0103
 
 def get_open_port():
     """Return an open ephemeral port."""
@@ -141,7 +149,7 @@ def create_credentials():
         log.error("neo4j-admin set-initial-password failed")
 
 
-def create_database():
+def create_database(bolt_port):
     """Create the neo4j database and return the process."""
     try:
         command = ['neo4j', 'console']
@@ -157,7 +165,8 @@ def create_database():
             "-W", "-b", GRAPHMLS_DIR + ":/var/lib/neo4j/import",
             CONTAINER_PATH, "--", *command
         ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        wait_gdb()
+        wait_gdb(bolt_port=bolt_port, user="neo4j", password=bc.get('graphdb', 'dbpass'),
+                 hostname=bc.get('graphdb', 'hostname'))
         return proc
 
     except FileNotFoundError:
@@ -167,6 +176,12 @@ def create_database():
 
 def start():
     """Start the graph database."""
+
+    global log
+    log = bee_logging.setup("neo4j")
+    log.setLevel(logging.INFO)
+    log.propagate = False
+
     log.info('Starting Neo4j Database')
 
     bolt_port, http_port, https_port = setup_ports()
@@ -179,17 +194,33 @@ def start():
 
     create_credentials()
 
-    return create_database()
+    return create_database(bolt_port=bolt_port)
 
 
-def wait_gdb():
-    """Need to wait for the GDB. Currently, we're using the sleep time paramater.
-
-    We'd like to remove that in the future.
+def wait_gdb(bolt_port=DEFAULT_BOLT_PORT, user=DEFAULT_USER, password=DEFAULT_PASSWORD, **kwargs):
     """
-    gdb_sleep_time = bc.get('graphdb', 'sleep_time')
-    print(f'waiting {gdb_sleep_time}s for GDB to come up')
-    time.sleep(gdb_sleep_time)
+    Block until the Neo4j instance answers a Bolt handshake
+    or raise RuntimeError after MAX_WAIT_SECS.
+    """
+    db_hostname = kwargs.get("db_hostname", DEFAULT_HOSTNAME)
+    uri = f"bolt://{db_hostname}:{bolt_port}"
+    start_time = time.monotonic()
+
+    while True:
+        try:
+            with GraphDatabase.driver(uri, auth=(user, password)) as driver:
+                driver.verify_connectivity()      # asks server for a tiny query
+            # Success → database is ready
+            log.info("Neo4j is up and responding")
+            return
+        except (neo4j_exc.ServiceUnavailable,
+                neo4j_exc.DriverError):
+            elapsed = time.monotonic() - start_time
+            if elapsed >= MAX_WAIT_SECS:
+                log.info("Max wait time elapsed")
+                return
+            log.info(f"Waiting {RETRY_DELAY_SECS} seconds for Neo4j to become ready...")
+            time.sleep(RETRY_DELAY_SECS)
 
 
 def remove_gdb():

--- a/beeflow/common/deps/neo4j_manager.py
+++ b/beeflow/common/deps/neo4j_manager.py
@@ -10,7 +10,8 @@ import logging
 from beeflow.common.gdb import neo4j_driver
 from beeflow.common.gdb.neo4j_driver import (DEFAULT_BOLT_PORT)
 
-from beeflow.wf_manager.resources import wf_utils
+from beeflow.common.db.bdb import connect_db
+
 from beeflow.common.db import wfm_db
 
 from beeflow.common import paths
@@ -49,7 +50,7 @@ def setup_ports():
     http_port = get_open_port()
     https_port = get_open_port()
 
-    db = wf_utils.connect_db(wfm_db, wf_utils.get_db_path())
+    db = connect_db(wfm_db, bc.get('DEFAULT', 'bee_workdir') + "/wfm.db")
 
     db.info.set_port('bolt', bolt_port)
     db.info.set_port('http', http_port)

--- a/beeflow/common/deps/neo4j_manager.py
+++ b/beeflow/common/deps/neo4j_manager.py
@@ -7,12 +7,8 @@ import subprocess
 import time
 import logging
 
-from neo4j import GraphDatabase as Neo4jDatabase
-from neo4j.exceptions import ServiceUnavailable
-
-from beeflow.common.gdb.neo4j_driver import (DEFAULT_USER, DEFAULT_PASSWORD, DEFAULT_HOSTNAME,
-                                             DEFAULT_BOLT_PORT, MAX_WAIT_SECS, RETRY_DELAY_SECS,
-                                             Neo4jNotRunning)
+from beeflow.common.gdb import neo4j_driver
+from beeflow.common.gdb.neo4j_driver import (DEFAULT_BOLT_PORT)
 
 from beeflow.wf_manager.resources import wf_utils
 from beeflow.common.db import wfm_db
@@ -166,8 +162,7 @@ def create_database(bolt_port):
             "-W", "-b", GRAPHMLS_DIR + ":/var/lib/neo4j/import",
             CONTAINER_PATH, "--", *command
         ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        wait_gdb(bolt_port=bolt_port, user="neo4j", password=bc.get('graphdb', 'dbpass'),
-                 hostname=bc.get('graphdb', 'hostname'))
+        wait_gdb(bolt_port=bolt_port)
         return proc
 
     except FileNotFoundError:
@@ -198,28 +193,20 @@ def start():
     return create_database(bolt_port=bolt_port)
 
 
-def wait_gdb(bolt_port=DEFAULT_BOLT_PORT, user=DEFAULT_USER, password=DEFAULT_PASSWORD, **kwargs):
+def wait_gdb(bolt_port=DEFAULT_BOLT_PORT):
     """
-    Block until the Neo4j instance answers a Bolt handshake
-    or raise RuntimeError after MAX_WAIT_SECS.
+    Block until the Neo4j instance answers a Bolt handshake.
     """
-    db_hostname = kwargs.get("db_hostname", DEFAULT_HOSTNAME)
-    uri = f"bolt://{db_hostname}:{bolt_port}"
-    start_time = time.monotonic()
+    connect_neo4j_driver(bolt_port)
 
-    driver = Neo4jDatabase.driver(uri, auth=(user, password))
-    while True:
-        try:
-            driver.verify_connectivity()
-            log.info("Neo4j is up and responding")
-            return
-        except ServiceUnavailable as sue:
-            elapsed = time.monotonic() - start_time
-            if elapsed >= MAX_WAIT_SECS:
-                log.error("Neo4j database is unavailable")
-                raise Neo4jNotRunning("Neo4j database is unavailable") from sue
-            log.info(f"Waiting {RETRY_DELAY_SECS} seconds for Neo4j to become ready...")
-            time.sleep(RETRY_DELAY_SECS)
+
+def connect_neo4j_driver(bolt_port):
+    """Create a neo4j driver to a gdb through bolt port."""
+    driver = neo4j_driver.Neo4jDriver()
+    driver.connect(user="neo4j", bolt_port=bolt_port,
+                   db_hostname=bc.get("graphdb", "hostname"),
+                   password=bc.get("graphdb", "dbpass"))
+    driver.create_bee_node()
 
 
 def remove_gdb():

--- a/beeflow/common/deps/neo4j_manager.py
+++ b/beeflow/common/deps/neo4j_manager.py
@@ -7,11 +7,12 @@ import subprocess
 import time
 import logging
 
-from neo4j import GraphDatabase
-from neo4j import exceptions as neo4j_exc
+from neo4j import GraphDatabase as Neo4jDatabase
+from neo4j.exceptions import ServiceUnavailable
 
 from beeflow.common.gdb.neo4j_driver import (DEFAULT_USER, DEFAULT_PASSWORD, DEFAULT_HOSTNAME,
-                                             DEFAULT_BOLT_PORT, MAX_WAIT_SECS, RETRY_DELAY_SECS)
+                                             DEFAULT_BOLT_PORT, MAX_WAIT_SECS, RETRY_DELAY_SECS,
+                                             Neo4jNotRunning)
 
 from beeflow.wf_manager.resources import wf_utils
 from beeflow.common.db import wfm_db
@@ -206,19 +207,17 @@ def wait_gdb(bolt_port=DEFAULT_BOLT_PORT, user=DEFAULT_USER, password=DEFAULT_PA
     uri = f"bolt://{db_hostname}:{bolt_port}"
     start_time = time.monotonic()
 
+    driver = Neo4jDatabase.driver(uri, auth=(user, password))
     while True:
         try:
-            with GraphDatabase.driver(uri, auth=(user, password)) as driver:
-                driver.verify_connectivity()      # asks server for a tiny query
-            # Success → database is ready
+            driver.verify_connectivity()
             log.info("Neo4j is up and responding")
             return
-        except (neo4j_exc.ServiceUnavailable,
-                neo4j_exc.DriverError):
+        except ServiceUnavailable as sue:
             elapsed = time.monotonic() - start_time
             if elapsed >= MAX_WAIT_SECS:
-                log.info("Max wait time elapsed")
-                return
+                log.error("Neo4j database is unavailable")
+                raise Neo4jNotRunning("Neo4j database is unavailable") from sue
             log.info(f"Waiting {RETRY_DELAY_SECS} seconds for Neo4j to become ready...")
             time.sleep(RETRY_DELAY_SECS)
 

--- a/beeflow/common/gdb/neo4j_driver.py
+++ b/beeflow/common/gdb/neo4j_driver.py
@@ -10,6 +10,7 @@ either standardized or read from a config file.
 # Disable E1129: External module is missing proper resource context manager methods.
 # pylint:disable=E1129
 
+import time
 from neo4j import GraphDatabase as Neo4jDatabase
 from neo4j.exceptions import ServiceUnavailable
 
@@ -27,6 +28,8 @@ DEFAULT_HOSTNAME = "localhost"
 DEFAULT_BOLT_PORT = "7687"
 DEFAULT_USER = "neo4j"
 DEFAULT_PASSWORD = "password"
+MAX_WAIT_SECS = 60
+RETRY_DELAY_SECS = 5
 
 
 class Neo4jNotRunning(Exception):
@@ -61,14 +64,19 @@ class Neo4jDriver(GraphDatabaseDriver):
         bolt_port = kwargs.get("bolt_port", DEFAULT_BOLT_PORT)
         password = kwargs.get("db_pass", DEFAULT_PASSWORD)
         uri = f"bolt://{db_hostname}:{bolt_port}"
-        try:
-            # Connect to the Neo4j database using the Neo4j proprietary driver
-            self._driver = Neo4jDatabase.driver(uri, auth=(user, password)) # pylint: disable=W0201
-            # Checks the connection and returns ServiceUnavailable if something is wrong
-            self._driver.verify_connectivity()
-        except ServiceUnavailable as sue:
-            log.error("Neo4j database is unavailable")
-            raise Neo4jNotRunning("Neo4j database is unavailable") from sue
+        start_time = time.monotonic()
+        self._driver = Neo4jDatabase.driver(uri, auth=(user, password)) # pylint: disable=W0201
+        while True:
+            try:
+                self._driver.verify_connectivity()
+                return
+            except ServiceUnavailable as sue:
+                elapsed = time.monotonic() - start_time
+                if elapsed >= MAX_WAIT_SECS:
+                    log.error("Neo4j database is unavailable")
+                    raise Neo4jNotRunning("Neo4j database is unavailable") from sue
+            log.info(f"Waiting {RETRY_DELAY_SECS} seconds for Neo4j to become ready...")
+            time.sleep(RETRY_DELAY_SECS)
 
     def create_bee_node(self):
         """Create the "BEE" node for all workflows to connect to."""

--- a/beeflow/wf_manager/resources/wf_utils.py
+++ b/beeflow/wf_manager/resources/wf_utils.py
@@ -17,6 +17,7 @@ from beeflow.common.connection import Connection
 from beeflow.common import paths
 from beeflow.common.db import wfm_db
 from beeflow.common.db.bdb import connect_db
+from beeflow.common.deps.neo4j_manager import connect_neo4j_driver
 
 
 log = bee_logging.setup(__name__)
@@ -259,15 +260,6 @@ def schedule_submit_tasks(wf_id, tasks):
     allocation = submit_tasks_scheduler(tasks)
     # Submit tasks to TM
     submit_tasks_tm(wf_id, tasks, allocation)
-
-
-def connect_neo4j_driver(bolt_port):
-    """Create a neo4j driver to a gdb through bolt port."""
-    driver = neo4j_driver.Neo4jDriver()
-    driver.connect(user="neo4j", bolt_port=bolt_port,
-                   db_hostname=bc.get("graphdb", "hostname"),
-                   password=bc.get("graphdb", "dbpass"))
-    driver.create_bee_node()
 
 
 def setup_workflow(wf_id, wf_name, wf_dir, wf_workdir, no_start, workflow=None, # pylint: disable=W0613


### PR DESCRIPTION
If someone submits a workflow while bee is still initializing, it will keep trying to verify connection for 60 seconds before erroring, rather than just erroring immediately. This fixes most startup issues people currently face, and it should only trigger on the first workflow for most people.

Resolves #1096 