### PR TITLE
Make cache keys more descriptive and cleanup caches on closed prs

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,0 +1,29 @@
+name: Cleanup caches on closed pull requests
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup-caches:
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      BRANCH: refs/pull/${{ github.event.pull-request.number }}/merge
+    runs_on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cleanup Caches
+        run: |
+          echo "Fetching list of cache keys"
+          cacheKeysPerPR=$(gh cache list --ref $BRANCH --limit 20 --json id --jq '.[].id')
+
+          # Make sure workflow does not fail if a cache is already deleted
+          set +e
+          echo "Deleting cache(s)..."
+          for cacheKey in $cacheKeysPerPR
+          do
+            gh cache delete $cacheKey
+          done
+

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -10,7 +10,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
       BRANCH: refs/pull/${{ github.event.pull-request.number }}/merge
-    runs_on: ubuntu-latest
+    runs-on: ubuntu-latest
     permissions:
       actions: write
     steps:

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -9,7 +9,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
-      BRANCH: refs/pull/${{ github.event.pull-request.number }}/merge
+      BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -19,11 +19,14 @@ jobs:
           echo "Fetching list of cache keys"
           cacheKeysPerPR=$(gh cache list --ref $BRANCH --limit 20 --json id --jq '.[].id')
 
-          # Make sure workflow does not fail if a cache is already deleted
-          set +e
-          echo "Deleting cache(s)..."
-          for cacheKey in $cacheKeysPerPR
-          do
-            gh cache delete $cacheKey
-          done
-
+          if [ -z "$cacheKeysPerPR" ]; then
+            echo "No caches found to delete"
+          else
+            # Make sure workflow does not fail if a cache is already deleted
+            set +e
+            echo "Deleting cache(s)..."
+            for cacheKey in $cacheKeysPerPR
+            do
+              gh cache delete $cacheKey
+            done
+          fi

--- a/.github/workflows/testing-coverage-docs.yml
+++ b/.github/workflows/testing-coverage-docs.yml
@@ -48,14 +48,14 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/slurm
-          key: ${{ runner.os }}-${{ github.ref_name }}-slurm-${{ hashFiles('./ci/env.sh','./ci/slurm_install.sh') }} 
+          key: ${{ runner.os }}-slurm-${{ hashFiles('./ci/env.sh','./ci/slurm_install.sh') }} 
 
       - name: Restore Charliecloud Install
         id: cache-charliecloud-restore
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/charliecloud
-          key: ${{ runner.os }}-${{ github.ref_name }}-charliecloud-${{ hashFiles('./ci/env.sh','./ci/charliecloud_install.sh') }}
+          key: ${{ runner.os }}-charliecloud-${{ hashFiles('./ci/env.sh','./ci/charliecloud_install.sh') }}
 
       - name: Build Slurm for Save
         if: steps.cache-slurm-restore.outputs.cache-hit != 'true' && (env.BEE_WORKER == 'Slurmrestd' || env.BEE_WORKER == 'SlurmCommands')
@@ -96,7 +96,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/flux
-          key: ${{ runner.os }}-${{ github.ref_name }}-flux-${{ hashFiles('./ci/env.sh','./ci/flux_install.sh') }} 
+          key: ${{ runner.os }}-flux-${{ hashFiles('./ci/env.sh','./ci/flux_install.sh') }} 
 
       - name: Build Flux Install for Save
         if: steps.cache-flux-restore.outputs.cache-hit != 'true' && env.BEE_WORKER == 'Flux'
@@ -134,7 +134,7 @@ jobs:
             ./venv
             /home/runner/img/neo4j.tar.gz
             /home/runner/img/redis.tar.gz
-          key: ${{ runner.os }}-${{ github.ref_name }}-venv-${{ hashFiles('poetry.lock','./ci/env.sh','./ci/bee_install.sh','./ci/bee_setup.sh') }}
+          key: ${{ runner.os }}-venv-${{ hashFiles('poetry.lock','./ci/env.sh','./ci/bee_install.sh','./ci/bee_setup.sh') }}
 
       - name: Build Containers and Virtual Environment
         if: steps.cache-venv-restore.outputs.cache-hit != 'true'
@@ -215,14 +215,14 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/slurm
-          key: ${{ runner.os }}-${{ github.ref_name }}-slurm-${{ hashFiles('./ci/env.sh','./ci/slurm_install.sh') }}
+          key: ${{ runner.os }}-slurm-${{ hashFiles('./ci/env.sh','./ci/slurm_install.sh') }}
 
       - name: Restore Charliecloud Install
         id: cache-charliecloud-restore
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/charliecloud
-          key: ${{ runner.os }}-${{ github.ref_name }}-charliecloud-${{ hashFiles('./ci/env.sh','./ci/charliecloud_install.sh') }}
+          key: ${{ runner.os }}-charliecloud-${{ hashFiles('./ci/env.sh','./ci/charliecloud_install.sh') }}
 
       - name: Build Slurm for Save
         if: steps.cache-slurm-restore.outputs.cache-hit != 'true'
