### PR TITLE
Add more data artifacts when CI fails

### DIFF
--- a/.github/workflows/testing-coverage.yml
+++ b/.github/workflows/testing-coverage.yml
@@ -51,12 +51,12 @@ jobs:
         if: failure()   # only when the job fails
         run: |
           mkdir bee-error-logs
-          cp bee-error-*.log bee-error-logs
-          cp -R $LOG_DIR bee-error-logs
-          cp -R $SLURM_CONF bee-error-logs
-          cp -R $BEE_WORKDIR/logs bee-error-logs
-          cp -R $BEE_WORKDIR/*.db bee-error-logs
-          cp -R $BEE_CONFIG bee-error-logs
+          cp bee-error-*.log bee-error-logs || true
+          cp -R $LOG_DIR bee-error-logs || true
+          cp -R $SLURM_CONF bee-error-logs || true
+          cp -R $BEE_WORKDIR/logs bee-error-logs || true
+          cp -R $BEE_WORKDIR/*.db bee-error-logs || true
+          cp -R $BEE_CONFIG bee-error-logs || true
       - name: Upload bee error logs
         if: failure()    # only when the job fails
         uses: actions/upload-artifact@v4

--- a/.github/workflows/testing-coverage.yml
+++ b/.github/workflows/testing-coverage.yml
@@ -37,7 +37,7 @@ jobs:
           echo "LOG_DIR=$LOG_DIR" >> $GITHUB_ENV
           echo "SLURM_CONF=$SLURM_CONF" >> $GITHUB_ENV
           echo "BEE_WORKDIR=$BEE_WORKDIR" >> $GITHUB_ENV
-          echo "BEE_CONFIG=$BEE_CONFIG" >> $GITHUB_ENV
+          echo "BEE_CONFIG=$BEE_CONFIG" >> $GITHUB_ENV 
           ./ci/deps_install.sh
           ./ci/batch_scheduler.sh
           ./ci/bee_install.sh

--- a/.github/workflows/testing-coverage.yml
+++ b/.github/workflows/testing-coverage.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Install and Configure
         run: |
           . ./ci/env.sh
+          echo "LOG_DIR=$LOG_DIR" >> $GITHUB_ENV
+          echo "SLURM_CONF=$SLURM_CONF" >> $GITHUB_ENV
+          echo "BEE_WORKDIR=$BEE_WORKDIR" >> $GITHUB_ENV
+          echo "BEE_CONFIG=$BEE_CONFIG" >> $GITHUB_ENV
           ./ci/deps_install.sh
           ./ci/batch_scheduler.sh
           ./ci/bee_install.sh
@@ -43,12 +47,22 @@ jobs:
           . ./ci/env.sh
           ./ci/integration_test.sh
           mv .coverage.integration ".coverage.${{ matrix.bee_worker }}.${{ matrix.gdb_backend }}"
+      - name: Stash bee error logs
+        if: failure()   # only when the job fails
+        run: |
+          mkdir bee-error-logs
+          cp bee-error-*.log bee-error-logs
+          cp -R $LOG_DIR bee-error-logs
+          cp -R $SLURM_CONF bee-error-logs
+          cp -R $BEE_WORKDIR/logs bee-error-logs
+          cp -R $BEE_WORKDIR/*.db bee-error-logs
+          cp -R $BEE_CONFIG bee-error-logs
       - name: Upload bee error logs
         if: failure()    # only when the job fails
         uses: actions/upload-artifact@v4
         with:
-          name: bee-error-logs-${{ matrix.bee_worker }}-${{ matrix.gdb_backend }}.log
-          path: bee-error-*.log
+          name: bee-error-logs-${{ matrix.bee_worker }}-${{ matrix.gdb_backend }}
+          path: bee-error-logs
           if-no-files-found: ignore
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- ci/env.sh sets a bunch of useful variables, after the first time it runs, capture them in $GITHUB_ENV which makes them accessible downstream
- downstream add a new step in case of failure to dump them in a single directory, modify following step to save the single directory as an artifact 

- So far I added:
  - individual process logs (wfm, redis...)
  - bee config file
  - slurm config/logs
  - db files

We can also add anything else we may need to examine here.