### PR TITLE
Fix Slurm attribute errors when switching between schedulers and choosing new attributes

### DIFF
--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -324,13 +324,20 @@ VALIDATOR.option('job', 'default_reservation', validator=lambda val: val.strip()
                  default='', info='default reservation to run jobs on (leave blank if none)')
 
 def validate_attributes(val):
-    """Ensures the atributes are stored as a comma-separated string in"""
+    """Ensures the atributes are spelled correctly and stored as a comma-separated 
+    string in the config"""
     if isinstance(val, str):
         parts = [p.strip() for p in val.split(',') if p.strip()]
     elif isinstance(val, (list, tuple)):
         parts = [str(v).strip() for v in val if str(v).strip()]
     else:
         raise ValueError("Expected a comma-separated string or list of strings.")
+
+    allowed = set(slurm_command_attr) | set(slurm_attr) | set(flux_attr)
+    for p in parts:
+        if p not in allowed:
+            print()
+            raise ValueError(f'The attribute is spelled incorrectly or not available: {p}\n')
     return ",".join(parts)
 
 slurm_command_attr= [

--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -108,7 +108,7 @@ class BeeConfig:
                 new(USERCONFIG_FILE, interactive=False)
 
         # remove default keys from the other sections
-        cls.CONFIG = config_utils.filter_and_validate(config, VALIDATOR)
+        cls.CONFIG = config_utils.filter_and_validate(config, VALIDATOR,USERCONFIG_FILE)
 
     @classmethod
     def userconfig_path(cls):
@@ -584,7 +584,8 @@ class AlterConfig:
         try:
             with open(self.fname, encoding='utf-8') as fp:
                 config.read_file(fp)
-                self.config = config_utils.filter_and_validate(config, self.validator)
+                self.config = config_utils.filter_and_validate(config,
+                self.validator,USERCONFIG_FILE)
         except FileNotFoundError:
             for section_change in self.changes:
                 for option_change in self.changes[section_change]:

--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -106,6 +106,35 @@ class BeeConfig:
             except FileNotFoundError:
                 print("Configuration file is missing! Generating new config file.")
                 new(USERCONFIG_FILE, interactive=False)
+
+        scheduler = config.get("DEFAULT", "workload_scheduler", fallback="Slurm").strip()
+        if config.has_section("slurm"):
+            use_commands = config.getboolean("slurm","use_commands",fallback=False)
+        else:
+            use_commands = False
+
+        # Determine which sections to remove and which to keep
+        sections_to_remove = []
+        if scheduler == "Flux":
+            sections_to_remove = ["slurm attributes", "slurm command attributes"]
+            if not config.has_section("flux attributes"):
+                config.add_section("flux attributes")
+            config.set("flux attributes", "attributes", "queue,runtime,nodelist")
+        elif scheduler == "Slurm":
+            if use_commands:
+                sections_to_remove = ["slurm attributes", "flux attributes"]
+                if not config.has_section("slurm command attributes"):
+                    config.add_section("slurm command attributes")
+                config.set("slurm command attributes", "attributes", "Partition,RunTime,NodeList")
+            else:
+                sections_to_remove = ["slurm command attributes", "flux attributes"]
+                if not config.has_section("slurm attributes"):
+                    config.add_section("slurm attributes")
+                config.set("slurm attributes", "attributes", "partition,nodes")
+
+        for sec in sections_to_remove:
+            if config.has_section(sec):
+                config.remove_section(sec)
         # remove default keys from the other sections
         cls.CONFIG = config_utils.filter_and_validate(config, VALIDATOR)
 

--- a/beeflow/common/config_driver.py
+++ b/beeflow/common/config_driver.py
@@ -107,34 +107,6 @@ class BeeConfig:
                 print("Configuration file is missing! Generating new config file.")
                 new(USERCONFIG_FILE, interactive=False)
 
-        scheduler = config.get("DEFAULT", "workload_scheduler", fallback="Slurm").strip()
-        if config.has_section("slurm"):
-            use_commands = config.getboolean("slurm","use_commands",fallback=False)
-        else:
-            use_commands = False
-
-        # Determine which sections to remove and which to keep
-        sections_to_remove = []
-        if scheduler == "Flux":
-            sections_to_remove = ["slurm attributes", "slurm command attributes"]
-            if not config.has_section("flux attributes"):
-                config.add_section("flux attributes")
-            config.set("flux attributes", "attributes", "queue,runtime,nodelist")
-        elif scheduler == "Slurm":
-            if use_commands:
-                sections_to_remove = ["slurm attributes", "flux attributes"]
-                if not config.has_section("slurm command attributes"):
-                    config.add_section("slurm command attributes")
-                config.set("slurm command attributes", "attributes", "Partition,RunTime,NodeList")
-            else:
-                sections_to_remove = ["slurm command attributes", "flux attributes"]
-                if not config.has_section("slurm attributes"):
-                    config.add_section("slurm attributes")
-                config.set("slurm attributes", "attributes", "partition,nodes")
-
-        for sec in sections_to_remove:
-            if config.has_section(sec):
-                config.remove_section(sec)
         # remove default keys from the other sections
         cls.CONFIG = config_utils.filter_and_validate(config, VALIDATOR)
 
@@ -467,7 +439,6 @@ class ConfigGenerator:
 
     def choose_values(self, interactive=False, flux=False, attributes=False):
         """Choose configuration values based on user input."""
-        print("[DEBUG] choose_values() started")
         dirname = os.path.dirname(self.fname)
         if dirname:
             os.makedirs(dirname, exist_ok=True)
@@ -480,12 +451,13 @@ class ConfigGenerator:
                        'values before running BEE.')
             print()
             print('Please enter values for the following sections and options:')
