### PR TITLE
Dump CWL and YAML as strings

### DIFF
--- a/beeflow/common/cwl/cwl.py
+++ b/beeflow/common/cwl/cwl.py
@@ -157,7 +157,6 @@ class Inputs:
 
 class RunInputs(Inputs):
     """Represents run inputs."""
-    pass
 
 class CWLInputs(Inputs):
     """CWLInputs is used to generate the YAML file."""

--- a/beeflow/common/cwl/cwl.py
+++ b/beeflow/common/cwl/cwl.py
@@ -157,6 +157,7 @@ class Inputs:
 
 class RunInputs(Inputs):
     """Represents run inputs."""
+    pass
 
 class CWLInputs(Inputs):
     """CWLInputs is used to generate the YAML file."""
@@ -621,9 +622,8 @@ class CWL:
         self.steps = steps
 
     def dump_wf(self, path=None):
-        """Dump the workflow. If no path is specified print to stdout."""
+        """Dump the workflow. If no path is specified return cwl file as a string."""
         cwl_dump = ruamel.yaml.comments.CommentedMap()
-        # cwl_dump = {}
         cwl_dump.update(self.header.dump())
         cwl_dump.update(self.header.dump())
         cwl_dump.update(self.inputs.dump())
@@ -638,12 +638,10 @@ class CWL:
         if path:
             with open(f"{path}/{self.cwl_name}.cwl", "w", encoding="utf-8") as wf_file:
                 print(wf_contents, file=wf_file)
-        else:
-            print(wf_contents)
         return wf_contents
 
     def dump_inputs(self, path=None):
-        """Dump YAML inputs."""
+        """Dump YAML inputs. If no path is specified return yaml file as a string."""
         stream = StringIO()
         yaml.dump(self.inputs.generate_yaml_inputs(), stream)
         yaml_contents = stream.getvalue()

--- a/beeflow/common/cwl/examples/cat_grep_tar.py
+++ b/beeflow/common/cwl/examples/cat_grep_tar.py
@@ -40,8 +40,8 @@ def main():
                         source="tar/tarball")])
 
     workflow = Workflow("cat-grep-tar", [cat, grep0, grep1, tar])
-    workflow.write_wf("cat-grep-tar")
-    workflow.write_yaml("cat-grep-tar")
+    workflow.dump_wf("cat-grep-tar")
+    workflow.dump_yaml("cat-grep-tar")
 
 
 if __name__ == "__main__":

--- a/beeflow/common/cwl/examples/comd.py
+++ b/beeflow/common/cwl/examples/comd.py
@@ -30,19 +30,15 @@ def main():
                         # The slurm requirement
                         MPI(nodes=4, ntasks=8),
                         # Example of slurm options
-                        # Slurm(account="standard", time_limit=60, partition="standard",
-                        #      qos="debug", reservation="standard"),
+                        Slurm(account="standard", time_limit=60, partition="standard",
+                              qos="debug", reservation="standard"),
                         Script(pre_script="comd_pre.sh"),
-                        Slurm(time_limit="500"),
                         Charliecloud(docker_file="Dockerfile.comd-x86_64",
                                      container_name="comd-mpi")
                      ])
     workflow = Workflow("comd", [comd_task])
-    workflow.write_wf("comd")
-    workflow.write_yaml("comd")
-    # workflow = Workflow("comd", [comd_task])
-    # workflow.write(".")
-
+    workflow.dump_wf("comd")
+    workflow.dump_yaml("comd")
 
 if __name__ == "__main__":
     main()

--- a/beeflow/common/cwl/workflow.py
+++ b/beeflow/common/cwl/workflow.py
@@ -165,7 +165,23 @@ class Workflow:
     def __init__(self, name, tasks):
         self.name = name
         self.tasks = tasks
-        self.generate_cwl()
+
+        # Generate a CWL object from a Workflow object.
+        cwl_inputs = []
+        for task in self.tasks:
+            cwl_inputs.extend([input_.cwl_input()
+                               for input_ in task.inputs if input_.cwl_input() is not None])
+        cwl_inputs = CWLInputs(cwl_inputs)
+
+        cwl_outputs = []
+        for task in self.tasks:
+            cwl_outputs.extend([output_.cwl_output()
+                                for output_ in task.outputs if output_.cwl_output() is not None])
+        cwl_outputs = Outputs(cwl_outputs)
+
+        cwl_steps = Steps([self.generate_step(task) for task in self.tasks])
+        self.cwl = CWL(self.name, cwl_inputs, cwl_outputs, cwl_steps)
+
 
     def generate_step(self, task):
         """Generates a Step object based off a Task object."""