@@ -263,7 +263,7 @@ jobs:
             ./venv
             /home/runner/img/neo4j.tar.gz
             /home/runner/img/redis.tar.gz
-          key: ${{ runner.os }}-${{ github.ref_name }}-venv-${{ hashFiles('poetry.lock','./ci/env.sh','./ci/bee_install.sh','./ci/bee_setup.sh') }}
+          key: ${{ runner.os }}-venv-${{ hashFiles('poetry.lock','./ci/env.sh','./ci/bee_install.sh','./ci/bee_setup.sh') }}
 
       - name: Build Containers and Virtual Environment
         if: steps.cache-venv-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/testing-coverage-docs.yml
+++ b/.github/workflows/testing-coverage-docs.yml
@@ -48,14 +48,14 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/slurm
-          key: ${{ runner.os }}-slurm-${{ hashFiles('./ci/env.sh','./ci/slurm_install.sh') }} 
+          key: ${{ runner.os }}-${{ github.ref_name }}-slurm-${{ hashFiles('./ci/env.sh','./ci/slurm_install.sh') }} 
 
       - name: Restore Charliecloud Install
         id: cache-charliecloud-restore
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/charliecloud
-          key: ${{ runner.os }}-charliecloud-${{ hashFiles('./ci/env.sh','./ci/charliecloud_install.sh') }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-charliecloud-${{ hashFiles('./ci/env.sh','./ci/charliecloud_install.sh') }}
 
       - name: Build Slurm for Save
         if: steps.cache-slurm-restore.outputs.cache-hit != 'true' && (env.BEE_WORKER == 'Slurmrestd' || env.BEE_WORKER == 'SlurmCommands')
@@ -96,7 +96,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/flux
-          key: ${{ runner.os }}-flux-${{ hashFiles('./ci/env.sh','./ci/flux_install.sh') }} 
+          key: ${{ runner.os }}-${{ github.ref_name }}-flux-${{ hashFiles('./ci/env.sh','./ci/flux_install.sh') }} 
 
       - name: Build Flux Install for Save
         if: steps.cache-flux-restore.outputs.cache-hit != 'true' && env.BEE_WORKER == 'Flux'
@@ -134,7 +134,7 @@ jobs:
             ./venv
             /home/runner/img/neo4j.tar.gz
             /home/runner/img/redis.tar.gz
-          key: ${{ runner.os }}-venv-${{ hashFiles('poetry.lock','./ci/env.sh','./ci/bee_install.sh','./ci/bee_setup.sh') }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-venv-${{ hashFiles('poetry.lock','./ci/env.sh','./ci/bee_install.sh','./ci/bee_setup.sh') }}
 
       - name: Build Containers and Virtual Environment
         if: steps.cache-venv-restore.outputs.cache-hit != 'true'
@@ -215,14 +215,14 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/slurm
-          key: ${{ runner.os }}-slurm-${{ hashFiles('./ci/env.sh','./ci/slurm_install.sh') }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-slurm-${{ hashFiles('./ci/env.sh','./ci/slurm_install.sh') }}
 
       - name: Restore Charliecloud Install
         id: cache-charliecloud-restore
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/charliecloud
-          key: ${{ runner.os }}-charliecloud-${{ hashFiles('./ci/env.sh','./ci/charliecloud_install.sh') }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-charliecloud-${{ hashFiles('./ci/env.sh','./ci/charliecloud_install.sh') }}
 
       - name: Build Slurm for Save
         if: steps.cache-slurm-restore.outputs.cache-hit != 'true'
@@ -263,7 +263,7 @@ jobs:
             ./venv
             /home/runner/img/neo4j.tar.gz
             /home/runner/img/redis.tar.gz
-          key: ${{ runner.os }}-venv-${{ hashFiles('poetry.lock','./ci/env.sh','./ci/bee_install.sh','./ci/bee_setup.sh') }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-venv-${{ hashFiles('poetry.lock','./ci/env.sh','./ci/bee_install.sh','./ci/bee_setup.sh') }}
 
       - name: Build Containers and Virtual Environment
         if: steps.cache-venv-restore.outputs.cache-hit != 'true'


### PR DESCRIPTION
As a security layer, each opened pull request has its own cache that cannot be used by develop or other feature branches. Although unused caches are deleted after seven days, I added a new workflow that deletes caches once a pull request is closed. This reduces the noise and saves storage, since caches can pile up for each feature branch depending on what is changed (there are 17 caches right now). This will prevent having to manually delete an old, lingering cache after a pull request is closed before the 7 days. 