### PR TITLE
1092 posixpath task workdirs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ Contributors:
 * Jacob Tronge - `jtronge <https://github.com/jtronge>`_
 * Kabir Vats - `kabir-vats <https://github.com/kabir-vats>`_
 * Sare Beste Zeytun - `sbzeytun <https://github.com/sbzeytun>`_
+* Wesley Mason - `wmason-lanl <https://github.com/wmason-lanl>`_
 
 Concept and Design Contributors
 

--- a/beeflow/common/cwl/cwl.py
+++ b/beeflow/common/cwl/cwl.py
@@ -1,7 +1,7 @@
 """Create and manage CWL files."""
 from dataclasses import dataclass
 from io import StringIO
-from pathlib import Path, PosixPath
+from pathlib import Path
 from typing import Optional, Union
 import ruamel.yaml
 
@@ -458,12 +458,12 @@ class ScriptRequirement:
 class TaskRequirement:
     """Defines task requirement."""
 
-    # Accept either a string or a PosixPath
-    workdir: Union[str, PosixPath] = None
+    # Accept either a string or a Path
+    workdir: Union[str, Path]
 
-    def __post_init__(self) -> None:
+    def __post_init__(self):
         """ Convert a Path object to a string."""
-        if isinstance(self.workdir, (Path, PosixPath)):
+        if isinstance(self.workdir, Path):
             self.workdir = str(self.workdir)
 
     def dump(self):

--- a/beeflow/common/cwl/cwl.py
+++ b/beeflow/common/cwl/cwl.py
@@ -1,7 +1,8 @@
 """Create and manage CWL files."""
 from dataclasses import dataclass
 from io import StringIO
-from typing import Optional
+from pathlib import Path, PosixPath
+from typing import Optional, Union
 import ruamel.yaml
 
 # Create the global object for ruamel.ymal
@@ -457,7 +458,13 @@ class ScriptRequirement:
 class TaskRequirement:
     """Defines task requirement."""
 
-    workdir: str
+    # Accept either a string or a PosixPath
+    workdir: Union[str, PosixPath] = None
+
+    def __post_init__(self) -> None:
+        """ Convert a Path object to a string."""
+        if isinstance(self.workdir, (Path, PosixPath)):
+            self.workdir = str(self.workdir)
 
     def dump(self):
         """Dump task requirement to a dictionary."""

--- a/beeflow/tests/test_cwl_workflow.py
+++ b/beeflow/tests/test_cwl_workflow.py
@@ -1,3 +1,4 @@
+import pytest
 from beeflow.common.cwl.workflow import (
     Task,
     Input,
@@ -11,6 +12,7 @@ from beeflow.common.cwl.workflow import (
     TaskReq,
 )
 from importlib.resources import files
+from pathlib import PosixPath
 
 expected_folder = files("beeflow.tests.cwl_files")
 
@@ -199,8 +201,15 @@ def test_workflow_checkpoint(tmpdir):
             expected = f2.read()
             assert actual == expected
 
-
-def test_workflow_task_req(tmpdir):
+@pytest.mark.parametrize(
+    "workdir_value, description",
+    [
+        ("cat_workdir", "plain string"),
+        (PosixPath("cat_workdir"), "PosixPath object"),
+    ],
+    ids=lambda val: f"workdir_as_{type(val).__name__}",
+)
+def test_workflow_task_req(tmpdir, workdir_value, description):
     """Regression test of example setting task workdir."""
     expected_wf = expected_folder / "task-req.cwl"
     expected_yaml = expected_folder / "task-req.yml"
@@ -216,7 +225,7 @@ def test_workflow_task_req(tmpdir):
             Output("contents", "stdout"),
             Output("cat_stderr", "stderr", source="cat/cat_stderr"),
         ],
-        hints=[TaskReq(workdir="cat_workdir")],
+        hints=[TaskReq(workdir=workdir_value)],
     )
 
     grep = Task(
@@ -238,8 +247,8 @@ def test_workflow_task_req(tmpdir):
         with open("task-req.cwl", "r") as f1, open(expected_wf, "r") as f2:
             actual = f1.read()
             expected = f2.read()
-            assert actual == expected
+            assert actual == expected, (f"CWL mismatch when workdir is a {description}. ")
         with open("task-req.yml", "r") as f1, open(expected_yaml, "r") as f2:
             actual = f1.read()
             expected = f2.read()
-            assert actual == expected
+            assert actual == expected, (f"YAML mismatch when workdir is a {description}. ")

--- a/beeflow/tests/test_cwl_workflow.py
+++ b/beeflow/tests/test_cwl_workflow.py
@@ -12,7 +12,7 @@ from beeflow.common.cwl.workflow import (
     TaskReq,
 )
 from importlib.resources import files
-from pathlib import PosixPath
+from pathlib import Path
 
 expected_folder = files("beeflow.tests.cwl_files")
 
@@ -205,7 +205,7 @@ def test_workflow_checkpoint(tmpdir):
     "workdir_value, description",
     [
         ("cat_workdir", "plain string"),
-        (PosixPath("cat_workdir"), "PosixPath object"),
+        (Path("cat_workdir"), "Path object"),
     ],
     ids=lambda val: f"workdir_as_{type(val).__name__}",
 )


### PR DESCRIPTION
Fixes #1092 

--
Task workdirs cannot be a PosixPath (#1092)
    
* Accept workdir as a string or a PosixPath
* Parametrize test_workflow_task_req pytest for string or PosixPath workdir