@@ -186,34 +202,14 @@ class Workflow:
             step = Step(step_name, step_run)
         return step
 
-    def generate_cwl(self):
-        """Generate a CWL object from a Workflow object."""
-        cwl_inputs = []
-        for task in self.tasks:
-            cwl_inputs.extend([input_.cwl_input()
-                               for input_ in task.inputs if input_.cwl_input() is not None])
-        cwl_inputs = CWLInputs(cwl_inputs)
-
-        cwl_outputs = []
-        for task in self.tasks:
-            cwl_outputs.extend([output_.cwl_output()
-                                for output_ in task.outputs if output_.cwl_output() is not None])
-        cwl_outputs = Outputs(cwl_outputs)
-
-        cwl_steps = Steps([self.generate_step(task) for task in self.tasks])
-        self.cwl = CWL(self.name, cwl_inputs, cwl_outputs, cwl_steps)
-
-    def write_wf(self, path=None):
+    def dump_wf(self, path=None):
         """Write the workflow."""
-        if path:
-            self.cwl.dump_wf(path)
-        else:
+        if not path:
             return self.cwl.dump_wf()
+        return self.cwl.dump_wf(path)
 
-    def write_yaml(self, path=None):
+    def dump_yaml(self, path=None):
         """Write the yaml file."""
-        self.cwl.dump_inputs(path)
-        if path:
-            self.cwl.dump_wf(path)
-        else:
+        if not path:
             return self.cwl.dump_inputs()
+        return self.cwl.dump_inputs(path)

--- a/beeflow/common/cwl/workflow.py
+++ b/beeflow/common/cwl/workflow.py
@@ -203,10 +203,17 @@ class Workflow:
         cwl_steps = Steps([self.generate_step(task) for task in self.tasks])
         self.cwl = CWL(self.name, cwl_inputs, cwl_outputs, cwl_steps)
 
-    def write_wf(self, path):
+    def write_wf(self, path=None):
         """Write the workflow."""
-        self.cwl.dump_wf(path)
+        if path:
+            self.cwl.dump_wf(path)
+        else:
+            return self.cwl.dump_wf()
 
-    def write_yaml(self, path):
+    def write_yaml(self, path=None):
         """Write the yaml file."""
         self.cwl.dump_inputs(path)
+        if path:
+            self.cwl.dump_wf(path)
+        else:
+            return self.cwl.dump_inputs()

--- a/beeflow/tests/test_cwl_workflow.py
+++ b/beeflow/tests/test_cwl_workflow.py
@@ -75,8 +75,8 @@ def test_workflow_cat_grep_tar(tmpdir):
 
     workflow = Workflow("cat-grep-tar", [cat, grep0, grep1, tar])
     with tmpdir.as_cwd():
-        workflow.write_wf(".")
-        workflow.write_yaml(".")
+        workflow.dump_wf(".")
+        workflow.dump_yaml(".")
         with open("cat-grep-tar.cwl", "r") as f1, open(expected_wf, "r") as f2:
             actual = f1.read()
             expected = f2.read()
@@ -128,8 +128,8 @@ def test_workflow_comd(tmpdir):
     )
     workflow = Workflow("comd", [comd_task])
     with tmpdir.as_cwd():
-        workflow.write_wf(".")
-        workflow.write_yaml(".")
+        workflow.dump_wf(".")
+        workflow.dump_yaml(".")
         with open("comd.cwl", "r") as f1, open(expected_wf, "r") as f2:
             actual = f1.read()
             expected = f2.read()
@@ -188,8 +188,8 @@ def test_workflow_checkpoint(tmpdir):
     )
     workflow = Workflow("clamr", [clamr_task])
     with tmpdir.as_cwd():
-        workflow.write_wf(".")
-        workflow.write_yaml(".")
+        workflow.dump_wf(".")
+        workflow.dump_yaml(".")
         with open("clamr.cwl", "r") as f1, open(expected_wf, "r") as f2:
             actual = f1.read()
             expected = f2.read()
@@ -233,8 +233,8 @@ def test_workflow_task_req(tmpdir):
 
     workflow = Workflow("task-req", [cat, grep])
     with tmpdir.as_cwd():
-        workflow.write_wf(".")
-        workflow.write_yaml(".")
+        workflow.dump_wf(".")
+        workflow.dump_yaml(".")
         with open("task-req.cwl", "r") as f1, open(expected_wf, "r") as f2:
             actual = f1.read()
             expected = f2.read()


### PR DESCRIPTION
This PR modifies the CWL API so that it will properly return the CWL and YAML files as strings when write_yaml or write_cwl is called. 