### PR TITLE
Fix networkx issue when numpy is also installed

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Lint
         run: |
-          pip install pylint=3.2.7 2>&1 >/dev/null
+          pip install pylint==3.2.7 2>&1 >/dev/null
           pylint --rcfile=setup.cfg beeflow/

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Lint
         run: |
-          pip install pylint>=3.2.7 2>&1 >/dev/null
+          pip install pylint=3.2.7 2>&1 >/dev/null
           pylint --rcfile=setup.cfg beeflow/

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Lint
         run: |
-          pip install pylint==3.2.7 2>&1 >/dev/null
+          pip install pylint==3.3.6 2>&1 >/dev/null
           pylint --rcfile=setup.cfg beeflow/

--- a/.github/workflows/testing-coverage.yml
+++ b/.github/workflows/testing-coverage.yml
@@ -56,12 +56,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
       - name: Install and Configure
         run: |
           . ./ci/env.sh

--- a/.github/workflows/testing-coverage.yml
+++ b/.github/workflows/testing-coverage.yml
@@ -26,6 +26,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Install and Configure
         run: |
           . ./ci/env.sh
@@ -33,11 +38,13 @@ jobs:
           ./ci/batch_scheduler.sh
           ./ci/bee_install.sh
           ./ci/bee_config.sh
+
       - name: Integration Test
         run: |
           . ./ci/env.sh
           ./ci/integration_test.sh
           mv .coverage.integration ".coverage.${{ matrix.bee_worker }}"
+
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
@@ -56,6 +63,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Install and Configure
         run: |
           . ./ci/env.sh
@@ -63,11 +76,13 @@ jobs:
           ./ci/batch_scheduler.sh
           ./ci/bee_install.sh
           ./ci/bee_config.sh
+
       - name: Unit tests
         run: |
           . ./ci/env.sh
           ./ci/unit_tests.sh
           mv .coverage ".coverage.unittests"
+
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/testing-coverage.yml
+++ b/.github/workflows/testing-coverage.yml
@@ -26,11 +26,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
       - name: Install and Configure
         run: |
           . ./ci/env.sh
@@ -38,13 +33,11 @@ jobs:
           ./ci/batch_scheduler.sh
           ./ci/bee_install.sh
           ./ci/bee_config.sh
-
       - name: Integration Test
         run: |
           . ./ci/env.sh
           ./ci/integration_test.sh
           mv .coverage.integration ".coverage.${{ matrix.bee_worker }}"
-
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
@@ -76,13 +69,11 @@ jobs:
           ./ci/batch_scheduler.sh
           ./ci/bee_install.sh
           ./ci/bee_config.sh
-
       - name: Unit tests
         run: |
           . ./ci/env.sh
           ./ci/unit_tests.sh
           mv .coverage ".coverage.unittests"
-
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/ci/bee_config_scaling.sh
+++ b/ci/bee_config_scaling.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# BEE Configuration
+
+case $BEE_WORKER in
+Slurm*)
+    export WORKLOAD_SCHEDULER=Slurm
+    ;;
+Flux)
+    export WORKLOAD_SCHEDULER=Flux
+    ;;
+esac
+
+mkdir -p $(dirname $BEE_CONFIG)
+cat >> $BEE_CONFIG <<EOF
+# BEE CONFIGURATION FILE #
+[DEFAULT]
+bee_workdir = $BEE_WORKDIR
+bee_archive_dir = $BEE_WORKDIR/archives
+bee_droppoint = $BEE_WORKDIR/droppoint
+workload_scheduler = $WORKLOAD_SCHEDULER
+neo4j_image = $NEO4J_CONTAINER
+redis_image = $REDIS_CONTAINER
+max_restarts = 2
+delete_completed_workflow_dirs = True
+
+[task_manager]
+jobs_limit =
+container_runtime = Charliecloud
+runner_opts =
+background_interval = 2
+
+[charliecloud]
+image_mntdir = /tmp
+chrun_opts = --home
+setup =
+
+[job]
+default_account =
+default_time_limit =
+default_partition = scaling
+default_qos=
+default_reservation=
+
+[graphdb]
+hostname = localhost
+dbpass = password
+gdb_image_mntdir = /tmp
+sleep_time = 10
+
+[scheduler]
+algorithm = fcfs
+default_algorithm = fcfs
+
+[workflow_manager]
+
+[builder]
+deployed_image_root = /tmp
+container_output_path = /tmp
+container_type = charliecloud
+container_archive = $BEE_WORKDIR/container_archive
+EOF
+
+case $BEE_WORKER in
+Slurmrestd)
+    cat >> $BEE_CONFIG <<EOF
+[slurm]
+use_commands = False
+EOF
+    ;;
+SlurmCommands)
+    cat >> $BEE_CONFIG <<EOF
+[slurm]
+use_commands = True
+EOF
+    ;;
+esac
+
+case $BEE_WORKER in
+Slurmrestd)
+	cat >> $BEE_CONFIG << EOF
+[slurm attributes]
+attributes = $BEE_ATTR
+EOF
+	;;
+SlurmCommands)
+	cat >> $BEE_CONFIG << EOF
+[slurm command attributes]
+attributes = $BEE_ATTR
+EOF
+	;;
+Flux)
+	cat >> $BEE_CONFIG << EOF
+[flux attributes]
+attributes = $BEE_ATTR
+EOF
+	;;
+esac
+
+printf "\n\n"
+printf "#### %s ####\n" $BEE_CONFIG
+cat $BEE_CONFIG
+printf "#### %s ####\n" $BEE_CONFIG
+printf "\n\n"

--- a/ci/deps_install.sh
+++ b/ci/deps_install.sh
@@ -24,3 +24,7 @@ sudo apt-get install -y software-properties-common
 sudo add-apt-repository -y ppa:deadsnakes/ppa
 sudo apt-get update
 sudo apt-get install -y python3.11 python3.11-venv python3.11-dev
