### PR TITLE
Fix bug in parser.py with workdirs

### DIFF
--- a/beeflow/common/parser/parser.py
+++ b/beeflow/common/parser/parser.py
@@ -281,7 +281,7 @@ class CwlParser:
                 raise CwlParseError(f"specified step output {out} not produced by CommandLineTool")
 
             output_type = out_map[out].type
-            glob = None
+            glob = ""
             if output_type == "stdout":
                 if not stdout:
                     raise CwlParseError(f"stdout capture required for step output {out} "


### PR DESCRIPTION
Closes #1115 

If a workdir is specified for a `Task` then `parse_step_outputs` in `parser.py` will try and join the workdir with the value of `glob`. This PR makes the default value of `glob` an empty string so this action succeeds.