### PR TITLE
Record Slurm submit failures in the task stderr file

### DIFF
--- a/beeflow/common/worker/slurm_worker.py
+++ b/beeflow/common/worker/slurm_worker.py
@@ -202,6 +202,11 @@ class BaseSlurmWorker(Worker):
         res = subprocess.run(['sbatch', '--parsable', f"--chdir={workdir}", script], text=True,  # pylint: disable=W1510
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if res.returncode != 0:
+            # Slurm never starts the job on a submit failure, so it never writes
+            # the task's .err file. Record the reason there ourselves so there's
+            # a persistent record in the workflow directory.
+            _stdout_path, stderr_path = self.resolve_stdout_stderr(task)
+            worker_utils.write_submit_failure(stderr_path, res.stderr)
             raise WorkerError(f'Failed to submit job: {res.stderr}')
         job_id = int(res.stdout)
         worker_utils.resolve_slurm_paths(job_id, task)

--- a/beeflow/common/worker/utils.py
+++ b/beeflow/common/worker/utils.py
@@ -33,6 +33,24 @@ def get_state_sacct(job_id):
         raise WorkerError(f'sacct query failed for job {job_id}') from exc
 
 
+def write_submit_failure(stderr_path, message):
+    """Record a job submission failure to the task's stderr file.
+
+    Slurm only creates the task's .err file once a job starts running, so on a
+    submit failure there is otherwise no record in the workflow directory of
+    what went wrong. This writes the failure reason to the same path the task's
+    stderr would have used, where the user would naturally look for it.
+
+    Best-effort: a failure to write here must not mask the original submit
+    error, so any OSError is logged rather than raised.
+    """
+    try:
+        with open(stderr_path, 'a', encoding='utf-8') as err_file:
+            err_file.write(f'Slurm job submission failed:\n{message}\n')
+    except OSError as exc:
+        log.warning(f'Could not record submit failure to {stderr_path}: {exc}')
+
+
 def parse_key_val(pair):
     """Parse the key-value pair separated by '='."""
     i = pair.find('=')

--- a/beeflow/tests/test_slurm_worker.py
+++ b/beeflow/tests/test_slurm_worker.py
@@ -17,7 +17,7 @@ import pytest
 import beeflow.common.worker.utils as worker_utils
 from beeflow.common.worker_interface import WorkerInterface
 from beeflow.common.worker.worker import WorkerError
-from beeflow.common.worker.slurm_worker import SlurmWorker
+from beeflow.common.worker.slurm_worker import SlurmWorker, SlurmCLIWorker
 from beeflow.common.object_models import Task
 
 
@@ -201,3 +201,51 @@ def test_parse_output_error(output_directive, error_directive, expected_stdout,
     assert stderr == expected_stderr
 
 
+def test_write_submit_failure_creates_record(tmp_path):
+    """A submit failure reason is written to the task's stderr path."""
+    stderr_path = tmp_path / "task.err"
+
+    worker_utils.write_submit_failure(str(stderr_path),
+                                      "sbatch: error: invalid partition specified")
+
+    contents = stderr_path.read_text(encoding="utf-8")
+    assert "Slurm job submission failed" in contents
+    assert "invalid partition specified" in contents
+
+
+def test_write_submit_failure_appends(tmp_path):
+    """Recording a submit failure appends rather than truncating."""
+    stderr_path = tmp_path / "task.err"
+    stderr_path.write_text("previous output\n", encoding="utf-8")
+
+    worker_utils.write_submit_failure(str(stderr_path), "boom")
+
+    contents = stderr_path.read_text(encoding="utf-8")
+    assert contents.startswith("previous output")
+    assert "boom" in contents
+
+
+def test_submit_job_records_failure(tmp_path, monkeypatch):
+    """A failed sbatch submission records the reason in the task's stderr file."""
+    # Bypass the config-heavy worker __init__; submit_job only needs
+    # resolve_stdout_stderr, which depends solely on the task.
+    worker = SlurmCLIWorker.__new__(SlurmCLIWorker)
+    task = Task(name='submit-fail', base_command=['true'], hints=[], requirements=[],
+                inputs=[], outputs=[], stdout='', stderr='', workdir=str(tmp_path),
+                workflow_id=uuid.uuid4().hex)
+
+    class FailedRun:
+        """Stand-in for a failed subprocess.run result."""
+
+        returncode = 1
+        stdout = ''
+        stderr = 'sbatch: error: invalid partition specified'
+
+    monkeypatch.setattr(subprocess, 'run', lambda *args, **kwargs: FailedRun())
+
+    with pytest.raises(WorkerError):
+        worker.submit_job(task, 'dummy_script.sh')
+
+    _stdout_path, stderr_path = worker.resolve_stdout_stderr(task)
+    with open(stderr_path, encoding="utf-8") as err_file:
+        assert 'invalid partition specified' in err_file.read()


### PR DESCRIPTION
Closes #685.

## Problem

When a task ends with a submit failure in Slurm (`sbatch` returns non-zero), Slurm never starts the job and therefore never writes the task's `.err` file in the workflow directory. The submit failure reason is raised as a `WorkerError`, but there is no persistent record in the workflow directory of what caused the failure, so a user inspecting the run afterwards has nothing to look at.

## Fix

On a submit failure, capture the `sbatch` stderr and append it to the same path the task's stderr would have used (as resolved by `resolve_stdout_stderr`) — the natural place a user looks for a task's error output. The `WorkerError` is still raised as before.

- New `worker_utils.write_submit_failure(stderr_path, message)`: appends `"Slurm job submission failed:\n<message>"` to the task's stderr path. It is best-effort — an `OSError` while writing is logged rather than raised, so it can never mask the original submit error.
- `BaseSlurmWorker.submit_job` calls it before raising when `sbatch` returns a non-zero exit code.

This addresses @pagrubel's note on the issue about giving the failure somewhere to live; writing to the task's `.err` path means it lands where the user already expects task error output rather than in separate metadata.

## Tests

Added to `beeflow/tests/test_slurm_worker.py` (all runnable without a live Slurm/slurmrestd):

- `test_write_submit_failure_creates_record` — the reason is written to the stderr path.
- `test_write_submit_failure_appends` — writing appends rather than truncating existing output.
- `test_submit_job_records_failure` — a failed `sbatch` (mocked) makes `submit_job` raise `WorkerError` and leaves the reason in the task's resolved `.err` file.

```
$ pytest beeflow/tests/test_slurm_worker.py -k "write_submit or records_failure"
3 passed
```

`pylint --rcfile=setup.cfg` on the changed files: 10.00/10 (source), and the new test code adds no new warnings.