+
+# Set this new Python3 to be the default in the container
+sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+sudo update-alternatives --set python3 /usr/bin/python3.11

--- a/ci/deps_install.sh
+++ b/ci/deps_install.sh
@@ -21,4 +21,6 @@ tar -xvf charliecloud-${CHARLIECLOUD_VERSION}.tar.gz
 
 # Install Python3
 sudo apt-get install -y software-properties-common
-sudo apt-get install -y python3 python3-dev python3-venv
+sudo add-apt-repository -y ppa:deadsnakes/ppa
+sudo apt-get update
+sudo apt-get install -y python3.11 python3.11-venv python3.11-dev

--- a/ci/flux_install.sh
+++ b/ci/flux_install.sh
@@ -37,6 +37,7 @@ sudo apt-get install -y \
     jq
 
 # Update the python installation with cffi bindings for flux
+sudo apt-get purge -y python3-cffi || true
 python3 -m pip install "cffi>=1.15" pycparser
 
 # Install flux-security

--- a/ci/flux_install.sh
+++ b/ci/flux_install.sh
@@ -39,14 +39,11 @@ sudo apt-get install -y \
 # Update the python installation with cffi bindings for flux
 python3 -m pip install "cffi>=1.15" pycparser
 
-# Make sure this uses python3.11 and not the system python
-export PYTHON=/usr/bin/python3.11
-
 # Install flux-security
 git clone --depth 1 -b v${FLUX_SECURITY_VERSION} https://github.com/flux-framework/flux-security.git
 (cd flux-security
  ./autogen.sh
- ./configure --prefix=/usr
+ PYTHON=/usr/bin/python3.11 ./configure --prefix=/usr
  make
  sudo make install
  sudo ldconfig)
@@ -55,7 +52,7 @@ git clone --depth 1 -b v${FLUX_SECURITY_VERSION} https://github.com/flux-framewo
 git clone --depth 1 -b v${FLUX_CORE_VERSION} https://github.com/flux-framework/flux-core.git
 (cd flux-core
  ./autogen.sh
- ./configure --prefix=/usr
+ PYTHON=/usr/bin/python3.11 ./configure --prefix=/usr
  make
  sudo make install
  sudo ldconfig)

--- a/ci/flux_install.sh
+++ b/ci/flux_install.sh
@@ -53,7 +53,7 @@ git clone --depth 1 -b v${FLUX_CORE_VERSION} https://github.com/flux-framework/f
 (cd flux-core
  ./autogen.sh
  ./configure --prefix=/usr
- make
+ make V=1 || { echo "Flux build failed, showing verbose log:"; make V=1 -C src/bindings/python/_flux; exit 1; }
  sudo make install
  sudo ldconfig)
 # Install the python API

--- a/ci/flux_install.sh
+++ b/ci/flux_install.sh
@@ -57,5 +57,5 @@ git clone --depth 1 -b v${FLUX_CORE_VERSION} https://github.com/flux-framework/f
  sudo make install
  sudo ldconfig)
 # Install the python API
-pip install --user wheel
-pip install --user flux-python==$FLUX_CORE_VERSION
+python3 -m pip install --user wheel
+python3 -m pip install --user flux-python==$FLUX_CORE_VERSION

--- a/ci/flux_install.sh
+++ b/ci/flux_install.sh
@@ -39,6 +39,9 @@ sudo apt-get install -y \
 # Update the python installation with cffi bindings for flux
 python3 -m pip install "cffi>=1.15" pycparser
 
