### PR TITLE
Start 0.1.11dev4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,9 +33,23 @@ Containers provide many benefits:
 BEE Sites
 =========
 
-* Documentation: `https://lanl.github.io/BEE/ <https://lanl.github.io/BEE/>`_
-
 * Github: `https://github.com/lanl/BEE <https://github.com/lanl/BEE>`_
+
+* Documentation:
+
+.. list-table:: 
+   :header-rows: 1
+   :widths: 20 25 55
+
+   * - Purpose
+     - Git Tag
+     - GitHub Pages URL
+   * - Stable release
+     - ``0.1.10``
+     - `https://lanl.github.io/BEE/ <https://lanl.github.io/BEE/>`__
+   * - Pre Release
+     - ``0.1.11dev3``
+     - `https://lanl.github.io/BEE/0.1.11dev3/ <https://lanl.github.io/BEE/0.1.11dev3/>`__
 
 
 Contact

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ BEE Sites
    * - Stable release
      - ``0.1.10``
      - `https://lanl.github.io/BEE/ <https://lanl.github.io/BEE/>`__
-   * - Pre Release
+   * - Pre-release
      - ``0.1.11dev3``
      - `https://lanl.github.io/BEE/0.1.11dev3/ <https://lanl.github.io/BEE/0.1.11dev3/>`__
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -3,7 +3,9 @@ Publishing a new release
 
 Verify all current changes in develop run correctly on nightly tests.
 Note: If you are publishing a pre-release from develop just checkout develop and pull,
-verify it is up to date and do steps 7 & 8 but stay on the develop branch.
+verify it is up to date and do steps 7 & 8 but stay on the develop branch. For both
+pre-releases (that will be published on PYPI) and release versions verify the information in
+README.rst has the correct tags and URL's.
 
 1. Start a branch named Release-0.x.x  Change the version in pyproject.toml and verify docs build, add to HISTORY.md for this release,
    and get this change merged into develop. (You may want to set the bypass as in step 2 on develop).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hpc-beeflow"
-version = "0.1.11dev3"
+version = "0.1.11dev4"
 description = "A software package for containerizing HPC applications and managing job workflows"
 
 


### PR DESCRIPTION
Start new version to differentiate work on develp from  0.1.11dev3, published on pypi.
Also, adds link to documentation of 0.1.11dev3 to the github site