+
         # Let the user choose values for each required attribute
         for sec_name, section in self.validator.sections:
             # Determine if this section is valid under the current configuration
             if not self.validator.is_section_valid(self.sections, sec_name):
                 continue
-            self.sections[sec_name] = {}
+            self.sections[sec_name]={}
             printed = False
             for opt_name, option in self.validator.options(sec_name):
                 # Print the section name if it hasn't already been printed.
@@ -500,13 +472,15 @@ class ConfigGenerator:
                     this_default = "Flux"
                     option.prompt = False
                 if attributes and not interactive and opt_name == 'attributes':
+                    scheduler = self.sections.get('DEFAULT', {}).get('workload_scheduler')
+                    use_commands = self.sections.get('slurm', {}).get('use_commands', False)
                     print(f'\nAvailable attributes for [{sec_name}]:')
-                    if sec_name == 'slurm attributes':
-                        attr_list = slurm_attr
-                    elif sec_name =='slurm command attributes':
-                        attr_list = slurm_command_attr
-                    else:
+                    if scheduler == 'Slurm':
+                        attr_list = slurm_command_attr if use_commands else slurm_attr
+                    elif scheduler == 'Flux':
                         attr_list = flux_attr
+                    else:
+                        attr_list = []
                     print(attr_list)
                     value = self._input_loop(opt_name, option)
                     validated = option.validate(value)
@@ -690,6 +664,23 @@ def new(path: str = typer.Argument(default=USERCONFIG_FILE,
                                         help='Chooses task attributes to display'
                                         'for "beeflow query"')):
     """Create a new config file."""
+    if attributes and os.path.exists(path):
+        try:
+            existing = AlterConfig(path).config
+            scheduler = existing.get('DEFAULT', {}).get('workload_scheduler')
+            if scheduler is not None:
+                for opt_name, opt in VALIDATOR.options('DEFAULT'):
+                    if opt_name == 'workload_scheduler':
+                        opt.default = scheduler
+            use_commands = existing.get('slurm', {}).get('use_commands')
+            if use_commands is not None:
+                for opt_name, opt in VALIDATOR.options('slurm'):
+                    if opt_name == 'use_commands':
+                        opt.default = use_commands
+
+        except OSError as err:
+            print(f"Failed to read BEE's configuration file: {err}")
+
     if os.path.exists(path):
         if not interactive or check_yes(f'Path "{path}" already exists.\n'
                                         + 'Would you like to save a copy of it?'):

--- a/beeflow/common/config_utils.py
+++ b/beeflow/common/config_utils.py
@@ -8,11 +8,6 @@ from configparser import ConfigParser
 
 def filter_and_validate(config, validator,config_path):
     """Filter and validate the configuration file."""
-    #default_keys = list(config['DEFAULT'])
-    #config = {sec_name: {key: config[sec_name][key] for key in config[sec_name]
-    #                     if sec_name == 'DEFAULT' or key not in default_keys}
-    #          for sec_name in config}
-
     if isinstance(config,dict):
         config_parser = ConfigParser()
         config_parser.read_dict(config)

