### PR TITLE
Fix validation error when switching from slurmrestd in config

### DIFF
--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -106,6 +106,35 @@ class BeeConfig:
             except FileNotFoundError:
                 print("Configuration file is missing! Generating new config file.")
                 new(USERCONFIG_FILE, interactive=False)
+
+        scheduler = config.get("DEFAULT", "workload_scheduler", fallback="Slurm").strip()
+        if config.has_section("slurm"):
+            use_commands = config.getboolean("slurm","use_commands",fallback=False)
+        else:
+            use_commands = False
+
+        # Determine which sections to remove and which to keep
+        sections_to_remove = []
+        if scheduler == "Flux":
+            sections_to_remove = ["slurm attributes", "slurm command attributes"]
+            if not config.has_section("flux attributes"):
+                config.add_section("flux attributes")
+            config.set("flux attributes", "attributes", "queue,runtime,nodelist")
+        elif scheduler == "Slurm":
+            if use_commands:
+                sections_to_remove = ["slurm attributes", "flux attributes"]
+                if not config.has_section("slurm command attributes"):
+                    config.add_section("slurm command attributes")
+                config.set("slurm command attributes", "attributes", "Partition,RunTime,NodeList")
+            else:
+                sections_to_remove = ["slurm command attributes", "flux attributes"]
+                if not config.has_section("slurm attributes"):
+                    config.add_section("slurm attributes")
+                config.set("slurm attributes", "attributes", "partition,nodes")
+
+        for sec in sections_to_remove:
+            if config.has_section(sec):
+                config.remove_section(sec)
         # remove default keys from the other sections
         cls.CONFIG = config_utils.filter_and_validate(config, VALIDATOR)
 


### PR DESCRIPTION
This is a temporary fix for issue #1165. Although this resolves the error message, there are still issues regarding the config file when switching between schedulers. For instance with the "beeflow config new -a (--attributes)" command, it defaults back to the slurmrestd attributes even if we switch from slurmrestd to command line. Additionally, the "[slurm attributes]" section is not deleted, rather it is ignored when switching to the command line and using "[slurm command attributes]" (Not a big issue, however it may be confusing). After switching over, it does use the slurm command line attributes. 