### PR TITLE
Build docs after badge gets updated in gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,14 @@
 name: Build Docs
 
 on:
+  workflow_run:
+    workflows: [Testing and Coverage]
+    types:
+      - completed
   workflow_dispatch: {}
   push:
-    branches: [main, develop]
     tags:
       - '*'
-  pull_request:
-    types: [opened, synchronize, edited, labeled, unlabeled]
-    branches: [main, develop]
   delete:
 
 permissions:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   docs:
-    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'WIP (no-ci)')) && !(contains(github.event.pull_request.labels.*.name, 'WIP (lint-only)')) }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'delete' || github.event.workflow_run.conclusion == 'success' }}
     name: Build Docs
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     workflows: [Testing and Coverage]
     types:
       - completed
+    branches:
+      - main
+      - develop
   workflow_dispatch: {}
   push:
     tags:

--- a/.github/workflows/tag-docs.yml
+++ b/.github/workflows/tag-docs.yml
@@ -1,14 +1,6 @@
-name: Build Docs
+name: Build Tag Docs
 
 on:
-  workflow_run:
-    workflows: [Testing and Coverage]
-    types:
-      - completed
-    branches:
-      - main
-      - develop
-  workflow_dispatch: {}
   push:
     tags:
       - '*'
@@ -18,29 +10,18 @@ permissions:
   contents: write
 
 jobs:
-  docs:
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'delete' || github.event.workflow_run.conclusion == 'success' }}
-    name: Build Docs
+  tag-docs:
+    if: startsWith(github.ref, 'refs/tags/')
+    name: Build and Publish Tag Docs 
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - name: Checkout latest tag for main
-        if: github.ref == 'refs/heads/main'
-        run: |
-          git fetch --tags --force
-          LATEST_TAG="$(git tag --sort=-creatordate | head -n 1)"
-          echo "Latest tag: $LATEST_TAG"
-          git checkout "$LATEST_TAG"
-
-      - name: Install BEE and Build Docs
+      - name: Build tag docs
         run: ./ci/docs.sh
 
       - name: Publish tag docs
-        if: startsWith(github.ref, 'refs/tags/')
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -49,18 +30,9 @@ jobs:
           destination_dir: ${{ github.ref_name }}
           keep_files: true
 
-      - name: Publish latest docs to root
-        if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: ./docs/sphinx/_build/html
-          destination_dir: .
-          keep_files: true
-
   cleanup-tag-docs:
     if: github.event_name == 'delete' && github.event.ref_type == 'tag'
+    name: Clean-Up Tag Docs
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/testing-coverage.yml
+++ b/.github/workflows/testing-coverage.yml
@@ -241,12 +241,12 @@ jobs:
       - name: Install BEE and Build Docs
         run: ./ci/docs.sh
 
-     - name: Publish latest docs to root
-       if: github.ref == 'refs/heads/main'
-       uses: peaceiris/actions-gh-pages@v4
-       with:
-         github_token: ${{ secrets.GITHUB_TOKEN }}
-         publish_branch: gh-pages
-         publish_dir: ./docs/sphinx/_build/html
-         destination_dir: .
-         keep_files: true
+      - name: Publish latest docs to root
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./docs/sphinx/_build/html
+          destination_dir: .
+          keep_files: true

--- a/.github/workflows/testing-coverage.yml
+++ b/.github/workflows/testing-coverage.yml
@@ -1,4 +1,4 @@
-name: Testing and Coverage
+name: Testing, Coverage, and Build Docs
 
 permissions:
   contents: read
@@ -218,3 +218,35 @@ jobs:
           publish_dir: ./badge-publish
           destination_dir: badges/${{ github.ref_name }}
           keep_files: true
+
+  build-and-publish-docs:
+    if: ${{ always() }}
+    needs: [coverage]
+    name: Build Docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name : Checkout latest tag for main
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git fetch --tags --force
+          LATEST_TAG="$(git tag --sort=-creatordate | head -n 1)"
+          echo "Latest tag: $LATEST_TAG"
+          git checkout "$LATEST_TAG"
+
+      - name: Install BEE and Build Docs
+        run: ./ci/docs.sh
+
+     - name: Publish latest docs to root
+       if: github.ref == 'refs/heads/main'
+       uses: peaceiris/actions-gh-pages@v4
+       with:
+         github_token: ${{ secrets.GITHUB_TOKEN }}
+         publish_branch: gh-pages
+         publish_dir: ./docs/sphinx/_build/html
+         destination_dir: .
+         keep_files: true

--- a/.github/workflows/testing-coverage.yml
+++ b/.github/workflows/testing-coverage.yml
@@ -224,8 +224,8 @@ jobs:
     needs: [coverage]
     name: Build Docs
     runs-on: ubuntu-latest
-     permissions:
-         contents: write
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/testing-coverage.yml
+++ b/.github/workflows/testing-coverage.yml
@@ -224,6 +224,8 @@ jobs:
     needs: [coverage]
     name: Build Docs
     runs-on: ubuntu-latest
+     permissions:
+         contents: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/testing-coverage.yml
+++ b/.github/workflows/testing-coverage.yml
@@ -225,6 +225,8 @@ jobs:
     name: Build Docs
     runs-on: ubuntu-latest
     permissions:
+        contents: write
+    permissions:
       contents: write
 
     steps:

--- a/.github/workflows/testing-coverage.yml
+++ b/.github/workflows/testing-coverage.yml
@@ -225,8 +225,6 @@ jobs:
     name: Build Docs
     runs-on: ubuntu-latest
     permissions:
-        contents: write
-    permissions:
       contents: write
 
     steps:


### PR DESCRIPTION
This fix makes it so that docs.yml is dependent on testing-coverage.yml to ensure that badge gets updated in gh-pages before building the documentation. However, I made sure it can also be run on manual triggers, version releases (when tags are pushed), and on delete events. 