--- a/beeflow/common/config_utils.py
+++ b/beeflow/common/config_utils.py
@@ -4,13 +4,19 @@ import os
 import shutil
 import tempfile
 
+from configparser import ConfigParser
 
-def filter_and_validate(config, validator):
+def filter_and_validate(config, validator,config_path):
     """Filter and validate the configuration file."""
     #default_keys = list(config['DEFAULT'])
     #config = {sec_name: {key: config[sec_name][key] for key in config[sec_name]
     #                     if sec_name == 'DEFAULT' or key not in default_keys}
     #          for sec_name in config}
+
+    if isinstance(config,dict):
+        config_parser = ConfigParser()
+        config_parser.read_dict(config)
+        config = config_parser
 
     scheduler = config.get('DEFAULT','workload_scheduler',fallback='Slurm').strip()
     if config.has_section('slurm'):
@@ -43,19 +49,14 @@ def filter_and_validate(config, validator):
         if config.has_section(sec):
             config.remove_section(sec)
 
-    try:
-        from beeflow.common.config_driver import USERCONFIG_FILE
-    except ImportError as err:
-        print(f'Warning: {err}')
-
     tmp_path = None
     try:
-        config_dirpath = os.path.dirname(USERCONFIG_FILE)
+        config_dirpath = os.path.dirname(config_path)
         fd,tmp_path = tempfile.mkstemp(dir=config_dirpath,prefix='tmp.bee.conf')
         os.close(fd)
         with open(tmp_path,'w',encoding='utf-8') as config_file:
             config.write(config_file)
-        os.replace(tmp_path, USERCONFIG_FILE)
+        os.replace(tmp_path, config_path)
         tmp_path = None
     except OSError as err:
         print(f'Could not successfully remove and rewrite attribute sections: {err}')

--- a/beeflow/common/config_utils.py
+++ b/beeflow/common/config_utils.py
@@ -2,14 +2,77 @@
 
 import os
 import shutil
+import tempfile
 
 
 def filter_and_validate(config, validator):
     """Filter and validate the configuration file."""
+    #default_keys = list(config['DEFAULT'])
+    #config = {sec_name: {key: config[sec_name][key] for key in config[sec_name]
+    #                     if sec_name == 'DEFAULT' or key not in default_keys}
+    #          for sec_name in config}
+
+    scheduler = config.get('DEFAULT','workload_scheduler',fallback='Slurm').strip()
+    if config.has_section('slurm'):
+        use_commands = config.getboolean('slurm','use_commands',fallback=False)
+    else:
+        use_commands = False
+
+    sections_to_remove = []
+    if scheduler == 'Flux':
+        sections_to_remove = ['slurm attributes','slurm command attributes']
+        if not config.has_section('flux attributes'):
+            config.add_section('flux attributes')
+        if not config.get('flux attributes','attributes',fallback='').strip():
+            config.set('flux attributes','attributes','queue,runtime,nodelist')
+    elif scheduler == 'Slurm':
+        if use_commands:
+            sections_to_remove = ['flux attributes','slurm attributes']
+            if not config.has_section('slurm command attributes'):
+                config.add_section('slurm command attributes')
+            if not config.get('slurm command attributes','attributes',fallback='').strip():
+                config.set('slurm command attributes','attributes','Partition,RunTime,NodeList')
+        else:
+            sections_to_remove = ['flux attributes','slurm command attributes']
+            if not config.has_section('slurm attributes'):
+                config.add_section('slurm attributes')
+            if not config.get('slurm attributes','attributes',fallback='').strip():
+                config.set('slurm attributes','attributes','partition,nodes')
+
+    for sec in sections_to_remove:
+        if config.has_section(sec):
+            config.remove_section(sec)
+
+    try:
+        from beeflow.common.config_driver import USERCONFIG_FILE
+    except ImportError as err:
+        print(f'Warning: {err}')
+
+    tmp_path = None
+    try:
+        config_dirpath = os.path.dirname(USERCONFIG_FILE)
+        fd,tmp_path = tempfile.mkstemp(dir=config_dirpath,prefix='tmp.bee.conf')
+        os.close(fd)
+        with open(tmp_path,'w',encoding='utf-8') as config_file:
+            config.write(config_file)
+        os.replace(tmp_path, USERCONFIG_FILE)
+        tmp_path = None
+    except OSError as err:
+        print(f'Could not successfully remove and rewrite attribute sections: {err}')
+
+    # if tmp_path still exits, remove it
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except OSError as err:
+                print(f'Could not successfully remove temporary config file: {err}')
+
     default_keys = list(config['DEFAULT'])
     config = {sec_name: {key: config[sec_name][key] for key in config[sec_name]
                          if sec_name == 'DEFAULT' or key not in default_keys}
               for sec_name in config}
