### PR TITLE
Remove container_path from Checkpoint Requirements, not used

### DIFF
--- a/beeflow/common/cwl/cwl.py
+++ b/beeflow/common/cwl/cwl.py
@@ -395,7 +395,6 @@ class CheckpointRequirement:
     """Represents a beeflow checkpoint requirement."""
 
     file_path: str
-    container_path: str
     file_regex: str
     restart_parameters: str
     num_tries: int
@@ -408,7 +407,6 @@ class CheckpointRequirement:
         checkpoint_dump = {req_name: {}}
         checkpoint_dump[req_name]['enabled'] = self.enabled
         checkpoint_dump[req_name]['file_path'] = self.file_path
-        checkpoint_dump[req_name]['container_path'] = self.container_path
         checkpoint_dump[req_name]['file_regex'] = self.file_regex
         checkpoint_dump[req_name]['restart_parameters'] = self.restart_parameters
         checkpoint_dump[req_name]['add_parameters'] = self.add_parameters

--- a/beeflow/common/cwl/workflow.py
+++ b/beeflow/common/cwl/workflow.py
@@ -130,7 +130,6 @@ class Checkpoint(CheckpointRequirement):
     def requirement(self):
         """Return a checkpoint requirement object."""
         return CheckpointRequirement(file_path=self.file_path,
-                                     container_path=self.container_path,
                                      file_regex=self.file_regex,
                                      restart_parameters=self.restart_parameters,
                                      add_parameters=self.add_parameters,

--- a/beeflow/tests/cwl_files/clamr.cwl
+++ b/beeflow/tests/cwl_files/clamr.cwl
@@ -82,7 +82,6 @@ steps:
       beeflow:CheckpointRequirement:
         enabled: true
         file_path: checkpoint_output
-        container_path: checkpoint_output
         file_regex: backup[0-9]*.crx
         restart_parameters: -R
         add_parameters:

--- a/beeflow/tests/test_cwl.py
+++ b/beeflow/tests/test_cwl.py
@@ -164,18 +164,16 @@ import pytest
             cwl.CheckpointRequirement,
             {
                 "file_path": "checkpoint_output",
-                "container_path": "checkpoint_output",
                 "file_regex": "backup[0-9]*.crx",
                 "restart_parameters": "-R",
                 "num_tries": 2,
             },
-            "beeflow:CheckpointRequirement:\n  enabled: true\n  file_path: checkpoint_output\n  container_path: checkpoint_output\n  file_regex: backup[0-9]*.crx\n  restart_parameters: -R\n  add_parameters:\n  num_tries: 2\n",
+            "beeflow:CheckpointRequirement:\n  enabled: true\n  file_path: checkpoint_output\n  file_regex: backup[0-9]*.crx\n  restart_parameters: -R\n  add_parameters:\n  num_tries: 2\n",
             {
                 "beeflow:CheckpointRequirement": {
                     "add_parameters": None,
                     "enabled": True,
                     "file_path": "checkpoint_output",
-                    "container_path": "checkpoint_output",
                     "file_regex": "backup[0-9]*.crx",
                     "restart_parameters": "-R",
                     "num_tries": 2,

--- a/beeflow/tests/test_cwl_workflow.py
+++ b/beeflow/tests/test_cwl_workflow.py
@@ -175,7 +175,6 @@ def test_workflow_checkpoint(tmpdir):
             Checkpoint(
                 enabled=True,
                 file_path="checkpoint_output",
-                container_path="checkpoint_output",
                 file_regex="backup[0-9]*.crx",
                 restart_parameters="-R",
                 num_tries=3,

--- a/beeflow/tests/test_parser.py
+++ b/beeflow/tests/test_parser.py
@@ -416,7 +416,6 @@ TASKS_NOJOB_GOLD = [
                     [
                         ("enabled", True),
                         ("file_path", "checkpoint_output"),
-                        ("container_path", "checkpoint_output"),
                         ("file_regex", "backup[0-9]*.crx"),
                         ("restart_parameters", None),
                         ("num_tries", 3),
@@ -430,7 +429,6 @@ TASKS_NOJOB_GOLD = [
                     params={
                         "enabled": True,
                         "file_path": "checkpoint_output",
-                        "container_path": "checkpoint_output",
                         "file_regex": "backup[0-9]*.crx",
                         "num_tries": 3,
                     },

--- a/beeflow/tests/test_wf_interface.py
+++ b/beeflow/tests/test_wf_interface.py
@@ -204,7 +204,6 @@ class TestWorkflowInterface(unittest.TestCase):
         hints = [Hint(class_="ResourceRequirement", params={"ramMin": 1024}),
                  Hint(class_="NetworkAccess", params={"networkAccess": True}),
                  Hint(class_="beeflow:CheckpointRequirement", params={"file_path": "checkpoint_output",
-                                                                    "container_path": "checkpoint_output",
                                                                     "file_regex": "backup[0-9]*.crx",
                                                                     "restart_parameters": "-R",
                                                                     "num_tries": 2})]

--- a/ci/test_workflows/checkpoint-too-long/workflow.cwl
+++ b/ci/test_workflows/checkpoint-too-long/workflow.cwl
@@ -21,7 +21,6 @@ steps:
       beeflow:CheckpointRequirement:
         enabled: true
         file_path: .
-        container_path: .
         file_regex: backup[0-9]*.crx
         restart_parameters: -R
         num_tries: 1

--- a/ci/test_workflows/clamr-wf-checkpoint/clamr_wf.cwl
+++ b/ci/test_workflows/clamr-wf-checkpoint/clamr_wf.cwl
@@ -56,7 +56,6 @@ steps:
         beeflow:CheckpointRequirement:
             enabled: true
             file_path: checkpoint_output
-            container_path: checkpoint_output
             file_regex: backup[0-9]*.crx 
             restart_parameters: -R
             num_tries: 3

--- a/docs/sphinx/bee_cwl.rst
+++ b/docs/sphinx/bee_cwl.rst
@@ -142,7 +142,6 @@ An example ``beeflow:CheckpointRequirement`` in BEE is shown below::
        beeflow:CheckpointRequirement:
             enabled: true
             file_path: checkpoint_output
-            container_path: checkpoint_output
             file_regex: backup[0-9]*.crx
             restart_parameters: -R
             add_parameters: --additional-options True


### PR DESCRIPTION
The checkpoint requirement does not need a container path and it is not used, so deleting it. This is the first part of fixing issue #1152 