+# Make sure this uses python3.11 and not the system python
+export PYTHON=/usr/bin/python3.11
+
 # Install flux-security
 git clone --depth 1 -b v${FLUX_SECURITY_VERSION} https://github.com/flux-framework/flux-security.git
 (cd flux-security
@@ -53,7 +56,7 @@ git clone --depth 1 -b v${FLUX_CORE_VERSION} https://github.com/flux-framework/f
 (cd flux-core
  ./autogen.sh
  ./configure --prefix=/usr
- make V=1 || { echo "Flux build failed, showing verbose log:"; make V=1 -C src/bindings/python/_flux; exit 1; }
+ make
  sudo make install
  sudo ldconfig)
 # Install the python API

--- a/ci/flux_install.sh
+++ b/ci/flux_install.sh
@@ -39,13 +39,12 @@ sudo apt-get install -y \
 # Update the python installation with cffi bindings for flux and purge the system cffi
 sudo apt-get purge -y python3-cffi || true
 python3 -m pip install "cffi>=1.15" pycparser
-PYTHON=/usr/bin/python3.11
 
 # Install flux-security
 git clone --depth 1 -b v${FLUX_SECURITY_VERSION} https://github.com/flux-framework/flux-security.git
 (cd flux-security
  ./autogen.sh
- $PYTHON ./configure --prefix=/usr
+ PYTHON=/usr/bin/python3.11 ./configure --prefix=/usr
  make
  sudo make install
  sudo ldconfig)
@@ -54,7 +53,7 @@ git clone --depth 1 -b v${FLUX_SECURITY_VERSION} https://github.com/flux-framewo
 git clone --depth 1 -b v${FLUX_CORE_VERSION} https://github.com/flux-framework/flux-core.git
 (cd flux-core
  ./autogen.sh
- $PYTHON ./configure --prefix=/usr
+ PYTHON=/usr/bin/python3.11 ./configure --prefix=/usr
  make
  sudo make install
  sudo ldconfig)

--- a/ci/flux_install.sh
+++ b/ci/flux_install.sh
@@ -37,7 +37,7 @@ sudo apt-get install -y \
     jq
 
 # Update the python installation with cffi bindings for flux
-pip install "cffi>=1.15" pycparser
+python3 -m pip install "cffi>=1.15" pycparser
 
 # Install flux-security
 git clone --depth 1 -b v${FLUX_SECURITY_VERSION} https://github.com/flux-framework/flux-security.git

--- a/ci/flux_install.sh
+++ b/ci/flux_install.sh
@@ -36,6 +36,9 @@ sudo apt-get install -y \
     libmpich-dev \
     jq
 
+# Update the python installation with cffi bindings for flux
+pip install "cffi>=1.15" pycparser
+
 # Install flux-security
 git clone --depth 1 -b v${FLUX_SECURITY_VERSION} https://github.com/flux-framework/flux-security.git
 (cd flux-security

--- a/ci/flux_install.sh
+++ b/ci/flux_install.sh
@@ -36,15 +36,16 @@ sudo apt-get install -y \
     libmpich-dev \
     jq
 
-# Update the python installation with cffi bindings for flux
+# Update the python installation with cffi bindings for flux and purge the system cffi
 sudo apt-get purge -y python3-cffi || true
 python3 -m pip install "cffi>=1.15" pycparser
+PYTHON=/usr/bin/python3.11
 
 # Install flux-security
 git clone --depth 1 -b v${FLUX_SECURITY_VERSION} https://github.com/flux-framework/flux-security.git
 (cd flux-security
  ./autogen.sh
- PYTHON=/usr/bin/python3.11 ./configure --prefix=/usr
+ $PYTHON ./configure --prefix=/usr
  make
  sudo make install
  sudo ldconfig)
@@ -53,7 +54,7 @@ git clone --depth 1 -b v${FLUX_SECURITY_VERSION} https://github.com/flux-framewo
 git clone --depth 1 -b v${FLUX_CORE_VERSION} https://github.com/flux-framework/flux-core.git
 (cd flux-core
  ./autogen.sh
- PYTHON=/usr/bin/python3.11 ./configure --prefix=/usr
+ $PYTHON ./configure --prefix=/usr
  make
  sudo make install
  sudo ldconfig)

--- a/docs/sphinx/development.rst
+++ b/docs/sphinx/development.rst
@@ -15,7 +15,7 @@ Additional Poetry documentation:
 
 * https://github.com/sdispater/poetry
 
-Requirement: Python version 3.8 or greater
+Requirement: Python version 3.11 to 3.14
 ------------------------------------------
 
 Installation Using a Python Environment 

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -8,7 +8,7 @@ This section describes how to install BEE and requirements for installation.
 Requirements:
 =============
 
-* **Python version 3.8 to 3.14**
+* **Python version 3.11 to 3.14**
 
 * `Charliecloud <https://hpc.github.io/charliecloud/>`_ **version 0.34 (or greater)**
     Charliecloud is installed on Los Alamos National Laboratory (LANL) clusters and can be invoked via ``module load charliecloud`` before running beeflow. If you are on a system that does not have the module, `Charliecloud <https://hpc.github.io/charliecloud/>`_ is easily installed in user space and requires no privileges to install. To insure Charliecloud is available in subsequent runs add ``module load charliecloud`` (or if you installed it ``export PATH=<path_to_ch-run>:$PATH``) to your .bashrc (or other appropriate shell initialization file). BEE runs dependencies from a Charliecloud container and uses it to run the graph database neo4j and other dependencies. The default container runtime for containerized applications in BEE is Charliecloud.

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -8,7 +8,7 @@ This section describes how to install BEE and requirements for installation.
 Requirements:
 =============
 
-* **Python version 3.8 (or greater)**
+* **Python version 3.8 to 3.14**
 
 * `Charliecloud <https://hpc.github.io/charliecloud/>`_ **version 0.34 (or greater)**
     Charliecloud is installed on Los Alamos National Laboratory (LANL) clusters and can be invoked via ``module load charliecloud`` before running beeflow. If you are on a system that does not have the module, `Charliecloud <https://hpc.github.io/charliecloud/>`_ is easily installed in user space and requires no privileges to install. To insure Charliecloud is available in subsequent runs add ``module load charliecloud`` (or if you installed it ``export PATH=<path_to_ch-run>:$PATH``) to your .bashrc (or other appropriate shell initialization file). BEE runs dependencies from a Charliecloud container and uses it to run the graph database neo4j and other dependencies. The default container runtime for containerized applications in BEE is Charliecloud.

--- a/poetry.lock
+++ b/poetry.lock
@@ -113,13 +113,13 @@ test = ["coverage", "mypy", "pexpect", "ruff", "wheel"]
 
 [[package]]
 name = "astroid"
-version = "3.2.4"
+version = "3.3.11"
 description = "An abstract syntax tree for Python with inference support."
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.9.0"
 files = [
-    {file = "astroid-3.2.4-py3-none-any.whl", hash = "sha256:413658a61eeca6202a59231abb473f932038fbcbf1666587f66d482083413a25"},
-    {file = "astroid-3.2.4.tar.gz", hash = "sha256:0e14202810b30da1b735827f78f5157be2bbd4a7a59b7707ca0bfc2fb4c0063a"},
+    {file = "astroid-3.3.11-py3-none-any.whl", hash = "sha256:54c760ae8322ece1abd213057c4b5bba7c49818853fc901ef09719a60dbf9dec"},
+    {file = "astroid-3.3.11.tar.gz", hash = "sha256:1e5a5011af2920c7c67a53f65d536d65bfa7116feeaf2354d8b94f29573bb0ce"},
 ]
 
 [[package]]
@@ -2556,25 +2556,25 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylint"
-version = "3.2.7"
+version = "3.3.6"
 description = "python code static checker"
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.9.0"
 files = [
-    {file = "pylint-3.2.7-py3-none-any.whl", hash = "sha256:02f4aedeac91be69fb3b4bea997ce580a4ac68ce58b89eaefeaf06749df73f4b"},
-    {file = "pylint-3.2.7.tar.gz", hash = "sha256:1b7a721b575eaeaa7d39db076b6e7743c993ea44f57979127c517c6c572c803e"},
+    {file = "pylint-3.3.6-py3-none-any.whl", hash = "sha256:8b7c2d3e86ae3f94fb27703d521dd0b9b6b378775991f504d7c3a6275aa0a6a6"},
+    {file = "pylint-3.3.6.tar.gz", hash = "sha256:b634a041aac33706d56a0d217e6587228c66427e20ec21a019bc4cdee48c040a"},
 ]
 
 [package.dependencies]
-astroid = ">=3.2.4,<=3.3.0-dev0"
+astroid = ">=3.3.8,<=3.4.0.dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
     {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
 ]
-isort = ">=4.2.5,<5.13.0 || >5.13.0,<6"
+isort = ">=4.2.5,<5.13 || >5.13,<7"
 mccabe = ">=0.6,<0.8"
-platformdirs = ">=2.2.0"
+platformdirs = ">=2.2"
 tomlkit = ">=0.10.1"
 
 [package.extras]
@@ -3709,4 +3709,4 @@ cloud-extras = ["google-api-python-client", "python-heatclient", "python-opensta
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<=3.14"
-content-hash = "4087eaeb3a40966fd3e8a267815882e8630f5a0d248948045fe11c40987f0af8"
+content-hash = "15d111bfde20314668fafd4dbae5a3b693dbbdf1cdca695df61140f78b4b7729"

--- a/poetry.lock
+++ b/poetry.lock
@@ -50,9 +50,6 @@ files = [
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.9\""}
-
 [[package]]
 name = "anyio"
 version = "4.5.2"
@@ -65,10 +62,8 @@ files = [
 ]
 
 [package.dependencies]
-exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
-typing-extensions = {version = ">=4.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
@@ -87,7 +82,6 @@ files = [
 ]
 
 [package.dependencies]
-"backports.zoneinfo" = {version = "*", markers = "python_version < \"3.9\""}
 tzlocal = ">=3.0"
 
 [package.extras]
@@ -127,9 +121,6 @@ files = [
     {file = "astroid-3.2.4-py3-none-any.whl", hash = "sha256:413658a61eeca6202a59231abb473f932038fbcbf1666587f66d482083413a25"},
     {file = "astroid-3.2.4.tar.gz", hash = "sha256:0e14202810b30da1b735827f78f5157be2bbd4a7a59b7707ca0bfc2fb4c0063a"},
 ]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "async-timeout"
@@ -183,42 +174,8 @@ files = [
     {file = "babel-2.16.0.tar.gz", hash = "sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316"},
 ]
 
-[package.dependencies]
-pytz = {version = ">=2015.7", markers = "python_version < \"3.9\""}
-
 [package.extras]
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
-
-[[package]]
-name = "backports-zoneinfo"
-version = "0.2.1"
-description = "Backport of the standard library zoneinfo module"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win32.whl", hash = "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win32.whl", hash = "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win32.whl", hash = "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6"},
-    {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
-]
-
-[package.dependencies]
-tzdata = {version = "*", optional = true, markers = "extra == \"tzdata\""}
-
-[package.extras]
-tzdata = ["tzdata"]
 
 [[package]]
 name = "bagit"
@@ -297,7 +254,6 @@ files = [
 ]
 
 [package.dependencies]
-"backports.zoneinfo" = {version = ">=0.2.1", markers = "python_version < \"3.9\""}
 billiard = ">=4.2.0,<5.0"
 click = ">=8.1.2,<9.0"
 click-didyoumean = ">=0.3.0"
@@ -636,7 +592,6 @@ files = [
 [package.dependencies]
 autopage = ">=0.4.0"
 cmd2 = ">=1.0.0"
-importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 PrettyTable = ">=0.7.2"
 PyYAML = ">=3.12"
 stevedore = ">=2.0.1"
@@ -773,9 +728,6 @@ files = [
     {file = "coverage-7.6.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:e9a6e0eb86070e8ccaedfbd9d38fec54864f3125ab95419970575b42af7541df"},
     {file = "coverage-7.6.1.tar.gz", hash = "sha256:953510dfb7b12ab69d20135a0662397f077c59b1e6379a768e97c59d852ee51d"},
 ]
-
-[package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
 
 [package.extras]
 toml = ["tomli"]
@@ -978,24 +930,9 @@ files = [
 [package.dependencies]
 decorator = ">=4.0.0"
 stevedore = ">=3.0.0"
-typing_extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 pifpaf = ["pifpaf (>=2.5.0)", "setuptools"]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.2.2"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
-    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
-]
-
-[package.extras]
-test = ["pytest (>=6)"]
 
 [[package]]
 name = "fastapi"
@@ -1047,7 +984,6 @@ files = [
 [package.dependencies]
 blinker = ">=1.6.2"
 click = ">=8.1.3"
-importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
 itsdangerous = ">=2.1.2"
 Jinja2 = ">=3.1.2"
 Werkzeug = ">=2.3.7"
@@ -1130,8 +1066,8 @@ files = [
 google-auth = ">=2.14.1,<3.0.dev0"
 googleapis-common-protos = ">=1.56.2,<2.0.dev0"
 proto-plus = [
-    {version = ">=1.22.3,<2.0.0dev", markers = "python_version < \"3.13\""},
     {version = ">=1.25.0,<2.0.0dev", markers = "python_version >= \"3.13\""},
+    {version = ">=1.22.3,<2.0.0dev", markers = "python_version < \"3.13\""},
 ]
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<6.0.0.dev0"
 requests = ">=2.18.0,<3.0.0.dev0"
@@ -1462,51 +1398,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.5.0"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b"},
-    {file = "importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"},
-]
-
-[package.dependencies]
-zipp = ">=3.20"
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-perf = ["ipython"]
-test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["pytest-mypy"]
-
-[[package]]
-name = "importlib-resources"
-version = "6.4.5"
-description = "Read resources from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_resources-6.4.5-py3-none-any.whl", hash = "sha256:ac29d5f956f01d5e4bb63102a5a19957f1b9175e45649977264a1416783bb717"},
-    {file = "importlib_resources-6.4.5.tar.gz", hash = "sha256:980862a1d16c9e147a59603677fa2aa5fd82b87f223b6cb870695bcfce830065"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
-type = ["pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -1671,8 +1562,6 @@ files = [
 
 [package.dependencies]
 amqp = ">=5.1.1,<6.0.0"
-"backports.zoneinfo" = {version = ">=0.2.1", extras = ["tzdata"], markers = "python_version < \"3.9\""}
-typing-extensions = {version = "4.12.2", markers = "python_version < \"3.10\""}
 tzdata = {version = "*", markers = "python_version >= \"3.9\""}
 vine = "5.1.0"
 
@@ -2107,21 +1996,23 @@ files = [
 
 [[package]]
 name = "networkx"
-version = "3.1"
+version = "3.5"
 description = "Python package for creating and manipulating graphs and networks"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.11"
 files = [
-    {file = "networkx-3.1-py3-none-any.whl", hash = "sha256:4f33f68cb2afcf86f28a45f43efc27a9386b535d567d2127f8f61d51dec58d36"},
-    {file = "networkx-3.1.tar.gz", hash = "sha256:de346335408f84de0eada6ff9fafafff9bcda11f0a0dfaa931133debb146ab61"},
+    {file = "networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec"},
+    {file = "networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037"},
 ]
 
 [package.extras]
-default = ["matplotlib (>=3.4)", "numpy (>=1.20)", "pandas (>=1.3)", "scipy (>=1.8)"]
-developer = ["mypy (>=1.1)", "pre-commit (>=3.2)"]
-doc = ["nb2plots (>=0.6)", "numpydoc (>=1.5)", "pillow (>=9.4)", "pydata-sphinx-theme (>=0.13)", "sphinx (>=6.1)", "sphinx-gallery (>=0.12)", "texext (>=0.6.7)"]
-extra = ["lxml (>=4.6)", "pydot (>=1.4.2)", "pygraphviz (>=1.10)", "sympy (>=1.10)"]
-test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
+default = ["matplotlib (>=3.8)", "numpy (>=1.25)", "pandas (>=2.0)", "scipy (>=1.11.2)"]
+developer = ["mypy (>=1.15)", "pre-commit (>=4.1)"]
+doc = ["intersphinx-registry", "myst-nb (>=1.1)", "numpydoc (>=1.8.0)", "pillow (>=10)", "pydata-sphinx-theme (>=0.16)", "sphinx (>=8.0)", "sphinx-gallery (>=0.18)", "texext (>=0.6.7)"]
+example = ["cairocffi (>=1.7)", "contextily (>=1.6)", "igraph (>=0.11)", "momepy (>=0.7.2)", "osmnx (>=2.0.0)", "scikit-learn (>=1.5)", "seaborn (>=0.13)"]
+extra = ["lxml (>=4.6)", "pydot (>=3.0.1)", "pygraphviz (>=1.14)", "sympy (>=1.10)"]
+test = ["pytest (>=7.2)", "pytest-cov (>=4.0)", "pytest-xdist (>=3.0)"]
+test-extras = ["pytest-mpl", "pytest-randomly"]
 
 [[package]]
 name = "nodeenv"
@@ -2248,7 +2139,6 @@ files = [
 msgpack = ">=0.5.2"
 "oslo.utils" = ">=3.33.0"
 pbr = ">=2.0.0"
-pytz = {version = ">=2013.6", markers = "python_version < \"3.9\""}
 tzdata = {version = ">=2022.4", markers = "python_version >= \"3.9\""}
 
 [[package]]
@@ -2270,7 +2160,6 @@ netifaces = ">=0.10.4"
 "oslo.i18n" = ">=3.15.3"
 packaging = ">=20.4"
 pyparsing = ">=2.1.0"
-pytz = {version = ">=2013.6", markers = "python_version < \"3.9\""}
 PyYAML = ">=3.13"
 tzdata = {version = ">=2022.4", markers = "python_version >= \"3.9\""}
 
@@ -2680,16 +2569,13 @@ files = [
 astroid = ">=3.2.4,<=3.3.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
     {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
     {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
 ]
 isort = ">=4.2.5,<5.13.0 || >5.13.0,<6"
 mccabe = ">=0.6,<0.8"
 platformdirs = ">=2.2.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 tomlkit = ">=0.10.1"
-typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 spelling = ["pyenchant (>=3.2,<4.0)"]
@@ -2747,11 +2633,9 @@ files = [
 [package.dependencies]
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
@@ -3158,123 +3042,50 @@ files = [
     {file = "ruamel.yaml-0.17.21.tar.gz", hash = "sha256:8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af"},
 ]
 
-[package.dependencies]
-"ruamel.yaml.clib" = {version = ">=0.2.6", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.11\""}
-
 [package.extras]
 docs = ["ryd"]
 jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
 
 [[package]]
-name = "ruamel-yaml-clib"
-version = "0.2.8"
-description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl", hash = "sha256:c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl", hash = "sha256:cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_24_aarch64.whl", hash = "sha256:1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win32.whl", hash = "sha256:53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win_amd64.whl", hash = "sha256:c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win32.whl", hash = "sha256:5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win_amd64.whl", hash = "sha256:1758ce7d8e1a29d23de54a16ae867abd370f01b5a69e1a3ba75223eaa3ca1a1b"},
-    {file = "ruamel.yaml.clib-0.2.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win32.whl", hash = "sha256:75e1ed13e1f9de23c5607fe6bd1aeaae21e523b32d83bb33918245361e9cc51b"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl", hash = "sha256:3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win32.whl", hash = "sha256:955eae71ac26c1ab35924203fda6220f84dce57d6d7884f189743e2abe3a9fbe"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl", hash = "sha256:56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win32.whl", hash = "sha256:84b554931e932c46f94ab306913ad7e11bba988104c5cff26d90d03f68258cd5"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win_amd64.whl", hash = "sha256:25ac8c08322002b06fa1d49d1646181f0b2c72f5cbc15a85e80b4c30a544bb15"},
-    {file = "ruamel.yaml.clib-0.2.8.tar.gz", hash = "sha256:beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512"},
-]
-
-[[package]]
 name = "schema-salad"
-version = "8.7.20241010092723"
+version = "8.9.20250723145140"
 description = "Schema Annotations for Linked Avro Data (SALAD)"
 optional = false
-python-versions = "<3.14,>=3.8"
+python-versions = "<3.15,>=3.9"
 files = [
-    {file = "schema_salad-8.7.20241010092723-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:487fcbafd310d5282f9138d91c08e5f0e86339ad8a25a7ce28966b045c91a637"},
-    {file = "schema_salad-8.7.20241010092723-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5521f1066caa2518f2d40ee66d563a8690b84131ceda4d91e72ed0f199946734"},
-    {file = "schema_salad-8.7.20241010092723-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc816f83ce5d74427f54fdc6b5257a07be7658add812b65e393587a40ec5013f"},
-    {file = "schema_salad-8.7.20241010092723-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:53ee29ba03690b143134225dfc18ceef7cc57a69a7064648f7196fd18bc618a1"},
-    {file = "schema_salad-8.7.20241010092723-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d60354631196e5f3088cec08e86ba26bd52f2f62765923fde709b96dce1cc9d5"},
-    {file = "schema_salad-8.7.20241010092723-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0577d6a44716e2fb7eca94d009ec562d7c6e956bcc2dbcfa188a9f53562d262c"},
-    {file = "schema_salad-8.7.20241010092723-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:abd5d93e3948ee0abc774b84b200a255b97379d52680ebc585ec51ae948d2c5b"},
-    {file = "schema_salad-8.7.20241010092723-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7227ba3806990bcb7559de1e1529e2fa3dfe09eb86f592d89207f79e1a72f42b"},
-    {file = "schema_salad-8.7.20241010092723-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f57d463e8cae899c7196f94b36e11ed47968de693d5675851f04575d9b3ae43"},
-    {file = "schema_salad-8.7.20241010092723-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:06611a20be03549f123318ddb5966991841bf824ddca181fbcb871bb49c2ed93"},
-    {file = "schema_salad-8.7.20241010092723-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:2507f1069657f5603aa819a5e8f4e75311a15b1b024d1ba8e2c8c69faa69fc60"},
-    {file = "schema_salad-8.7.20241010092723-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:43680b915082d51d06c71e8dcffdaa6a14e95bf3d138e678ab955fa3393db5f7"},
-    {file = "schema_salad-8.7.20241010092723-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:864c83ae19c9df97e6a5c981e2aea15042e967670e77dd8c368bf50e168ac5b0"},
-    {file = "schema_salad-8.7.20241010092723-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a83477daf843ab42df003ace702db02925f6eb2eec33673d9b30bbd109cacfda"},
-    {file = "schema_salad-8.7.20241010092723-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cd7a4ba2182813859aee0f936f549638a05b4eaf44344616c52d5968c81bae2b"},
-    {file = "schema_salad-8.7.20241010092723-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6154e11222b6dc398f64681d0a7a593716d433eab3fa9c98d31f0098cc2f724"},
-    {file = "schema_salad-8.7.20241010092723-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0048f07b2f701ed7fc48593079222bad3492911baab35ad474446e7a8df7fd16"},
-    {file = "schema_salad-8.7.20241010092723-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:43b6c31c14b6fc2bf53f368ec0dab1277d781673587087ff4502ea974641b886"},
-    {file = "schema_salad-8.7.20241010092723-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:08e20120ac0981e0f4d11a97728dd71ed81aef03ea1d2766e9c96c583ea466b2"},
-    {file = "schema_salad-8.7.20241010092723-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bcd9fbee7a04451d950b13fba3193d6c6912d1a312b19452a6ca74c53c295cda"},
-    {file = "schema_salad-8.7.20241010092723-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:cbe264e84ed9ee1e192c4e03292bc327bd10449e472b418ebca8f37afb999dd0"},
-    {file = "schema_salad-8.7.20241010092723-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5fecdf4b64dc3c5c3fb30a6e608ec7d63c1634979da2282d4be92638d4ba4488"},
-    {file = "schema_salad-8.7.20241010092723-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d928c1d5852c188b1304d8c67ce6a0b003145d6e92400d9282770ee575f7ec06"},
-    {file = "schema_salad-8.7.20241010092723-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d277c5189dcc17c3e2012a2ca7d67abcca43c36ec193087d129036ca81bf153"},
-    {file = "schema_salad-8.7.20241010092723-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:20c2510b49783805ee6f22d7a86479d8c63cdc1d99e5ae0847efc5d3de695a8c"},
-    {file = "schema_salad-8.7.20241010092723-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:feb90e5ddfbea80b242bf400dc4eaecc0e77d78b41659e8def6b60d1e86da995"},
-    {file = "schema_salad-8.7.20241010092723-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:12b5c7b7962cd5d04e3079b84cd8915d4f55e34029fb2a7a677d781f6d6fc644"},
-    {file = "schema_salad-8.7.20241010092723-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:26798ce6621aa6790e658741c785d79ebc0c879227f53c284fcbebcbaadd674c"},
-    {file = "schema_salad-8.7.20241010092723-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b0caf3e312dac876d15465b0226d04039c41378fcf13c8d2b857efd7506b4746"},
-    {file = "schema_salad-8.7.20241010092723-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c385b4f646c0b9fd662cc7114f840c9206f6294b3b7fb597423b95859d7ff186"},
-    {file = "schema_salad-8.7.20241010092723-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78181131cfc335105ce616fd12f1b4eb24d51794028267234bbfdd3a7421cff9"},
-    {file = "schema_salad-8.7.20241010092723-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:647972d43b0275ed3f507a6219be9003722a1ad9634041bd53c46b064ce5779a"},
-    {file = "schema_salad-8.7.20241010092723-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d4d5dddb12735a8f99dd465576425800e198a4ec179787ea8cc8c726deb8c562"},
-    {file = "schema_salad-8.7.20241010092723-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:d2ec91982cd4229e564f128b6a87e4d55e1181dbf8c8e58faa9b3bbe29978f8a"},
-    {file = "schema_salad-8.7.20241010092723-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:74dea07b54b2a276ef2f0e43e25583ad6c4a0c69805b4b7f0a697c787065e014"},
-    {file = "schema_salad-8.7.20241010092723-py3-none-any.whl", hash = "sha256:53acfd740b8ae5df26a71e90d4177c6c82b8ef163be36e0072500bc2e794935b"},
-    {file = "schema_salad-8.7.20241010092723.tar.gz", hash = "sha256:f0f15890402531bec4bb18a5dfbb592dae4413c71e444f82ada95274b83d34bc"},
+    {file = "schema_salad-8.9.20250723145140-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f26f5cad9d2b01b359c0aff7118f73e16902c3948ebc57869de478bda2d89935"},
+    {file = "schema_salad-8.9.20250723145140-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a7cf66e2e16334dae1010e7a5e80f9a7524184189a68658405b7faac203b2b5"},
+    {file = "schema_salad-8.9.20250723145140-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6251c72613d0ae067bbebe10e34afb3f80d6ce2b4fb7a7e350cfe4a1c4a62c2e"},
+    {file = "schema_salad-8.9.20250723145140-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:200b7e87f33c106ed7416eb63e810d694e36c6325cf97119c3a7363609b18900"},
+    {file = "schema_salad-8.9.20250723145140-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:dfdb981ca78025cc923cc0a73ead39e34ace58cc56db9da9de241744075601e4"},
+    {file = "schema_salad-8.9.20250723145140-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:074c5c47f512c8eef21a0484884f6fdfc08be485c37291ce60b38d1833f25c30"},
+    {file = "schema_salad-8.9.20250723145140-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3225f71c7e2dd6fc6292c20dc7dd88354c55fbb836d1ff6d8d6e5d31f889298b"},
+    {file = "schema_salad-8.9.20250723145140-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de33e71f5a235354d00b7233b5c76b77b917a86ed8058659ae3618f958f89630"},
+    {file = "schema_salad-8.9.20250723145140-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:469fddf382b213295321ace9315b8ef1443d52bd4c3aade09c4635a661182c99"},
+    {file = "schema_salad-8.9.20250723145140-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1cfd11fd8d4fe643238400a4bc4af67f42e3a59dfd21972bdc492344245d5d91"},
+    {file = "schema_salad-8.9.20250723145140-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bf04129584504b6f54af5ea2531f3182c7f0f3c885a79bff4b8467d77f8eb7a0"},
+    {file = "schema_salad-8.9.20250723145140-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb9ac893758fe52b757b0080aa1da47c3153cb3f502e74fdcee03fb5fac5dc49"},
+    {file = "schema_salad-8.9.20250723145140-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c7060c7777dc980058f984c27fb4e71d2cc0644f7f57080ffac04f703fe998b"},
+    {file = "schema_salad-8.9.20250723145140-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2fbdf55c2aac537f4431753d483cecb844cb9462debc0c8364f45119fc1e83d0"},
+    {file = "schema_salad-8.9.20250723145140-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:57e69e0f3cb3e698064dd86924bd52b1daab978546d46d9026633945d303cad6"},
+    {file = "schema_salad-8.9.20250723145140-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8519939e1d6e29c326fadd91dc1974c5b8b28de8b01421a6c4c53e9e37a184de"},
+    {file = "schema_salad-8.9.20250723145140-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd7a235dc7c81751b40a89232753b993ba5e5ec1c1604963ca2e59bf9c476dad"},
+    {file = "schema_salad-8.9.20250723145140-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f44fd199e5aff93060353d160be413e9c3a000af85cf77bdaf8b660201bfc4b7"},
+    {file = "schema_salad-8.9.20250723145140-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:20f3016db9c051f543280fa30a2159338c86cd57e18ec4d4e77756ecc7b6d01d"},
+    {file = "schema_salad-8.9.20250723145140-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:be0d7f55cf74593ab92487356ae1ba2a3101a16a64ee7f6309f608aef056de42"},
+    {file = "schema_salad-8.9.20250723145140-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d752c4cfa62f2e56751c289b367ab359b084c0fa15191fe4eda0ecec88520235"},
+    {file = "schema_salad-8.9.20250723145140-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4fd1568c248992b6fa766ba42bb4ed86a8db09de9aae11bc3ce4acf8a9b4a2b"},
+    {file = "schema_salad-8.9.20250723145140-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:684393b238fac5ee6c63146391ebd5dcb53e18cde5853cb5c0997c280235ef7e"},
+    {file = "schema_salad-8.9.20250723145140-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:22564d44aaa455b7ff6fcf0d4f1ae9e395adda1322a2c5d87a0f35bfbffbccb2"},
+    {file = "schema_salad-8.9.20250723145140-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:4fe121dfc898edec8e7524e9d1f8e64a3f75ffa46b850e91a199f1478bb56059"},
+    {file = "schema_salad-8.9.20250723145140-py3-none-any.whl", hash = "sha256:4d96c6988c66a8ef2dfa6c005bd1c938055d85a112a3204cdf68d3ed1e9aa701"},
+    {file = "schema_salad-8.9.20250723145140.tar.gz", hash = "sha256:58e3d02ea1773259987f9c74a99974c52ffa3c18ad02a2dd60642249c257a2e4"},
 ]
 
 [package.dependencies]
 CacheControl = {version = ">=0.13.1,<0.15", extras = ["filecache"]}
-importlib-resources = {version = ">=1.4", markers = "python_version < \"3.9\""}
 mistune = ">=3,<3.1"
-mypy-extensions = "*"
+mypy_extensions = "*"
 rdflib = ">=4.2.2,<8.0.0"
 requests = ">=1.0"
 "ruamel.yaml" = ">=0.17.6,<0.19"
@@ -3364,7 +3175,6 @@ babel = ">=2.9"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 docutils = ">=0.18.1,<0.20"
 imagesize = ">=1.3"
-importlib-metadata = {version = ">=4.8", markers = "python_version < \"3.10\""}
 Jinja2 = ">=3.0"
 packaging = ">=21.0"
 Pygments = ">=2.13"
@@ -3612,7 +3422,6 @@ files = [
 
 [package.dependencies]
 anyio = ">=3.4.0,<5"
-typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
@@ -3644,17 +3453,6 @@ files = [
 
 [package.extras]
 widechars = ["wcwidth"]
-
-[[package]]
-name = "tomli"
-version = "2.1.0"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "tomli-2.1.0-py3-none-any.whl", hash = "sha256:a5c57c3d1c56f5ccdf89f6523458f60ef716e210fc47c4cfb188c5ba473e0391"},
-    {file = "tomli-2.1.0.tar.gz", hash = "sha256:3f646cae2aec94e17d04973e4249548320197cfabdf130015d023de4b74d8ab8"},
-]
 
 [[package]]
 name = "tomlkit"
@@ -3721,7 +3519,6 @@ files = [
 ]
 
 [package.dependencies]
-"backports.zoneinfo" = {version = "*", markers = "python_version < \"3.9\""}
 tzdata = {version = "*", markers = "platform_system == \"Windows\""}
 
 [package.extras]
@@ -3769,7 +3566,6 @@ files = [
 [package.dependencies]
 click = ">=7.0"
 h11 = ">=0.8"
-typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
@@ -3907,29 +3703,10 @@ files = [
     {file = "wrapt-1.17.0.tar.gz", hash = "sha256:16187aa2317c731170a88ef35e8937ae0f533c402872c1ee5e6d079fcf320801"},
 ]
 
-[[package]]
-name = "zipp"
-version = "3.20.2"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350"},
-    {file = "zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
-type = ["pytest-mypy"]
-
 [extras]
 cloud-extras = ["google-api-python-client", "python-heatclient", "python-openstackclient"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8.3,<=3.13.0"
-content-hash = "eb9cca872e1aafc8d26fa430625b0562a836c36a76018a42f4ea29db340b240f"
+python-versions = ">=3.11,<=3.14"
+content-hash = "4087eaeb3a40966fd3e8a267815882e8630f5a0d248948045fe11c40987f0af8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ beecloud = 'beeflow.cloud_launcher:main'
 
 [tool.poetry.dependencies]
 
-# Python version (>=3.8.3, <=3.12.2)
-python = ">=3.8.3,<=3.13.0"
+# Python version (>=3.11, <=3.14)
+python = ">=3.11,<=3.14"
 
 # Package dependencies
 Flask = { version = "^2.0" }
@@ -81,7 +81,7 @@ google-api-python-client = { version = "^2.66.0", optional = true }
 python-openstackclient = { version = "^6.0.0", optional = true }
 python-heatclient = { version = "^3.1.0", optional = true }
 graphviz = "^0.20.3"
-networkx = "3.1"
+networkx = "3.5"
 requests-unixsocket2 = "^0.4.2"
 pylint = "^3.2.7"
 pre-commit = "3.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,15 +75,16 @@ cffi = "^1.15.1"
 celery = { version = "^5.3.4", extras = ["redis", "sqlalchemy"] }
 # Fix for poetry/docutils related bug
 docutils = "0.18.1"
+graphviz = "^0.20.3"
+networkx = "3.5"
+
 
 # Cloud optional dependencies
 google-api-python-client = { version = "^2.66.0", optional = true }
 python-openstackclient = { version = "^6.0.0", optional = true }
 python-heatclient = { version = "^3.1.0", optional = true }
-graphviz = "^0.20.3"
-networkx = "3.5"
 requests-unixsocket2 = "^0.4.2"
-pylint = "3.2.7"
+pylint = "3.3.6"
 pre-commit = "3.5.0"
 
 [tool.poetry.extras]
@@ -91,7 +92,7 @@ cloud_extras = ["google-api-python-client", "python-openstackclient", "python-he
 
 [tool.poetry.dev-dependencies]
 # Developer dependencies
-pylint = "3.2.7"
+pylint = "3.3.6"
 pytest = "7.2.0"
 pytest-mock = "3.3.1"
 pytest-cov = "5.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ python-heatclient = { version = "^3.1.0", optional = true }
 graphviz = "^0.20.3"
 networkx = "3.5"
 requests-unixsocket2 = "^0.4.2"
-pylint = "^3.2.7"
+pylint = "3.2.7"
 pre-commit = "3.5.0"
 
 [tool.poetry.extras]
@@ -91,7 +91,7 @@ cloud_extras = ["google-api-python-client", "python-openstackclient", "python-he
 
 [tool.poetry.dev-dependencies]
 # Developer dependencies
-pylint = "^3.2.7"
+pylint = "3.2.7"
 pytest = "7.2.0"
 pytest-mock = "3.3.1"
 pytest-cov = "5.0.0"


### PR DESCRIPTION
This PR addresses #1055 by updating the networkx version. This did require tightening the python versions we support, but that doesn't impact any other applications that currently depend on bee. 