+
     # Validate the config
     return validator.validate(config)
 

--- a/beeflow/tests/test_config_driver.py
+++ b/beeflow/tests/test_config_driver.py
@@ -155,6 +155,13 @@ def test_config_generator_save(mocker, tmpdir, capsys, interactive, input_val, e
                          )
 def test_config_new(mocker, tmpdir, interactive, input_val, expected):
     """Test creation of new config with different settings."""
+    # Setup valid paths for neo4j_image and redis_image
+    img_dir = tmpdir.mkdir("img")
+    neo4j_path = img_dir.join("neo4j.tar.gz")
+    redis_path = img_dir.join("redis.tar.gz")
+    neo4j_path.write("")  # Create empty mock tarball
+    redis_path.write("")  # Create empty mock tarball
+
     filename = 'bee.conf'
     mocker.patch('builtins.input', return_value=input_val)
     mocker.patch('beeflow.common.config_driver.ConfigGenerator.choose_values')
@@ -164,7 +171,9 @@ def test_config_new(mocker, tmpdir, interactive, input_val, expected):
             f.write(
                 "[DEFAULT]\n"
                 "bee_workdir = .\n"
-                "workload_scheduler = Slurm\n\n"
+                "workload_scheduler = Slurm\n"
+                f"neo4j_image = {neo4j_path}\n"
+                f"redis_image = {redis_path}\n\n"
                 "[task_manager]\n"
                 "container_runtime = Charliecloud\n"
                 "runner_opts = \n\n"

--- a/beeflow/tests/test_config_driver.py
+++ b/beeflow/tests/test_config_driver.py
@@ -160,7 +160,18 @@ def test_config_new(mocker, tmpdir, interactive, input_val, expected):
     mocker.patch('beeflow.common.config_driver.ConfigGenerator.choose_values')
     mocker.patch('beeflow.common.config_driver.ConfigGenerator.choose_values.save')
     with tmpdir.as_cwd():
-        with open(filename, 'w', encoding='utf-8'):
-            pass
+        with open(filename, 'w', encoding='utf-8') as f:
+            f.write(
+                "[DEFAULT]\n"
+                "bee_workdir = .\n"
+                "workload_scheduler = Slurm\n\n"
+                "[task_manager]\n"
+                "container_runtime = Charliecloud\n"
+                "runner_opts = \n\n"
+                "[slurm]\n"
+                "use_commands = False\n\n"
+                "[slurm attributes]\n"
+                "attributes = partition,nodes\n"
+            )
         new("bee.conf", interactive=interactive)
         assert os.path.exists('bee.conf.1') == expected

--- a/beeflow/tests/test_config_utils.py
+++ b/beeflow/tests/test_config_utils.py
@@ -22,7 +22,7 @@ class MockValidator:
         return self._called_with
 
 
-def test_filter_and_validate():
+def test_filter_and_validate(tmp_path):
     """Test filtering and validating configuration."""
     # Define the config
     sample_config = {
@@ -30,9 +30,14 @@ def test_filter_and_validate():
         'task_manager': {'container_runtime': 'Charliecloud', 'runner_opts': ''},
         'charliecloud': {'workload_scheduler': 'new_value', 'setup': ''}
     }
+
+    # Write the config to a file
+    temp_file = tmp_path / "test_config.conf"
+    write_config(temp_file, sample_config)
+
     # Run the function
     mocked_validator = MockValidator()
-    result = filter_and_validate(sample_config, mocked_validator)
+    result = filter_and_validate(sample_config, mocked_validator,temp_file)
 
     # Check that the validator was called with the correct filtered config
     expected_filtered_config = {


### PR DESCRIPTION
This is for issue 1165. This should fix the validation error and ensure the correct attributes section shows up when you change use_commands from False to True, and vice versa. The previously used attribute section should be deleted to ensure there's no confusion. This should also fix the issue when using "beeflow config new -a." Previously, it defaulted to show slurm attributes even when using the command-line interface. Make sure after editing the config file to stop and start beeflow to see the changes. 