### PR TITLE
Issue#1069 document warning overwrite checkpointed outputs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,7 @@ Contributors:
 * Ragini Gupta - `raginigupta6 <https://github.com/raginigupta6>`_
 * Aaron R Hall - `arhall0 <https://github.com/arhall0>`_
 * Leah Howell - `Leahh02 <https://github.com/Leahh02>`_
+* Lilikoi Latimer - `lilikoi-l <https://github.com/lilikoi-l>
 * Andres Quan - `aquan9 <https://github.com/aquan9>`_
 * Quincy Wofford - `qwofford <https://github.com/qwofford>`_
 * Tim Randles - `trandles-lanl <https://github.com/trandles-lanl>`_

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Contributors:
 * Ragini Gupta - `raginigupta6 <https://github.com/raginigupta6>`_
 * Aaron R Hall - `arhall0 <https://github.com/arhall0>`_
 * Leah Howell - `Leahh02 <https://github.com/Leahh02>`_
-* Lilikoi Latimer - `lilikoi-l <https://github.com/lilikoi-l>
+* Lilikoi Latimer - `lilikoi-l <https://github.com/lilikoi-l>`_
 * Andres Quan - `aquan9 <https://github.com/aquan9>`_
 * Quincy Wofford - `qwofford <https://github.com/qwofford>`_
 * Tim Randles - `trandles-lanl <https://github.com/trandles-lanl>`_

--- a/docs/sphinx/_static/custom.css
+++ b/docs/sphinx/_static/custom.css
@@ -1,0 +1,3 @@
+.red-block {
+    color: red;
+}

--- a/docs/sphinx/bee_cwl.rst
+++ b/docs/sphinx/bee_cwl.rst
@@ -158,10 +158,10 @@ number of times the task will be restarted.
 
 .. container:: red-block
 
-   Warning: beeflow is not responsible for saving outputs from each subtask that
-   may be overwritten. We suggest you include a pre-script to preserve any desired 
-   intermediate outputs. To do this use `beflow:ScriptRequirement` and a script
-   similar to those below:
+   Warning: beeflow is not responsible for preserving outputs from each restart
+   subtask. We suggest you include a pre-script to preserve any desired intermediate 
+   outputs. To do this use `beflow:ScriptRequirement` and a script similar to 
+   the examples below (shown for both tcsh and bash):
 
 Example pre-script to preserve outputs during Checkpoint/Restarts (tcsh)
       -- Contributed by Lilikoi Latimer

--- a/docs/sphinx/bee_cwl.rst
+++ b/docs/sphinx/bee_cwl.rst
@@ -160,7 +160,80 @@ number of times the task will be restarted.
 
    Warning: beeflow is not responsible for saving outputs from each subtask that
    may be overwritten. We suggest you include a pre-script to preserve any desired 
-   intermediate outputs. To do this use `beflow:SriptRequirement`.
+   intermediate outputs. To do this use `beflow:ScriptRequirement` and a script
+   similar to those below:
+
+Example pre-script to preserve outputs during Checkpoint/Restarts (tcsh)
+      -- Contributed by Lilikoi Latimer
+
+.. code-block::
+
+     # Cleanup output files from previous job
+     # Make outputs folder if it doesn't already exist
+     if (! -d outputs ) then
+        mkdir outputs
+     endif
+     # Set list of file extensions to move
+     set output_ext=(.example .extensions .here)
+
+     # Prevents errors with setting array to patterns if no
+     # files matching the pattern are found
+     set nonomatch
+
+     # Move output files
+     foreach ext ($output_ext)
+         set pattern="*$ext"
+         set timestamp=`date "+%Y%m%d%H%M%S"`
+
+         # Make list of files with extension, continuing if none exist
+         set files=($pattern)
+         if (! -e $files[1] ) then
+             continue
+         endif
+
+         # Loop through files, moving to outputs
+         foreach file ($files)
+             cp $file "outputs/$file.$timestamp"
+         end
+     end
+
+     unset nonomatch
+
+Example pre-script to preserve outputs during Checkpoint/Restarts (bash)
+      -- Contributed by Lilikoi Latimer
+
+.. code-block::
+
+     set -euo pipefail
+
+     # Cleanup output files from previous job
+
+     # Make outputs folder if it doesn't already exist
+     mkdir -p outputs
+
+     # Set list of file extensions to move
+     output_ext=(.example .extensions .here)
+
+     # Prevents treating unmatched globs as literals
+     shopt -s nullglob
+
+     # Move output files
+     for ext in "${output_ext[@]}"; do
+         pattern="*${ext}"
+         timestamp=$(date "+%Y%m%d%H%M%S")
+
+         # Make list of files with extension, continue if none exist
+         files=($pattern)
+         ((${#files[@]} == 0)) && continue
+
+         # Loop through files, copying to outputs with timestamp
+         for file in "${files[@]}"; do
+             cp -- "$file" "outputs/$file.$timestamp"
+         done
+     done
+
+     # Restore default globbing behavior
+     shopt -u nullglob
 
 
 beeflow:SlurmRequirement
@@ -191,7 +264,8 @@ beeflow:ScriptRequirement
 -------------------------
 
 Some tasks may require small additional commands for setup or teardown such as
-loading modules, setting up checkpointing files, or cleaning up after a run.
+loading modules, setting up checkpointing files, perserving outputs of subtasks
+that have been restarted, or cleaning up after a run.
 The script requirement enables this by adding shell scripts that will run before
 and after a task. The script must be within the workflow directory. The desired
 shell interpreter must be specified in both the ``beeflow:ScriptRequirement`` section

--- a/docs/sphinx/bee_cwl.rst
+++ b/docs/sphinx/bee_cwl.rst
@@ -134,10 +134,9 @@ beeflow:CheckpointRequirement
 BEE is designed to manage workflows that include long running scientific
 simulations, requiring checkpointing and restarting. We implemented the
 ``beeflow:CheckpointRequirement`` for this purpose. If a step in a workflow
-includes this requirement and the task stops, such as for a timelimit on the job, 
+includes this requirement and the task stops, such as for a timelimit on the job,
 a subtask will run to continue the simulation using the specified checkpoint
 file.
-
 An example ``beeflow:CheckpointRequirement`` in BEE is shown below::
 
        beeflow:CheckpointRequirement:
@@ -156,6 +155,13 @@ by the path to the latest checkpoint file. ``add_parameters`` allows for
 additional parameters that need to be specified; these will be appended to the
 run command after the checkpoint file. ``num_tries`` specifies the maximum
 number of times the task will be restarted.
+
+.. container:: red-block
+
+   Warning: beeflow is not responsible for saving outputs from each subtask that
+   may be overwritten. We suggest you include a pre-script to preserve any desired 
+   intermediate outputs. To do this use `beflow:SriptRequirement`.
+
 
 beeflow:SlurmRequirement
 ----------------------------

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -58,5 +58,6 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static']
+html_css_files = ['custom.css']
 


### PR DESCRIPTION
Closes issue #1069 
Add's a warning when using Checkpoint/Restart to add a script with examples for preserving files if needed